### PR TITLE
fix: pass teamId explicitly for notarization

### DIFF
--- a/packages/electron/electron-builder.yml
+++ b/packages/electron/electron-builder.yml
@@ -52,7 +52,8 @@ mac:
   gatekeeperAssess: false
   entitlements: build/entitlements.mac.plist
   entitlementsInherit: build/entitlements.mac.plist
-  notarize: true
+  notarize:
+    teamId: Z6J8AVT9QK
 
 linux:
   category: Utility


### PR DESCRIPTION
electron-builder's notarize: true shorthand does not forward APPLE_TEAM_ID env var to @electron/notarize. Pass teamId in the config object directly.

Ref #29