### PR TITLE
ci: pin released container image by digest, not by :latest

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -10,8 +10,13 @@ on:
       - main
   # Manual rebuild (uses submodules at the checked-out ref — bump forks/ in main first).
   workflow_dispatch:
-  # Called by release.yml
+  # Called by release.yml. The digest output lets the caller pin the released
+  # image to the exact bytes this run pushed (closes the `:latest` race in #41).
   workflow_call:
+    outputs:
+      digest:
+        description: "Content digest of the pushed image (e.g. sha256:abc...)."
+        value: ${{ jobs.build-and-push.outputs.digest }}
 
 jobs:
   build-and-push:
@@ -21,6 +26,9 @@ jobs:
     permissions:
       contents: read
       packages: write   # required to push to GHCR
+
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
 
     steps:
       - name: Checkout (with submodules)
@@ -60,8 +68,17 @@ jobs:
             .
 
       - name: Push Docker image to GHCR
+        id: push
         run: |
-          docker push ghcr.io/fox-in-the-box-ai/cloud:${{ steps.meta.outputs.tag }}
+          set -euo pipefail
+          IMAGE="ghcr.io/fox-in-the-box-ai/cloud:${{ steps.meta.outputs.tag }}"
+          docker push "$IMAGE"
+          # `RepoDigests` is `[name@sha256:...]` once the image has been pushed
+          # to the registry. Strip the `name@` prefix to get the bare digest so
+          # callers can compose `name@<digest>` for any tag they want.
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$IMAGE" | cut -d'@' -f2)
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+          echo "Pushed $IMAGE @ $DIGEST"
 
       - name: Tag and push :stable
         if: github.event_name != 'pull_request'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,15 +57,26 @@ jobs:
         id: tag
         run: echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
 
+      # Pin the released image to the exact bytes that wait-for-container just
+      # pushed. Pulling `:latest` would be racy: a concurrent push to main can
+      # mutate `:latest` between the build and this step, so the released
+      # vX.Y.Z / :stable tags would point at the newer commit's image instead
+      # of the tagged one. Pulling `name@sha256:...` removes that window. (#41)
       - name: Re-tag Docker image as versioned and :stable
+        env:
+          DIGEST: ${{ needs.wait-for-container.outputs.digest }}
         run: |
-          docker pull ghcr.io/fox-in-the-box-ai/cloud:latest
-          docker tag  ghcr.io/fox-in-the-box-ai/cloud:latest \
-                      ghcr.io/fox-in-the-box-ai/cloud:${{ steps.tag.outputs.version }}
-          docker tag  ghcr.io/fox-in-the-box-ai/cloud:latest \
-                      ghcr.io/fox-in-the-box-ai/cloud:stable
-          docker push ghcr.io/fox-in-the-box-ai/cloud:${{ steps.tag.outputs.version }}
-          docker push ghcr.io/fox-in-the-box-ai/cloud:stable
+          set -euo pipefail
+          if [[ -z "$DIGEST" ]]; then
+            echo "::error::wait-for-container did not produce a digest output."
+            exit 1
+          fi
+          IMG="ghcr.io/fox-in-the-box-ai/cloud"
+          docker pull "$IMG@$DIGEST"
+          docker tag  "$IMG@$DIGEST" "$IMG:${{ steps.tag.outputs.version }}"
+          docker tag  "$IMG@$DIGEST" "$IMG:stable"
+          docker push "$IMG:${{ steps.tag.outputs.version }}"
+          docker push "$IMG:stable"
 
       - name: Download Windows artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary

`release.yml` did `docker pull :latest && docker tag :vX.Y.Z`. A concurrent push to `main` between `wait-for-container`'s push and this pull could mutate `:latest`, leaving the released `:vX.Y.Z` / `:stable` tags pointing at a newer commit's image rather than the tagged one. Pulling by content digest closes that window.

- `build-container.yml` captures the pushed digest from `docker inspect ... RepoDigests` and exposes it as a `workflow_call` output.
- `release.yml` reads `needs.wait-for-container.outputs.digest` and pulls / retags `name@sha256:...`. Fails fast if the digest is missing.

## Why this also resolves #43

#43 asks for a `tags: ['v*']` trigger on `build-container.yml`, but build-container.yml **already runs on tag pushes** via `workflow_call` from `release.yml`'s `wait-for-container` job. Adding a literal `tags` trigger would fire two parallel container builds on every release tag — the same duplicate-run pattern that broke v0.1.1's Windows `.exe` upload. The digest pin closes the actual race #43 describes.

## Test plan

- [x] yaml syntax checked (`gh pr` accepts the diff)
- [ ] Verified end-to-end on the v0.2.0 tag push: released `:vX.Y.Z` and `:stable` images point to the same digest as `wait-for-container`'s push step printed
- [ ] Test plan re-runs OK after merge — fresh main push pulls/pushes `:latest` as before; only `release.yml` reads the new digest output

Closes #41. Closes #43 (see explanation above).