### PR TITLE
ci(electron): document why Windows uses npm, not pnpm

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -71,6 +71,15 @@ jobs:
         with:
           node-version: "20"
 
+      # macOS/Linux: workspace-aware install at the repo root.
+      # Windows: install in packages/electron with npm so node_modules is flat.
+      # pnpm's content-addressed store nests deps under
+      #   node_modules/.pnpm/<name>@<ver>_<longhash>/...
+      # which blows past Windows MAX_PATH (260) for makensis.exe's NSIS include
+      # resolver during electron-builder. `--shamefully-hoist` was tried in
+      # 4510cc5 and still produced unreachable include paths, so the fallback
+      # is intentional. Don't switch back to pnpm here without confirming
+      # makensis can resolve every NSIS include from the resulting tree (#42).
       - name: Install dependencies
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

The npm-on-Windows install in \`build-electron.yml\` is intentional — pnpm's content-addressed store puts deps under \`node_modules/.pnpm/<name>@<ver>_<longhash>/...\` which blows past Windows MAX_PATH (260) for makensis.exe's NSIS include resolver. The team already tried \`--shamefully-hoist\` (4510cc5) and still got unreachable include paths.

This PR adds an inline comment so the next person who looks at the divergence doesn't try to "fix" it back to pnpm and break Windows installer builds. No behavior change.

## Why not switch to pnpm

#42's first acceptance bullet asks whether \`pnpm install --frozen-lockfile\` runs successfully on \`windows-latest\`. It does — pnpm/action-setup@v3 works on Windows fine, and the install itself completes. The problem surfaces later, in the \`pnpm build\` step (\`electron-builder\`), when makensis can't open NSIS includes from the deeply-hashed pnpm store paths. So the install command's exit code is misleading; the load-bearing constraint is downstream.

## Test plan

- [x] Documentation-only change — Windows / macOS smoke jobs should still pass with no behavior change
- [ ] If Windows MAX_PATH ever stops being a constraint (e.g. long-paths enabled by default in a future runner image), revisit and consolidate to pnpm

Closes #42 by documenting the reason inline (per the issue's third acceptance bullet).