### PR TITLE
ci: add azure/login step before Trusted Signing on Windows

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -77,12 +77,22 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
+      # Establish Azure auth context via OIDC. The signing action below picks up
+      # credentials from the active Azure session rather than re-authenticating
+      # itself; without this step, the signing step's inline OIDC path fails to
+      # complete the token exchange against the Trusted Signing endpoint.
+      - name: Azure login (OIDC)
+        if: runner.os == 'Windows'
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
       # Sign the NSIS installer in place using Azure Trusted Signing (Icemint LLC
-      # certificate profile). OIDC auth — no client secret needed; the federated
-      # credential in Azure trusts this repo's GitHub Actions runs via the
-      # AZURE_TENANT_ID + AZURE_CLIENT_ID identity. Runs only on Windows; the
-      # already-signed *.exe is what's picked up by the next Upload step, so
-      # release.yml downloads and ships a signed installer.
+      # certificate profile). Auth comes from the azure/login step above. Runs
+      # only on Windows; the already-signed *.exe is what's picked up by the next
+      # Upload step, so release.yml downloads and ships a signed installer.
       - name: Sign Windows installer (Azure Trusted Signing)
         if: runner.os == 'Windows'
         uses: azure/artifact-signing-action@v1


### PR DESCRIPTION
## Summary

Follow-up to #49. The signing step there set up OIDC inline via `azure-tenant-id` and `azure-client-id` inputs, but that path doesn't complete the token exchange against the Trusted Signing endpoint at runtime. The canonical pattern is `azure/login@v2` first (federated OIDC) and the signing action picks up the active Azure session.

## What changed

`.github/workflows/build-electron.yml`: one new step inserted between `Build Electron app` and the existing `Sign Windows installer` step.

```yaml
- name: Azure login (OIDC)
  if: runner.os == 'Windows'
  uses: azure/login@v2
  with:
    client-id: ${{ secrets.AZURE_CLIENT_ID }}
    tenant-id: ${{ secrets.AZURE_TENANT_ID }}
    subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
```

The signing step's own `azure-tenant-id` / `azure-client-id` inputs are kept as-is — surgical change. They become the fallback path; the active session from `azure/login` is what the signing action actually uses.

`id-token: write` permission is already at workflow level from #49, so no permissions change needed.

## Required action before this can succeed

Add a new repo secret **`AZURE_SUBSCRIPTION_ID`** with the subscription ID provided out of band. (`AZURE_TENANT_ID` and `AZURE_CLIENT_ID` are already configured.)

## Alignment with current CI/CD

Same single-source-of-truth pattern as v0.1.2+:
- `build-electron.yml` runs only on push to `main`, `workflow_call`, or `workflow_dispatch` — never duplicates with `release.yml`.
- The signed `.exe` is produced by this workflow and uploaded as the `fox-windows` artifact.
- `release.yml` downloads that artifact and uploads it to the GitHub Release atomically. No change needed in `release.yml`.

## Test plan

- [ ] Add `AZURE_SUBSCRIPTION_ID` repo secret.
- [ ] After merge, push to `main` triggers `Build Electron`. The `windows-latest` job's `Azure login (OIDC)` step should succeed; `Sign Windows installer` should follow with success.
- [ ] If both succeed, cut a test tag (`v0.1.4-rc1` or similar) and verify the `.exe` on the Release shows a valid Authenticode signature from Icemint LLC.

## Failure modes considered

- `AZURE_SUBSCRIPTION_ID` missing: `azure/login@v2` fails. The signing step never runs. Artifact upload fails because the `.exe` is unsigned but expected. Loud failure (good).
- Federated credential subject pattern doesn't include `refs/heads/main`: login fails on every `main` push. Surface in the workflow log clearly.
- macOS jobs: short-circuited by `if: runner.os == 'Windows'` — no impact.