### PR TITLE
ci: include macOS artifacts in GitHub Release (closes #30)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
       - "v*"
 
 jobs:
-  # ── Wait for upstream workflows to pass on this tag commit ─────────────────
   wait-for-container:
     name: Wait — build-container.yml
     uses: ./.github/workflows/build-container.yml
@@ -21,16 +20,16 @@ jobs:
     permissions:
       contents: write
       packages: write
+    secrets: inherit
 
-  # ── Retag Docker image and create GitHub Release ───────────────────────────
   release:
     name: Create GitHub Release
     needs: [wait-for-container, wait-for-electron]
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write   # required to create releases
-      packages: write   # required to push re-tagged image
+      contents: write
+      packages: write
 
     steps:
       - name: Checkout
@@ -63,13 +62,17 @@ jobs:
           name: fox-windows
           path: release-artifacts/windows
 
+      - name: Download macOS artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: fox-macos
+          path: release-artifacts/macos
+
       - name: Extract release notes from CHANGELOG
         id: changelog
         run: |
           VERSION="${{ steps.tag.outputs.version }}"
-          # Strip leading 'v' to match CHANGELOG format (e.g. v0.1.0 → 0.1.0)
           VERSION_BARE="${VERSION#v}"
-          # Extract the section for this version between its header and the next
           awk "/^## \[${VERSION_BARE}\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md \
             > /tmp/release_notes.md
           echo "notes_path=/tmp/release_notes.md" >> "$GITHUB_OUTPUT"
@@ -81,5 +84,7 @@ jobs:
           body_path: ${{ steps.changelog.outputs.notes_path }}
           files: |
             release-artifacts/windows/*.exe
+            release-artifacts/macos/*.dmg
+            release-artifacts/macos/*.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Add secrets: inherit to pass signing secrets to called workflow
- Download fox-macos artifact alongside fox-windows
- Add *.dmg and *.zip to release file glob

Closes #30