### PR TITLE
docs: README overhaul + split out reset guide (#40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,52 @@
 # Fox in the Box
 
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/bsgdigital?label=Sponsor&logo=githubsponsors&color=ea4aaa)](https://github.com/sponsors/bsgdigital)
-
-> A self-hosted AI assistant that runs entirely on your machine — no subscriptions, no cloud dependencies, no data leaving your control.
-
-Fox in the Box packages a full AI assistant stack into a single Docker container, with a native Windows desktop app and a one-command install script for **Linux and macOS** (Docker-based, same flow on both). Bring your own API key and you're up in minutes.
-
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey)](https://github.com/fox-in-the-box-ai/fox-in-the-box/releases)
 [![Release](https://img.shields.io/github/v/release/fox-in-the-box-ai/fox-in-the-box)](https://github.com/fox-in-the-box-ai/fox-in-the-box/releases/latest)
 
----
+> A private AI assistant that runs on your computer. No subscriptions, no cloud lock-in, no data leaving your machine without your say-so.
 
-## Features
+Fox in the Box bundles a full AI assistant — agent, chat UI, persistent memory, and secure remote access — into one app. Bring an OpenRouter API key, run the installer, and start chatting in minutes.
 
-| Feature | Description |
-|---------|-------------|
-| Single container | AI agent, web UI, memory, and VPN in one Docker image |
-| Web-based setup | Browser onboarding wizard — no terminal required |
-| Persistent memory | Remembers context across sessions via local vector store |
-| Remote access | Built-in Tailscale VPN with automatic HTTPS |
-| Desktop app | Native Electron wrapper for Windows; macOS uses the install script or Docker |
-| Open source | MIT licensed, full source available |
+<!-- TODO: add a screenshot or short GIF of the chat UI here -->
 
 ---
 
-## Installation
+## What you get
 
-### Option 1 — Install script (Linux and macOS)
+- **Runs on your computer.** Conversations, memory, and files stay on your machine.
+- **Remembers across sessions.** Your assistant picks up where you left off.
+- **Reachable from anywhere.** Optional secure HTTPS access from your phone or another laptop via Tailscale.
+- **Setup in the browser.** No terminal needed for the desktop app. Paste your API key, click Open Fox, start chatting.
+- **Open source.** MIT licensed. You can read every line of what's running.
 
-Same flow on both platforms: installs Docker if needed, pulls `ghcr.io/fox-in-the-box-ai/cloud:stable`, runs the container, and sets up **systemd** (Linux) or **launchd** (macOS) so the stack comes back after reboot.
+---
+
+## Install
+
+### Windows desktop app — **easiest**
+
+Download **[`fox-in-the-box-setup-x64.exe`](https://github.com/fox-in-the-box-ai/fox-in-the-box/releases/latest)** from the latest release. Run the installer and follow the prompts. Docker Desktop is installed automatically if missing.
+
+### macOS desktop app — **easiest**
+
+Download the matching DMG from the [latest release](https://github.com/fox-in-the-box-ai/fox-in-the-box/releases/latest):
+
+- Apple Silicon (M1/M2/M3/M4): **`fox-in-the-box-arm64-mac.dmg`**
+- Intel Mac: **`fox-in-the-box-x64-mac.dmg`**
+
+Open the DMG and drag Fox in the Box to your Applications folder. The DMG is signed and notarized by Apple.
+
+### Linux / macOS install script
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/fox-in-the-box-ai/fox-in-the-box/main/packages/scripts/install.sh | bash
 ```
 
-Or clone the repo and run `bash packages/scripts/install.sh`.
+Installs Docker if needed, pulls the container image, asks how you want to access it (port, Tailscale, or both), prompts for a friendly Tailscale hostname, and sets up `systemd` (Linux) or `launchd` (macOS) so the assistant comes back after reboot.
 
-- **Data directory (default):** Linux `~/.foxinthebox`; macOS `~/Library/Application Support/Fox in the Box`. Override with `FOX_DATA_DIR` / `FOX_WORKSPACE_DIR` if you need to.
-- **macOS:** If Docker is missing, the script installs **Docker Desktop** via Homebrew when `brew` is available, then exits so you can start Docker once and re-run the script.
-- **Browser:** The script waits until **`http://127.0.0.1:8787/health`** responds (up to **240s** on first boot), then opens **http://localhost:8787**. Set **`FOX_OPEN_BROWSER=0`** to skip opening; **`FOX_HEALTH_WAIT_SEC`** overrides the wait cap. If the tab still loads slowly, refresh once Hermes has finished starting (`docker logs -f fox-in-the-box`).
-
-### Option 2 — Docker one-liner (all platforms)
-
-Matches the integration smoke test (localhost binding, Tailscale-capable container):
+### Docker one-liner — advanced users
 
 ```bash
 docker run -d \
@@ -57,88 +60,42 @@ docker run -d \
   ghcr.io/fox-in-the-box-ai/cloud:stable
 ```
 
-On macOS you can keep `-v ~/.foxinthebox:/data` or use a path under `~/Library/Application Support/Fox in the Box` for consistency with the install script.
+Then open **http://localhost:8787** and follow the setup wizard.
 
-### Option 3 — Windows desktop app
-
-Download the installer from the [latest release](https://github.com/fox-in-the-box-ai/fox-in-the-box/releases/latest): **`fox-in-the-box-setup.exe`** (stable name on tagged releases).
-
-There is **no** signed macOS `.dmg` in releases; use **Option 1** on Mac.
-
-### Option 4 — Build from source
-
-Initialize submodules (Hermes agent and webui are **copied into the image at build time** from `forks/`):
+### Build from source
 
 ```bash
 git submodule update --init --recursive
 ```
 
-Then see [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md) for full build instructions (e.g. `pnpm build:docker` from the repo root).
-
----
-
-## Full reset (desktop app, “clean install”)
-
-Use this when you want a **new container**, fresh **on-disk data**, and optionally a **fresh image** (for example after changing Docker options such as `/dev/net/tun`).
-
-### Windows
-
-1. **Quit** Fox in the box completely (including the system tray icon).
-2. **Uninstall** the application from **Settings → Apps → Installed apps** if you also want the program files removed. The installer does **not** delete your data folder by default.
-3. Remove the container and app data — either:
-   - **Script (recommended):** in PowerShell, from the repo (or copy the file elsewhere):
-
-     ```powershell
-     cd packages\scripts
-     .\clean-windows-desktop.ps1
-     ```
-
-     To also delete the published Linux image (next app start will `docker pull` again):
-
-     ```powershell
-     .\clean-windows-desktop.ps1 -RemoveImage
-     ```
-
-     If you ever used the **CLI** flow with `-v ~/.foxinthebox:/data` from this README, add `-RemoveFoxintheboxDir` to remove `%USERPROFILE%\.foxinthebox` as well.
-
-   - **Manual:** `docker rm -f fox-in-the-box`, delete `%APPDATA%\Fox in the box`, and optionally `docker rmi ghcr.io/fox-in-the-box-ai/cloud:stable`.
-4. **Reinstall** from the [latest release](https://github.com/fox-in-the-box-ai/fox-in-the-box/releases/latest) (or run your new installer / dev build), then start the app once so it recreates the container.
-
-### macOS (install script or Docker)
-
-1. Stop the stack: `docker stop fox-in-the-box` (or `docker rm -f fox-in-the-box`).
-2. If you used **launchd** from the install script: `launchctl unload ~/Library/LaunchAgents/io.foxinthebox.plist` and remove that plist if you no longer want auto-start.
-3. Remove data under your chosen `FOX_DATA_DIR` (default: `~/Library/Application Support/Fox in the Box`).
-4. Optionally `docker rmi ghcr.io/fox-in-the-box-ai/cloud:stable`, then re-run the [install script](#option-1--install-script-linux-and-macos) or the Docker one-liner.
+See [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md) for the full build flow.
 
 ---
 
 ## Requirements
 
-| Platform | Requirement |
-|----------|-------------|
-| Docker | 20.10 or later |
-| Windows | Windows 10 or later (x64) |
-| macOS | macOS 12 (Monterey) or later |
-| Linux | Any distro with Docker support |
-
-An [OpenRouter](https://openrouter.ai) API key is required for AI functionality.
+- **Windows 10** or later, **macOS 12** (Monterey) or later, or **any Linux** with Docker.
+- An **[OpenRouter](https://openrouter.ai)** API key (required for setup). Additional providers — Anthropic, OpenAI, etc. — are configurable in Settings after install.
 
 ---
 
 ## Architecture
 
-Fox in the Box bundles the following components:
-
 | Component | Purpose |
 |-----------|---------|
 | [Hermes Agent](https://github.com/fox-in-the-box-ai/hermes-agent) | AI agent core — LLM orchestration, tools, skills |
 | [Hermes WebUI](https://github.com/fox-in-the-box-ai/hermes-webui) | Browser-based chat interface |
-| mem0\_oss + Qdrant | Persistent memory with local vector search |
-| Tailscale | VPN tunneling and automatic HTTPS |
+| mem0 + Qdrant | Persistent memory with local vector search |
+| Tailscale | Optional VPN tunneling and automatic HTTPS |
 | supervisord | Process management inside the container |
 
-**Container vs. data:** The published Docker image includes Hermes agent and webui source (from the monorepo `forks/` submodules) installed at **build** time. On startup, the entrypoint links them under `/data/apps` so supervisord paths stay stable; the **`/data` volume** holds your config, databases, logs, and Tailscale state — not a fresh `git clone` of Hermes on every first run. Updating Hermes for end users means pulling a **newer image**, not waiting for the container to clone GitHub.
+**Container vs. data:** the published Docker image bundles Hermes agent and webui source (from `forks/` submodules) at **build** time. The container's `/data` volume holds your config, databases, logs, and Tailscale state. Updating Hermes for end users means pulling a newer image, not re-cloning at runtime.
+
+---
+
+## Need a fresh start?
+
+See **[docs/RESET.md](docs/RESET.md)** for the full reset procedure (Windows and macOS).
 
 ---
 
@@ -147,9 +104,49 @@ Fox in the Box bundles the following components:
 - [CHANGELOG.md](CHANGELOG.md) — release history
 - [CONTRIBUTING.md](CONTRIBUTING.md) — how to contribute
 - [SECURITY.md](SECURITY.md) — vulnerability reporting
-- [CODE\_OF\_CONDUCT.md](CODE_OF_CONDUCT.md) — community standards
-- [docs/GETTING\_STARTED.md](docs/GETTING_STARTED.md) — development setup
+- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) — community standards
+- [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md) — development setup
 - [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — system design
+- [docs/RESET.md](docs/RESET.md) — full reset / clean install
+
+---
+
+## FAQ
+
+**Is it really private?**
+Yes. The app runs on your computer. The only outbound traffic is the API call to your AI provider when you send a message. Conversations, memory, and files never leave your machine.
+
+**Do I need to know how to code?**
+No. Download the desktop app, run it, and follow the setup wizard in your browser. No terminal, no commands, no config files.
+
+**What's an API key and where do I get one?**
+An API key is a token that lets the app talk to an AI service. Create a free account at **[openrouter.ai](https://openrouter.ai)** and generate a key — the setup wizard asks you to paste it in. Top up a few dollars of credit there to send messages.
+
+**Can I use it on my phone?**
+Yes. Choose the Tailscale option during setup; you'll get an HTTPS URL you can open from any device on your tailnet — phone, tablet, another laptop.
+
+**How much does it cost?**
+The app itself is free and open source. You only pay for AI usage at your provider (typically a few cents per conversation, depending on the model).
+
+---
+
+## Support
+
+Open an [issue](https://github.com/fox-in-the-box-ai/fox-in-the-box/issues/new/choose) or start a [discussion](https://github.com/fox-in-the-box-ai/fox-in-the-box/discussions).
+
+---
+
+## Acknowledgments
+
+Fox in the Box stands on the shoulders of:
+
+- **[Hermes Agent](https://github.com/NousResearch/hermes-agent)** by NousResearch — the agent core.
+- **[Hermes WebUI](https://github.com/NousResearch/hermes-webui)** — the browser chat interface.
+- **[Qdrant](https://qdrant.tech)** — vector database powering memory.
+- **[mem0](https://github.com/mem0ai/mem0)** — memory layer.
+- **[Tailscale](https://tailscale.com)** — secure remote access and HTTPS.
+- **[Electron](https://www.electronjs.org)** — desktop app framework.
+- **[Brave Search](https://brave.com/search/)** — web search via MCP.
 
 ---
 

--- a/docs/RESET.md
+++ b/docs/RESET.md
@@ -1,0 +1,86 @@
+# Full reset — clean install
+
+Use this when you want a new container, fresh on-disk data, and optionally a fresh image (for example after changing Docker options like `/dev/net/tun`).
+
+## Windows
+
+1. **Quit Fox in the Box completely**, including the system-tray icon.
+2. **Uninstall the app** from *Settings → Apps → Installed apps* if you also want the program files removed. The installer does not delete your data folder by default.
+3. **Remove the container and data** — pick one:
+
+   **Script (recommended).** In PowerShell, from the repo (or copy the script elsewhere):
+
+   ```powershell
+   cd packages\scripts
+   .\clean-windows-desktop.ps1
+   ```
+
+   To also delete the cached Linux image (the next app start will `docker pull` again):
+
+   ```powershell
+   .\clean-windows-desktop.ps1 -RemoveImage
+   ```
+
+   If you ever ran the CLI Docker one-liner with `-v ~/.foxinthebox:/data`, add `-RemoveFoxintheboxDir` to remove `%USERPROFILE%\.foxinthebox` as well.
+
+   **Manual.**
+
+   ```powershell
+   docker rm -f fox-in-the-box
+   Remove-Item -Recurse -Force "$env:APPDATA\Fox in the box"
+   docker rmi ghcr.io/fox-in-the-box-ai/cloud:stable   # optional
+   ```
+
+4. **Reinstall** from the [latest release](https://github.com/fox-in-the-box-ai/fox-in-the-box/releases/latest) and start the app once so it recreates the container.
+
+## macOS
+
+1. **Quit Fox in the Box** from the menu-bar icon (or stop the container directly: `docker stop fox-in-the-box`).
+2. **Remove the container.**
+
+   ```bash
+   docker rm -f fox-in-the-box
+   ```
+
+3. **If you used the install script**, unload the launchd agent so it stops auto-starting:
+
+   ```bash
+   launchctl unload ~/Library/LaunchAgents/io.foxinthebox.plist
+   rm ~/Library/LaunchAgents/io.foxinthebox.plist   # only if you no longer want auto-start
+   ```
+
+4. **Remove your data** at the path you chose during install (default: `~/Library/Application Support/Fox in the Box`):
+
+   ```bash
+   rm -rf "$HOME/Library/Application Support/Fox in the Box"
+   ```
+
+5. **Optionally remove the cached image** so the next install pulls fresh:
+
+   ```bash
+   docker rmi ghcr.io/fox-in-the-box-ai/cloud:stable
+   ```
+
+6. **Reinstall** by re-running the [install script](../README.md#linux--macos-install-script) or the Docker one-liner.
+
+## Linux
+
+1. Stop and remove the container:
+   ```bash
+   docker rm -f fox-in-the-box
+   ```
+2. If you installed the systemd unit, disable + remove it:
+   ```bash
+   sudo systemctl disable --now foxinthebox.service foxinthebox-updater.service foxinthebox-updater.path
+   sudo rm /etc/systemd/system/foxinthebox*
+   sudo systemctl daemon-reload
+   ```
+3. Remove your data directory (default: `~/.foxinthebox`):
+   ```bash
+   rm -rf ~/.foxinthebox
+   ```
+4. Optionally clear the image:
+   ```bash
+   docker rmi ghcr.io/fox-in-the-box-ai/cloud:stable
+   ```
+5. Reinstall via `bash packages/scripts/install.sh` or the Docker one-liner.


### PR DESCRIPTION
## Summary

Closes #40 (the substantive parts; full visual hero/screenshots flagged for a separate pass once we have screenshot assets).

The README had two factual errors that actively turned away Mac users — the v0.1.0 release shipped signed+notarized DMGs but the README still said *"there is no signed macOS .dmg in releases"* and *"macOS uses the install script or Docker."* Those are gone.

## What changed

### Install section reordered
Was: install script → Docker → Windows .exe → from-source.
Now: **Windows .exe → macOS DMG → install script → Docker one-liner → from-source.** Each desktop option uses the actual filename the v0.1.2 release pipeline produces (`fox-in-the-box-setup-x64.exe`, `fox-in-the-box-arm64-mac.dmg`, `fox-in-the-box-x64-mac.dmg`).

### "What you get" replaces "Features"
Plain language, no Docker / Qdrant / supervisord jargon above the install section. Technical detail still present further down in Architecture for developers.

### Reset moved to `docs/RESET.md`
The PowerShell `.\clean-windows-desktop.ps1` and `launchctl unload` steps used to live in the main README. They're necessary but they made the project look complicated to non-technical readers. The README now has one line linking to the new guide.

### New sections
- **FAQ** — 5 questions: privacy, no-code requirement, what's an API key, mobile access, cost.
- **Support** — link to issues + discussions.
- **Acknowledgments** — Hermes, Qdrant, mem0, Tailscale, Electron, Brave Search.

### OpenRouter still listed as required
Per scope decision: the onboarding wizard asks for an OpenRouter key before unlocking chat. README is explicit that additional providers (Anthropic, OpenAI, etc.) are configurable in Settings after install.

## Out of scope (intentional, flagged)

- **Screenshots / GIFs** — placeholder TODO comment in the file. Will need actual asset files.
- **Centered HTML hero** — GitHub markdown renders inconsistently with raw HTML; sticking to plain markdown for portability. The badges row at the top serves the same purpose.
- **README in other languages** — separate effort.

## Test plan

- [x] Markdown lints clean (no broken link syntax)
- [ ] Render preview on github.com after merge — verify Acknowledgments / FAQ formatting
- [ ] All internal links (`docs/RESET.md`, `CHANGELOG.md`, etc.) resolve

Generated with [Claude Code](https://claude.com/claude-code)