### PR TITLE
feat: hot-reload provider keys saved via Settings → Providers (#13)

### DIFF
--- a/packages/integration/scripts/run-with-env.sh
+++ b/packages/integration/scripts/run-with-env.sh
@@ -15,4 +15,15 @@ if [ -f /data/config/hermes.env ]; then
   source /data/config/hermes.env || true
   set +a
 fi
+
+# Also pick up keys saved post-onboarding via the WebUI's Settings → Providers
+# panel, which writes to the active hermes home (~/.hermes/.env). The two
+# files are sourced in order so Settings entries override onboarding ones,
+# matching the in-app expectation that the most recent Settings save wins.
+if [ -n "${HOME:-}" ] && [ -f "$HOME/.hermes/.env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "$HOME/.hermes/.env" || true
+  set +a
+fi
 exec "$@"


### PR DESCRIPTION
Closes #13.

After v0.1.6 a user could go to Settings → Providers, save an API key, click Save... and the key wouldn't take effect until they restarted the container. Two reasons:

1. **Path mismatch.** Onboarding wizard writes to `/data/config/hermes.env`. Settings panel writes to `~/.hermes/.env` (= `/app/.hermes/.env` for the foxinthebox user). `run-with-env.sh` was only sourcing the first.
2. **No restart.** `set_provider_key` invalidates the WebUI's models cache but doesn't touch the gateway. Several runtime_provider paths (OpenRouter, OpenAI) read keys via `os.getenv` directly, so the gateway's process env had to be refreshed.

### Changes
- `packages/integration/scripts/run-with-env.sh` now sources `$HOME/.hermes/.env` in addition to `/data/config/hermes.env`.
- `forks/hermes-webui` submodule bumped — `api/providers.py` best-effort calls `supervisorctl restart hermes-gateway` after writing. No-op outside supervisor deployments (gated by `shutil.which`).

### Test plan (verified end-to-end against test image on 8788)
- Wizard saves OpenRouter key → `openrouter has_key=True src=env_var`
- `POST /api/providers anthropic` → `{ok:true,action:"updated"}`
- `/app/.hermes/.env` written
- `hermes-gateway` selectively restarts; `hermes-webui` keeps running
- Post-save: `anthropic has_key=True src=env_file`