### PR TITLE
ci: grant id-token: write to wait-for-electron in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write   # OIDC token for Azure Trusted Signing — must be granted at the caller, not just declared in the called workflow
     secrets: inherit
 
   release:


### PR DESCRIPTION
## Summary

Fixes the v0.1.4 release failure:

> Error calling workflow `fox-in-the-box-ai/fox-in-the-box/.github/workflows/build-electron.yml@091ec2bad9bc4e6d25be4f7908ca31edd39fc44b`. The workflow is requesting `'id-token: write'`, but is only allowed `'id-token: none'`.

## Root cause

`build-electron.yml` declares `permissions.id-token: write` at workflow level so its `azure/login` + Trusted Signing chain can request an OIDC token. That declaration applies when the workflow runs as the top-level event source (push to `main`, `workflow_dispatch`, direct tag trigger).

When `release.yml` calls `build-electron.yml` via `workflow_call`, the called workflow inherits permissions from the **calling job's** `permissions:` block — not from its own declaration. The calling job (`wait-for-electron`) listed only `contents: write` + `packages: write`, so `id-token` was implicitly denied.

This explains the data:
- `main` push at `16811a6` (PR #50): direct trigger → uses build-electron.yml's own permissions → signing succeeded.
- `v0.1.4` tag push: routed through `release.yml` → `wait-for-electron` permissions block did not grant `id-token` → invalid-workflow error before any job ran.

## Fix

One line added to `release.yml`'s `wait-for-electron` job permissions:

```yaml
permissions:
  contents: write
  packages: write
  id-token: write   # OIDC token for Azure Trusted Signing — must be granted at the caller, not just declared in the called workflow
```

No change to `build-electron.yml`.

## Post-merge to ship v0.1.4

The v0.1.4 tag points at `091ec2b` which doesn't have this fix. Re-running the failed Release run wouldn't pick it up — re-runs use the workflow at the tagged commit, not main.

Two options:
1. **Move the v0.1.4 tag** to the post-merge commit (delete + recreate the tag pointing at the new HEAD of main). Same version number, same CHANGELOG entry, no published release exists yet so nothing breaks.
2. **Cut v0.1.5** — clean but the existing v0.1.4 tag becomes a tombstone.

Option 1 keeps version intent stable since v0.1.4 has no published release. Either is fine; needs your call.