### PR TITLE
docs(readme): reflect v0.4.0 — local-AI fallback to Coming soon

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,13 +245,14 @@ The app itself is free and open source. You only pay for AI usage at your provid
 What we're working on next. No promises on dates — this is a small team — but this is the direction.
 
 **Coming soon**
+- **Local AI fallback** — chat with a small on-device model when your provider is unavailable or rate-limited. Download infrastructure shipped in v0.4.0; the runtime + Settings toggle land in v0.4.1, conversational onboarding wires through in v0.4.2
 - Conversational onboarding when no local model is detected (currently the chat-driven welcome only kicks in if Ollama is already installed)
 - Hostname prompt during first-run when Tailscale is enabled (today the field lives in Settings only)
 
 **On the horizon**
-- Bundled local AI fallback — auto-download a small model so Fox keeps working when your provider is down or rate-limited (no Ollama required)
-- Safety guardrails — PII detection, content filtering, and input/output validation
+- Safety guardrails — PII detection, content filtering, and input/output validation (opt-in per workspace)
 - Scriptable workflows — teach Fox multi-step routines specific to your business
+- UI overhaul — clean, professional design system replacing the developer-tool look
 
 **Have an idea?** [Open a discussion](https://github.com/fox-in-the-box-ai/fox-in-the-box/discussions) or [file a feature request](https://github.com/fox-in-the-box-ai/fox-in-the-box/issues/new).
 


### PR DESCRIPTION
## Summary

Three small Roadmap edits after v0.4.0. README only.

### Coming soon

**New lead item — Local AI fallback.** Phrasing matches v0.4.0's reality: download infrastructure is in (Settings → System → Local AI models) but the runtime + Settings toggle land in v0.4.1, conversational onboarding in v0.4.2.

### On the horizon

- **Removed** \"Bundled local AI fallback — auto-download a small model …\" — no longer accurate (decision switched to lazy-load) AND the feature itself moved up to "Coming soon" since it's actively in flight across v0.4.0–v0.4.2.
- **Tightened** the guardrails line to mention the opt-in-per-workspace default we locked.
- **Surfaced** #64 (UI overhaul) — was on the internal v0.7.0 plan but missing from the public roadmap.

### Why no other edits

\"Supported providers\" and \"After setup\" don't need updates — Phi-4-mini isn't usable for chat until v0.4.1, so promising a local-AI experience now would mislead users. Will update those sections in v0.4.1's PR when the runtime ships.

## Test plan

- [x] No other content modified (\`git diff --stat\` shows +3 / -2, README only)