### PR TITLE
ci: bind Windows signing to a GitHub Environment for Azure OIDC

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -6,6 +6,17 @@ on:
     branches:
       - main
   workflow_call:
+    inputs:
+      signing-environment:
+        description: >-
+          GitHub Environment to bind the Windows signing job to. The Azure
+          federated identity credential is keyed on this environment's subject
+          claim, so it must match the environment configured in Entra ID.
+          Empty (default) means: produce unsigned build artifacts and skip
+          the Azure login + signing steps. release.yml passes "release".
+        type: string
+        required: false
+        default: ''
   workflow_dispatch:
 
 permissions:
@@ -16,6 +27,11 @@ jobs:
   build:
     name: Build Electron — ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    # When signing-environment is set (release.yml call), the matrix jobs
+    # bind to that GitHub Environment. The OIDC token GitHub mints then
+    # carries `environment:<name>` in its sub claim, which the Azure
+    # federated credential matches exactly. Empty value = no environment.
+    environment: ${{ inputs.signing-environment }}
 
     strategy:
       fail-fast: false
@@ -77,12 +93,12 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
-      # Establish Azure auth context via OIDC. The signing action below picks up
-      # credentials from the active Azure session rather than re-authenticating
-      # itself; without this step, the signing step's inline OIDC path fails to
-      # complete the token exchange against the Trusted Signing endpoint.
+      # Establish Azure auth context via OIDC. Skipped when signing-environment
+      # is empty (e.g. push to main, workflow_dispatch without input) — those
+      # builds produce unsigned artifacts purely for CI verification and never
+      # ship to a release.
       - name: Azure login (OIDC)
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && inputs.signing-environment != ''
         uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -90,11 +106,10 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       # Sign the NSIS installer in place using Azure Trusted Signing (Icemint LLC
-      # certificate profile). Auth comes from the azure/login step above. Runs
-      # only on Windows; the already-signed *.exe is what's picked up by the next
-      # Upload step, so release.yml downloads and ships a signed installer.
+      # certificate profile). Auth comes from the azure/login step above. Same
+      # gate as the login step — only signs when bound to the signing environment.
       - name: Sign Windows installer (Azure Trusted Signing)
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && inputs.signing-environment != ''
         uses: azure/artifact-signing-action@v1
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,12 @@ jobs:
       packages: write
       id-token: write   # OIDC token for Azure Trusted Signing — must be granted at the caller, not just declared in the called workflow
     secrets: inherit
+    with:
+      # Binds the Windows matrix job to this GitHub Environment so its OIDC
+      # token's sub claim is `repo:.../environment:release`, which the Azure
+      # federated credential `github-env-release` matches exactly. Removes
+      # dependency on tag-name patterns (Azure FICs don't actually wildcard).
+      signing-environment: release
 
   release:
     name: Create GitHub Release


### PR DESCRIPTION
## Summary

Replaces the broken tag-pattern federated credential approach with environment-bound OIDC. Microsoft's recommended pattern for "many tags" releases — GA, no preview risk, no per-tag Azure maintenance.

## What was broken

Standard Azure federated identity credentials **do not actually wildcard** tag names. The portal's "GitHub tag name: v*" UI stores `v*` as a literal subject string, and Azure does exact-string match against the OIDC token's `sub` claim. v0.1.5's `sub` was `repo:fox-in-the-box-ai/fox-in-the-box:ref:refs/tags/v0.1.5`, and no literal credential matched → AADSTS700213.

[Microsoft Learn confirms](https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation-create-trust):

> Pattern matching isn't supported for branches and tags. Specify an environment if your on-push workflow runs against many branches or tags.

## What's now in place

**Azure side (already configured):**
- App registration has a federated credential `github-env-release` with subject `repo:fox-in-the-box-ai/fox-in-the-box:environment:release`.
- Old `github-tags` literal-`v*` credential pending cleanup.

**GitHub side (already configured):**
- Repo Environment `release` exists.

**Code side (this PR):**

`build-electron.yml`:
- New optional `workflow_call.inputs.signing-environment` (default `''`).
- The `build` matrix job binds to that environment via `environment: ${{ inputs.signing-environment }}`. Empty value = no environment, which GitHub treats as no environment binding.
- Azure login + signing steps gate on `runner.os == 'Windows' && inputs.signing-environment != ''`.

`release.yml`:
- `wait-for-electron` now passes `with: { signing-environment: release }`.

Push-to-main and `workflow_dispatch` builds keep producing unsigned artifacts for CI verification and never try to authenticate to Azure.

## How signing now resolves end-to-end

1. Tag push → `release.yml` fires.
2. `wait-for-electron` calls `build-electron.yml` with `signing-environment: release`.
3. The Windows matrix job binds to the `release` environment. GitHub mints an OIDC token whose `sub` claim is `repo:fox-in-the-box-ai/fox-in-the-box:environment:release`.
4. `azure/login@v2` sends that token to Azure. The `github-env-release` credential matches exactly. Login succeeds.
5. `azure/artifact-signing-action@v1` picks up the active Azure session, signs the NSIS installer in place.
6. The signed `.exe` is uploaded as the `fox-windows` artifact.
7. `release.yml`'s `release` job downloads it and publishes the GitHub Release with `softprops/action-gh-release@v2`.

Independent of the tag name. v0.1.6 → v0.99.0 → v1.0.0 all work without touching Azure.

## Tradeoffs / failure modes

- **Empty `environment:` value:** GitHub interprets `environment: ''` as no-environment. This is the path for push-to-main and `workflow_dispatch`. If GitHub ever changes this behavior, those builds would fail loudly at job-init — fixable by introducing a `ci` environment as the non-empty default.
- **Optional protection rules:** the `release` environment can have approval/reviewer gates added later in repo settings without code changes.
- **Old `github-tags` credential** can now be deleted from Azure — it never matched anything and won't going forward.

## Test plan

- [ ] Merge this PR.
- [ ] Cut a fresh tag (`v0.1.6` — leaves the orphaned v0.1.4/v0.1.5 tags untouched).
- [ ] Watch the Release workflow: `wait-for-electron` Windows job's `Azure login (OIDC)` step succeeds and `Sign Windows installer` succeeds.
- [ ] Verify the published Release has all 5 expected assets, with the `.exe` carrying a valid Authenticode signature from Icemint LLC.

## Sources

- [Federated identity credentials — exact-match requirement and environment recommendation](https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation-create-trust)
- [Flexible FICs (preview) — alternative we evaluated and didn't take](https://learn.microsoft.com/en-us/entra/workload-id/workload-identities-flexible-federated-identity-credentials)