### PR TITLE
feat: first-run conversation flow — skip + Ollama fast-path (#11)

### DIFF
--- a/packages/integration/default-configs/onboarding.md
+++ b/packages/integration/default-configs/onboarding.md
@@ -1,0 +1,3 @@
+Let's get you set up. This will only take a minute.
+
+Bring an OpenRouter API key for cloud models, or skip this wizard if you're running a local AI on your computer (Ollama, LM Studio, etc.) — you can configure providers any time from Settings.


### PR DESCRIPTION
## Summary

Closes #11. Option B from the [Phase 1 plan](https://github.com/fox-in-the-box-ai/fox-in-the-box/issues/11#issuecomment-4375689366) — augments the existing 3-step button wizard without replacing it.

### Three additions

1. **Skip CTA** on every step. \`POST /api/setup/skip\` marks onboarding complete without collecting an API key. Provides an exit hatch for users who'll configure providers later from Settings, or who'll rely on local Ollama (#66).
2. **Externalized welcome text.** Read from \`/data/config/onboarding.md\` via \`GET /api/setup/welcome\`; default copy ships in \`packages/integration/default-configs/onboarding.md\` and is copied on first container run by entrypoint.sh's defaults sweep. Editable per install — closes the AC bullet \"Script is externalized (editable without code change)\".
3. **State alignment.** \`/api/setup/{complete,skip}\` now write both \`onboarding.json:completed\` (the redirect middleware's flag) AND \`settings.json:onboarding_completed\` (the WebUI settings surface). \`onboarding_complete()\` reads either, so future code paths flipping settings.json directly are honoured. Closes a long-standing dual-state-file bug.

### Local Ollama fast-path (depends on #66)

When the Welcome step loads, the wizard probes \`/api/ollama/status\` (the endpoint #66 just shipped). If a host-side Ollama daemon is reachable with at least one model installed, the Welcome step surfaces a green-bordered \"Local model detected\" panel with a \"Use \<model name\>\" CTA. Click → calls \`/api/ollama/use-model\` → marks onboarding complete → drops the user straight into chat with their local model. **No API key step.** Falls back gracefully to the existing OpenRouter wizard when Ollama isn't detected.

### Why Option B

The issue's original AC said *\"Local model used regardless of provider status\"*. That depends on #9 (llama.cpp + Phi-4-mini auto-fallback), which is deferred to v0.4.0. Option B couples the conversational/local path to #66's Ollama detection cleanly — Ollama present → fast-path; absent → existing wizard. Closure of the original AC tracked as **#69** (blocked on #9).

### What's still deferred

- Conversational LLM-driven welcome (full chat UI inside the wizard) — out of scope; the headline UX win for v0.3.0 is the local fast-path
- SOUL.md per-profile personality picker, multi-language onboarding, resume-from-skip — explicitly out of scope per Phase 1 plan

## Files changed

### \`forks/hermes-webui\` (submodule, dacff00)
- \`api/onboarding.py\` — \`handle_setup_skip\`, \`handle_setup_welcome\`, \`read_welcome_text\`, state alignment in \`_mark_onboarding_complete\`, \`onboarding_complete()\` reads either flag
- \`api/routes.py\` — registers \`GET /api/setup/welcome\`, \`POST /api/setup/skip\`
- \`static/setup.js\` — fetches welcome + Ollama state on boot, renders Skip CTA on every step, renders Ollama fast-path on Welcome when applicable
- \`static/setup.css\` — \`.btn-secondary\`, \`.btn-link\`, \`.skip-row\`, \`.ollama-detected\` styles

### This repo
- \`packages/integration/default-configs/onboarding.md\` — bundled welcome text (copied to \`/data/config\` on first run)
- \`forks/hermes-webui\` submodule pointer bump

## Test plan (verified e2e on test image, port 8788)

- [x] \`/api/setup/welcome\` returns the externalized text from \`/data/config/onboarding.md\`
- [x] Editing \`/data/config/onboarding.md\` propagates to the next request
- [x] Pre-skip GET \`/\` → 302 (redirect to /setup)
- [x] \`POST /api/setup/skip\` returns \`{ok: true, skipped: true}\`
- [x] After skip, both \`onboarding.json:completed=true,skipped=true\` and \`settings.json:onboarding_completed=true\` are set (state alignment)
- [x] Post-skip GET \`/\` → 200 (chat unlocked)
- [x] \`/setup\` page renders the new \`setup.js\` with Skip CTA and Ollama branch markers present
- [ ] Manual UI smoke with a real Ollama daemon on the next release (positive Ollama path was verified end-to-end against a mock daemon during #66 / PR #71 testing)