### PR TITLE
feat: first-class local Ollama integration (#66 phase 1+2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Installs Docker if needed, pulls the container image, asks how you want to acces
 docker run -d \
   --name fox-in-the-box \
   --restart unless-stopped \
+  --add-host=host.docker.internal:host-gateway \
   --cap-add=NET_ADMIN \
   --device /dev/net/tun \
   --sysctl net.ipv4.ip_forward=1 \

--- a/packages/electron/src/docker-manager.js
+++ b/packages/electron/src/docker-manager.js
@@ -330,6 +330,12 @@ function buildContainerCreateOptions(dataDir, accessMode) {
         },
       ],
     },
+    // Lets the container reach a host-side daemon at host.docker.internal —
+    // required for the local-Ollama integration (issue #66) on Linux. Docker
+    // Desktop on macOS/Windows resolves this name natively. Linux Docker
+    // Engine 20.10+ takes the special host-gateway value as a placeholder
+    // for the host's gateway address.
+    ExtraHosts: ['host.docker.internal:host-gateway'],
   };
   if (accessMode === '2' || accessMode === '3') {
     hostConfig.CapAdd = ['NET_ADMIN'];

--- a/packages/scripts/install.sh
+++ b/packages/scripts/install.sh
@@ -351,6 +351,7 @@ info "Starting container…"
 $DOCKER_CMD run -d \
   --name "$CONTAINER" \
   --restart unless-stopped \
+  --add-host=host.docker.internal:host-gateway \
   $TAILSCALE_FLAGS \
   -v "$DATA_DIR":/data \
   $PORT_BIND \


### PR DESCRIPTION
## Summary

Closes #66 phases 1 and 2. Users who already have Ollama installed on their machine now go from \"open Fox\" to \"chatting with a local model\" without ever touching the terminal — no API key, no custom-endpoint configuration, no model name guessing.

### What ships

- **Auto-detection.** Settings → Providers gets a **Local Ollama** tile that probes \`host.docker.internal:11434\` and \`localhost:11434\` (10s cache). Status dot shows green when a daemon is reachable, gray otherwise.
- **Model picker.** Installed models from \`/api/tags\` render as cards with name, parameter size, quantization, and disk size. One-click \"Use\" button activates a model.
- **Routing via existing custom path.** Picking a model writes \`model.{provider:custom, base_url, name}\` into \`config.yaml\` and triggers the gateway hot-reload pattern from v0.2.0 PR #61. **No hermes-agent changes** — Hermes already handles custom OpenAI-compat endpoints, so the integration is webui-side only.
- **Linux network compatibility.** \`packages/electron/src/docker-manager.js\` (Dockerode HostConfig.ExtraHosts), \`packages/scripts/install.sh\`, and the README's docker run example all add \`--add-host=host.docker.internal:host-gateway\` so the probe reaches the host on Linux Docker Engine 20.10+.

### Backend (forks/hermes-webui submodule, now at 42c2af5)

- **NEW** \`api/ollama.py\` — detection probe with module-level cache, \`/api/tags\` wrapper that flattens to name/size/parameter_size/quantization, \`use_model()\` that mutates config.yaml + hot-reloads gateway
- \`api/routes.py\` — registers \`GET /api/ollama/{status,models}\`, \`POST /api/ollama/{refresh,use-model}\`
- \`static/index.html\` — Settings → Providers tile with status dot, model list, refresh button. Distinct empty / not-detected states with clear next-step guidance
- \`static/panels.js\` — \`loadOllamaLocal()\` / \`refreshOllamaLocal()\` / \`useOllamaModel()\`

### Out of scope (tracked elsewhere)

- **Phase 3** — Pull / delete model UI from inside Fox → #67 (v0.3.1)
- **Phase 4** — Onboarding wizard integration (\"Use a local model for setup?\") → folded into #11 in v0.3.0
- **Bundling Ollama** — issue body explicitly forbids
- **Rootless Docker support** — known broken upstream (moby#47684); skip rather than fix

### Caveat for existing users

Containers created before v0.3.0 don't have \`--add-host=host.docker.internal:host-gateway\` set. They'll see \"Not detected\" on Linux until they're re-created. Surfaced in the empty-state copy and will be in the v0.3.0 CHANGELOG.

## Test plan (verified e2e on test image, port 8788)

- [x] **Negative path** (no host Ollama): \`/api/ollama/status\` returns \`running: false\`; tile shows \"Not detected\" with install link
- [x] **Positive path** (mock Ollama on host:11434 with two models): probe via \`host.docker.internal\` succeeds; \`/api/ollama/models\` lists both with parsed details
- [x] \`use-model\` mutates \`config.yaml model.*\`; \`hermes-gateway\` uptime drops to single digits (selective hot-reload, webui keeps running)
- [x] \`/api/ollama/refresh\` invalidates the cache and re-probes
- [ ] Manual UI smoke against a real Ollama on the next release

## Phase 1 plan with research sources

[Posted on #66](https://github.com/fox-in-the-box-ai/fox-in-the-box/issues/66#issuecomment-4375687534) — Ollama API endpoints, response shapes, NDJSON pull stream format, OpenAI-compat caveats, host.docker.internal cross-platform behavior.