### PR TITLE
fix(electron): validate /health body marker in setup polling

### DIFF
--- a/packages/electron/src/health-check.js
+++ b/packages/electron/src/health-check.js
@@ -11,12 +11,46 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// Match the in-container probe (forks/hermes-webui/bootstrap.py:wait_for_health):
+// healthy = HTTP 200 AND body contains `"status": "ok"`. Status alone is too loose
+// — anything on :8787 returning 200 with a different shape would falsely satisfy
+// the gate. Cap the captured body so a misbehaving endpoint can't pin memory.
+const HEALTHY_MARKER = '"status": "ok"';
+const MAX_BODY_BYTES = 4096;
+
 function requestHealth(url, timeoutMs) {
   return new Promise((resolve) => {
     const req = http.get(url, (res) => {
       const statusCode = res.statusCode;
-      res.resume(); // drain
-      resolve({ ok: statusCode === 200, statusCode, error: null });
+      if (statusCode !== 200) {
+        res.resume();
+        resolve({ ok: false, statusCode, error: null });
+        return;
+      }
+      let body = '';
+      let truncated = false;
+      res.setEncoding('utf8');
+      res.on('data', (chunk) => {
+        if (truncated) return;
+        if (body.length + chunk.length > MAX_BODY_BYTES) {
+          body += chunk.slice(0, MAX_BODY_BYTES - body.length);
+          truncated = true;
+          res.resume(); // discard remainder without buffering
+          return;
+        }
+        body += chunk;
+      });
+      res.on('end', () => {
+        const ok = body.includes(HEALTHY_MARKER);
+        resolve({
+          ok,
+          statusCode,
+          error: ok ? null : `body missing ${HEALTHY_MARKER}`,
+        });
+      });
+      res.on('error', (err) => {
+        resolve({ ok: false, statusCode, error: err.message });
+      });
     });
 
     req.on('error', (err) => {

--- a/tests/electron/health-check.test.js
+++ b/tests/electron/health-check.test.js
@@ -6,6 +6,24 @@ jest.mock('http', () => ({ get: jest.fn() }));
 const http = require('http');
 const { waitUntilHealthy } = require('../../packages/electron/src/health-check');
 
+function makeRes({ statusCode, body }) {
+  const handlers = {};
+  return {
+    statusCode,
+    setEncoding() {},
+    resume() {},
+    on(event, handler) {
+      handlers[event] = handler;
+    },
+    _emit() {
+      if (body !== undefined && handlers.data) handlers.data(body);
+      if (handlers.end) handlers.end();
+    },
+  };
+}
+
+const HEALTHY_BODY = '{\n  "status": "ok",\n  "uptime_seconds": 1.2\n}';
+
 describe('waitUntilHealthy', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -36,7 +54,9 @@ describe('waitUntilHealthy', () => {
         if (calls < 3) {
           if (req._onError) req._onError(new Error('not ready'));
         } else {
-          cb({ statusCode: 200, resume: () => {} });
+          const res = makeRes({ statusCode: 200, body: HEALTHY_BODY });
+          cb(res);
+          res._emit();
         }
         inFlight -= 1;
       }, 10);
@@ -52,6 +72,52 @@ describe('waitUntilHealthy', () => {
 
     expect(maxInFlight).toBe(1);
     expect(calls).toBeGreaterThanOrEqual(3);
+  });
+
+  test('rejects 200 responses missing the "status": "ok" marker', async () => {
+    http.get.mockImplementation((_url, cb) => {
+      const req = {
+        _onError: null,
+        on(event, handler) { if (event === 'error') this._onError = handler; },
+        setTimeout() {},
+        destroy(err) { if (this._onError) this._onError(err || new Error('timeout')); },
+      };
+      setTimeout(() => {
+        const res = makeRes({ statusCode: 200, body: '{"status":"degraded"}' });
+        cb(res);
+        res._emit();
+      }, 1);
+      return req;
+    });
+
+    await expect(waitUntilHealthy({
+      timeoutMs: 30,
+      intervalMs: 1,
+      requestTimeoutMs: 10,
+    })).rejects.toMatchObject({ code: 'HEALTH_TIMEOUT' });
+  });
+
+  test('accepts 200 with healthy body and resolves', async () => {
+    http.get.mockImplementation((_url, cb) => {
+      const req = {
+        _onError: null,
+        on(event, handler) { if (event === 'error') this._onError = handler; },
+        setTimeout() {},
+        destroy() {},
+      };
+      setTimeout(() => {
+        const res = makeRes({ statusCode: 200, body: HEALTHY_BODY });
+        cb(res);
+        res._emit();
+      }, 1);
+      return req;
+    });
+
+    await expect(waitUntilHealthy({
+      timeoutMs: 1000,
+      intervalMs: 1,
+      requestTimeoutMs: 100,
+    })).resolves.toBeUndefined();
   });
 
   test('rejects with HEALTH_TIMEOUT when service never becomes healthy', async () => {
@@ -92,7 +158,11 @@ describe('waitUntilHealthy', () => {
         destroy(err) {
           if (this._onError) this._onError(err || new Error('timeout'));
           // Late success callback should not flip result.
-          setTimeout(() => cb({ statusCode: 200, resume: () => {} }), 20);
+          setTimeout(() => {
+            const res = makeRes({ statusCode: 200, body: HEALTHY_BODY });
+            cb(res);
+            res._emit();
+          }, 20);
         },
       };
       return req;


### PR DESCRIPTION
## Summary

The Electron setup window's `/health` probe accepted any HTTP 200, while the in-container probe (`forks/hermes-webui/bootstrap.py:wait_for_health`) requires the body to contain `"status": "ok"`. Same endpoint, two different success criteria — and when the gates disagreed, the setup window could hang at **Step 5/6 — Wait for services** even with `curl http://127.0.0.1:8787/health` returning a healthy 200.

`packages/electron/src/health-check.js:requestHealth` now reads the body (capped at 4KB so a misbehaving endpoint can't pin memory) and requires both the status code and the `"status": "ok"` marker before resolving.

## Test plan

- [x] Existing 63 unit tests still pass (`jest` from `packages/electron/`)
- [x] Two new tests cover the body-validation branch — 200 with healthy body resolves, 200 with `{"status":"degraded"}` keeps polling until timeout
- [x] Patched `waitUntilHealthy` resolves in <10ms against a live healthy WebUI on `127.0.0.1:8787`
- [ ] Smoke test on a fresh container: setup window should close within ~1s of `/health` going green
- [ ] Smoke test on Windows DMG/EXE flow

Closes #57