### PR TITLE
ci: sign Windows installer with Azure Trusted Signing

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write   # OIDC token for Azure Trusted Signing on Windows builds
 
 jobs:
   build:
@@ -75,6 +76,27 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+
+      # Sign the NSIS installer in place using Azure Trusted Signing (Icemint LLC
+      # certificate profile). OIDC auth — no client secret needed; the federated
+      # credential in Azure trusts this repo's GitHub Actions runs via the
+      # AZURE_TENANT_ID + AZURE_CLIENT_ID identity. Runs only on Windows; the
+      # already-signed *.exe is what's picked up by the next Upload step, so
+      # release.yml downloads and ships a signed installer.
+      - name: Sign Windows installer (Azure Trusted Signing)
+        if: runner.os == 'Windows'
+        uses: azure/artifact-signing-action@v1
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          endpoint: https://eus.codesigning.azure.net/
+          trusted-signing-account-name: Icemint
+          certificate-profile-name: fitb-exe-signing
+          files-folder: packages/electron/dist
+          files-folder-filter: exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

The Windows `.exe` shipped in v0.1.0–v0.1.3 was unsigned. Microsoft Defender SmartScreen blocks it on first launch with a *"Windows protected your PC"* dialog and no obvious trust path — hostile first-run for non-technical users. This PR wires Azure Trusted Signing (Icemint LLC certificate profile) into the build pipeline.

## What changed

Single file: `.github/workflows/build-electron.yml`.

1. **Workflow-level permissions:** added `id-token: write` so the runner can request a GitHub OIDC token to exchange for Azure credentials.
2. **New signing step**, placed between `Build Electron app` and `Upload build artifact`, gated on `runner.os == 'Windows'`:
   ```yaml
   - name: Sign Windows installer (Azure Trusted Signing)
     if: runner.os == 'Windows'
     uses: azure/artifact-signing-action@v1
     with:
       azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
       azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
       endpoint: https://eus.codesigning.azure.net/
       trusted-signing-account-name: Icemint
       certificate-profile-name: fitb-exe-signing
       files-folder: packages/electron/dist
       files-folder-filter: exe
       file-digest: SHA256
       timestamp-rfc3161: http://timestamp.acs.microsoft.com
       timestamp-digest: SHA256
   ```

The .exe is signed **in place** before the upload, so the existing `fox-windows` artifact and the existing `release.yml` download-and-upload path now ship a signed installer. **No change needed to `release.yml`.**

## Why this aligns with our updated CI/CD

After v0.1.2's pipeline overhaul (#39):
- `build-electron.yml` is the only workflow that produces Electron artifacts.
- Tag pushes go through `release.yml` only — no parallel uploaders.
- `release.yml` downloads artifacts from `wait-for-electron` and uploads to the GitHub Release atomically.

Signing the .exe inside `build-electron.yml` (rather than as a separate post-release step) keeps that single-source-of-truth pattern intact: **what the artifact contains is what gets released.**

## Prerequisites before merge

Azure-side setup that must be in place before the first Windows build after this PR merges:

1. Trusted Signing account `Icemint` exists with profile `fitb-exe-signing` at `https://eus.codesigning.azure.net/`.
2. App registration created in Azure AD (the federated identity).
3. Federated credential added to that app registration trusting this repo:
   - Issuer: `https://token.actions.githubusercontent.com`
   - Subject: `repo:fox-in-the-box-ai/fox-in-the-box:ref:refs/heads/main` (and `:tag:refs/tags/v*` for tag-triggered runs through `release.yml`)
   - Audience: `api://AzureADTokenExchange`
4. The app registration has `Trusted Signing Certificate Profile Signer` role on the Trusted Signing account.
5. Repo secrets configured:
   - `AZURE_TENANT_ID` — the tenant the app registration lives in
   - `AZURE_CLIENT_ID` — the app registration's client ID

If these aren't in place, the first signed build after merge will fail at the Sign step. **That's intentional** — a broken signing path should be a loud failure, not a silent shipment of unsigned binaries.

## Failure modes considered

- **Secrets not set yet:** the Sign step fails, the artifact upload doesn't run, `release.yml`'s `download-artifact` for `fox-windows` returns nothing, `fail_on_unmatched_files: true` (added in v0.1.2) catches it. Pipeline fails loud.
- **Forked-repo PRs:** can't read repo secrets, so the Sign step fails. Acceptable — signing is for trusted release artifacts only. Fork contributors test unsigned locally; CI for their PRs will fail Windows builds, which is fine for review.
- **Federated credential subject scope:** if the federated credential is restricted to `refs/heads/main`, manual `workflow_dispatch` runs from feature branches won't be able to sign. Either broaden the federated credential to `repo:fox-in-the-box-ai/fox-in-the-box:*` or accept that signed builds happen only on `main` and tag pushes.
- **macOS runners:** `if: runner.os == 'Windows'` short-circuits — no impact on existing notarized DMG signing.

## Test plan

- [ ] Confirm Azure-side setup (5 prerequisites above) before merging.
- [ ] After merge, `workflow_dispatch` on `build-electron.yml` for verification — the Windows build's Sign step should succeed.
- [ ] Cut a test tag (e.g. `v0.1.4-rc1`) and verify the resulting .exe on the GitHub Release is signed (right-click → Properties → Digital Signatures should show Icemint LLC).
- [ ] Confirm Microsoft SmartScreen no longer blocks first launch.

Generated with [Claude Code](https://claude.com/claude-code)