### PR TITLE
ci: push :stable tag on main push (alongside :latest)

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -53,6 +53,12 @@ jobs:
         run: |
           docker push ghcr.io/fox-in-the-box-ai/cloud:${{ steps.meta.outputs.tag }}
 
+      - name: Tag and push :stable
+        if: github.event_name == 'push'
+        run: |
+          docker tag ghcr.io/fox-in-the-box-ai/cloud:latest ghcr.io/fox-in-the-box-ai/cloud:stable
+          docker push ghcr.io/fox-in-the-box-ai/cloud:stable
+
       - name: Smoke test — start container
         run: |
           docker run -d \


### PR DESCRIPTION
## What
The install.sh pulls `ghcr.io/fox-in-the-box-ai/cloud:stable` but CI only pushed `:latest`.
This adds a step to tag and push `:stable` on every push to `main`.

## Change
- After existing push-to-ghcr step, tag `:latest` → `:stable` and push it
- Only runs on `push` events (not PRs)

No rebuild cost — just a `docker tag` + `docker push`.