### PR TITLE
ci: add signed macOS DMG build (closes #29)

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -7,7 +7,6 @@ on:
       - main
     tags:
       - "v*"
-  # Called by release.yml
   workflow_call:
 
 permissions:
@@ -20,13 +19,16 @@ jobs:
 
     strategy:
       fail-fast: false
-      # macOS: no packaged build in CI/releases — use packages/scripts/install.sh
-      # (same curl|bash flow as Linux). Local unsigned zip: pnpm build --mac.
       matrix:
         include:
           - os: windows-latest
             artifact-name: fox-windows
             artifact-path: packages/electron/dist/*.exe
+          - os: macos-latest
+            artifact-name: fox-macos
+            artifact-path: |
+              packages/electron/dist/*.dmg
+              packages/electron/dist/*-mac.zip
 
     steps:
       - name: Checkout (with submodules)
@@ -34,7 +36,6 @@ jobs:
         with:
           submodules: recursive
 
-      # Windows: enable long paths in git and OS (pnpm hashed store paths exceed MAX_PATH)
       - name: Enable long paths (Windows only)
         if: runner.os == 'Windows'
         shell: pwsh
@@ -54,9 +55,6 @@ jobs:
         with:
           node-version: "20"
 
-      # Windows: use npm install (flat node_modules) to avoid pnpm's deeply-hashed
-      # store paths that exceed Windows MAX_PATH — makensis.exe can't open NSIS includes
-      # from paths like node_modules/.pnpm/app-builder-lib@24.13.3_<longhash>/...
       - name: Install dependencies
         shell: bash
         run: |
@@ -72,12 +70,12 @@ jobs:
         shell: bash
         run: pnpm build
         env:
-          # No code signing cert for v0.1 — CSC_IDENTITY_AUTO_DISCOVERY=false tells
-          # electron-builder to skip signing entirely rather than error on missing/empty cert.
-          # Remove this line and set WIN_CSC_LINK + WIN_CSC_KEY_PASSWORD secrets when ready to sign.
-          CSC_IDENTITY_AUTO_DISCOVERY: "false"
-          # GitHub token for electron-updater publish config
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
@@ -92,16 +90,15 @@ jobs:
         shell: bash
         working-directory: packages/electron/dist
         run: |
-          # Rename to fixed filename so website can link to /releases/latest/download/
           if [[ "${{ runner.os }}" == "Windows" ]]; then
             mv *.exe fox-in-the-box-setup.exe
           fi
 
       - name: Upload to GitHub Release (tagged releases only)
-        if: startsWith(github.ref, 'refs/tags/v') && runner.os == 'Windows'
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
           files: ${{ matrix.artifact-path }}
-          generate_release_notes: false   # release.yml owns release notes
+          generate_release_notes: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/electron/build/entitlements.mac.plist
+++ b/packages/electron/build/entitlements.mac.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+</dict>
+</plist>

--- a/packages/electron/electron-builder.yml
+++ b/packages/electron/electron-builder.yml
@@ -3,8 +3,6 @@ productName: Fox in the box
 executableName: FoxInTheBox
 copyright: "Copyright © 2024 Vulpy, Inc."
 
-# Skip native module rebuild — no native modules need rebuilding for the target platform
-# (cpu-features via ssh2/dockerode fails on Windows with pnpm due to .cjs invocation issue)
 npmRebuild: false
 
 directories:
@@ -26,8 +24,6 @@ win:
         - x64
   artifactName: "fox-in-the-box-setup-${arch}.exe"
   signAndEditExecutable: false
-  # Code signing: set WIN_CSC_LINK (path/URL to .pfx) and WIN_CSC_KEY_PASSWORD in CI
-  # electron-builder picks these up automatically when present
 
 nsis:
   oneClick: true
@@ -36,26 +32,28 @@ nsis:
   deleteAppDataOnUninstall: false
   uninstallDisplayName: Fox in the box
   shortcutName: Fox in the box
-  # Explicit icons — Start menu / Add/Remove can show the default Electron icon if these are omitted.
   installerIcon: assets/icon.ico
   uninstallerIcon: assets/icon.ico
   include: build/installer.nsh
 
-# Unsigned .zip only — no DMG (avoids Apple notarization / cert gatekeeper issues).
-# Release installs for macOS use packages/scripts/install.sh (same as Linux).
 mac:
   icon: assets/icon.icns
   target:
+    - target: dmg
+      arch:
+        - x64
+        - arm64
     - target: zip
       arch:
         - x64
         - arm64
-  artifactName: "fox-in-the-box-${arch}-mac.zip"
-  identity: null
+  artifactName: "fox-in-the-box-${arch}-mac.${ext}"
+  hardenedRuntime: true
+  gatekeeperAssess: false
+  entitlements: build/entitlements.mac.plist
+  entitlementsInherit: build/entitlements.mac.plist
+  notarize: true
 
-# Linux desktop installers (snap/AppImage) are not shipped; install.sh + Docker is the path.
-# Unpacked "dir" is enough to validate the app on Linux. Scoped package "name" still needs
-# explicit executableName for a sane binary in dist/linux-unpacked.
 linux:
   category: Utility
   executableName: fox-in-the-box


### PR DESCRIPTION
- Add macOS (macos-latest) to build matrix
- Enable code signing with Developer ID cert via secrets
- Enable notarization (hardenedRuntime + notarize: true)
- Add entitlements.mac.plist for Electron compatibility
- Add DMG target alongside ZIP
- Remove CSC_IDENTITY_AUTO_DISCOVERY: false

Closes #29