### PR TITLE
fix: source hermes.env on every gateway/webui restart

### DIFF
--- a/packages/integration/scripts/run-with-env.sh
+++ b/packages/integration/scripts/run-with-env.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# run-with-env.sh — source /data/config/hermes.env, then exec the wrapped command.
+#
+# Why: supervisord freezes its environment at startup, so `supervisorctl restart`
+# alone cannot pick up keys the user adds via the onboarding wizard. Wrapping the
+# program command lets each restart re-read the latest hermes.env on disk, so the
+# wizard's restart path takes effect in seconds without a container restart.
+#
+# Source is best-effort: a malformed hermes.env must not block the wrapped
+# process from starting — a missing key surfaces downstream as the existing
+# "No LLM provider configured" error, not as a supervisord crash loop.
+if [ -f /data/config/hermes.env ]; then
+  set -a
+  # shellcheck disable=SC1091
+  source /data/config/hermes.env || true
+  set +a
+fi
+exec "$@"

--- a/packages/integration/supervisord.conf
+++ b/packages/integration/supervisord.conf
@@ -42,8 +42,10 @@ stderr_logfile=/data/logs/qdrant.err
 priority=20
 
 ; ── hermes gateway ────────────────────────────────────────────────────────────
+; Wrapped with run-with-env.sh so `supervisorctl restart` picks up keys the
+; onboarding wizard wrote to /data/config/hermes.env without a container restart.
 [program:hermes-gateway]
-command=python -m hermes_cli.main gateway run --replace
+command=/app/scripts/run-with-env.sh python -m hermes_cli.main gateway run --replace
 user=foxinthebox
 autostart=true
 autorestart=true
@@ -54,7 +56,7 @@ priority=30
 
 ; ── hermes webui ──────────────────────────────────────────────────────────────
 [program:hermes-webui]
-command=python /data/apps/hermes-webui/server.py
+command=/app/scripts/run-with-env.sh python /data/apps/hermes-webui/server.py
 user=foxinthebox
 autostart=true
 autorestart=true


### PR DESCRIPTION
## Summary

Makes the onboarding wizard's `POST /api/setup/restart` actually take effect, so the user gets a working chat within ~5 seconds of clicking "Open Fox" -- no manual `docker restart` required.

## Root cause

`supervisord` freezes its environment at PID-1 startup and passes that frozen env to all children. After the wizard writes `OPENROUTER_API_KEY` to `/data/config/hermes.env`, a `supervisorctl restart hermes-gateway` re-spawns the gateway with the **same** frozen env -- so the new process still has no key, and the user keeps seeing "No LLM provider configured" until they restart the whole container.

## Fix

Wrap the `hermes-gateway` and `hermes-webui` commands in `packages/integration/scripts/run-with-env.sh`:

```bash
if [ -f /data/config/hermes.env ]; then
  set -a
  source /data/config/hermes.env || true
  set +a
fi
exec "$@"
```

Now each `supervisorctl restart` re-spawns the wrapper, which reads the latest `hermes.env` from disk and hands the fresh vars to the wrapped process. No container restart, no patch to hermes-agent.

Source is best-effort (`|| true`, no `set -e`) so a malformed `hermes.env` cannot crash-loop supervisord -- a missing key still surfaces as the existing user-facing error, not as a hard failure.

`tailscaled` and `qdrant` are intentionally left untouched -- they don't consume user-supplied env vars.

The Dockerfile already does `COPY packages/integration/scripts/ /app/scripts/` and `chmod +x /app/scripts/*.sh`, so no Dockerfile change is needed.

## Verified end-to-end

Built `fox-in-the-box:test` from this branch and ran on port 8788 with a fresh data volume:

| Check | Result |
|-------|--------|
| Wrapper present + executable in container | `-rwxr-xr-x /app/scripts/run-with-env.sh` |
| Pre-wizard gateway env | no `OPENROUTER_API_KEY` |
| `POST /api/setup/openrouter` writes hermes.env | `OPENROUTER_API_KEY=sk-or-v1-...` |
| `POST /api/setup/restart` | gateway PID 29 -> 407 (restart fired) |
| Post-restart gateway `/proc/<pid>/environ` | `OPENROUTER_API_KEY=...` present |
| Container `stop` + `start` regression | gateway has key on boot, `GET /` returns 200 (no `/setup` redirect loop) |

## Out of scope

- Tailscale step (#3, #11)
- Multi-provider key entry (#13)
- Any change to hermes-agent or hermes-webui

## Test plan

- [ ] Pull this branch, rebuild image, run fresh container
- [ ] Walk through wizard with a real OpenRouter key, send a chat message immediately after "Open Fox" -- should get a real response
- [ ] Stop + start the container -- chat should still work, no `/setup` redirect

Generated with [Claude Code](https://claude.com/claude-code)