### PR TITLE
feat: bundle llama.cpp + local-fallback orchestration (#9)

### DIFF
--- a/packages/integration/Dockerfile
+++ b/packages/integration/Dockerfile
@@ -6,6 +6,10 @@ ARG TARGETARCH=amd64
 # Pin QDRANT_VERSION to match qdrant-client in hermes-agent (see task 03 docs).
 # Do NOT use "latest" in production builds.
 ARG QDRANT_VERSION=v1.9.4
+# Pin LLAMACPP_VERSION — daily build tags on ggml-org/llama.cpp ship pre-built
+# CPU binaries for both ubuntu-x64 and ubuntu-arm64. Avoid "latest"; pick a
+# tested tag and bump deliberately. (#9)
+ARG LLAMACPP_VERSION=b9026
 # FITB_VERSION: written to /app/version.txt for migrations and display.
 # hermes-agent / hermes-webui are copied from forks/ at build time (requires submodules).
 ARG FITB_VERSION=v0.1.0
@@ -13,6 +17,8 @@ ARG FITB_VERSION=v0.1.0
 ARG FITB_DEV=0
 
 # ── system dependencies ───────────────────────────────────────────────────────
+# libgomp1 + libcurl4 are runtime deps for the bundled llama.cpp llama-server
+# binary (issue #9). Both are small (libgomp1 ~150 KB, libcurl4 ~400 KB).
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         ca-certificates \
@@ -21,6 +27,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         lsb-release \
         iproute2 \
         iptables \
+        libgomp1 \
+        libcurl4 \
     && rm -rf /var/lib/apt/lists/*
 
 # ── Node.js (LTS) — required for npx-based MCP servers (e.g. Brave Search) ───
@@ -56,6 +64,28 @@ RUN set -eux; \
         "https://github.com/qdrant/qdrant/releases/download/${QDRANT_VERSION}/qdrant-${ARCH}-unknown-linux-musl.tar.gz" \
         | tar -xzf - -C /app/qdrant; \
     chmod +x /app/qdrant/qdrant
+
+# ── llama.cpp llama-server binary ─────────────────────────────────────────────
+# Bundled per-arch CPU build. Used by issue #9's local-fallback runtime —
+# llama-server speaks /v1/chat/completions, /v1/models, /v1/embeddings
+# (drop-in OpenAI-compat). Tarball ships its own .so files; llama-server's
+# RUNPATH=$ORIGIN makes them resolve from /app/llama-cpp without any
+# LD_LIBRARY_PATH gymnastics.
+#
+# The supervisord [program:llama-server] block is autostart=false and only
+# spawns when api/local_fallback.py decides the user has opted in AND the
+# model file (#10's download manager) is present. No idle RAM cost when
+# the user hasn't enabled local fallback.
+RUN set -eux; \
+    mkdir -p /app/llama-cpp; \
+    case "${TARGETARCH}" in \
+        arm64) ARCH_SUFFIX="arm64" ;; \
+        *)     ARCH_SUFFIX="x64"  ;; \
+    esac; \
+    curl -fsSL \
+        "https://github.com/ggml-org/llama.cpp/releases/download/${LLAMACPP_VERSION}/llama-${LLAMACPP_VERSION}-bin-ubuntu-${ARCH_SUFFIX}.tar.gz" \
+        | tar -xzf - -C /app/llama-cpp --strip-components=1; \
+    chmod +x /app/llama-cpp/llama-server
 
 # ── non-root user ─────────────────────────────────────────────────────────────
 RUN useradd -r -s /bin/bash -d /app foxinthebox \

--- a/packages/integration/supervisord.conf
+++ b/packages/integration/supervisord.conf
@@ -64,3 +64,30 @@ stdout_logfile=/data/logs/hermes-webui.log
 stderr_logfile=/data/logs/hermes-webui.err
 environment=HOME="/app",PYTHONPATH="/data/apps/hermes-webui",HERMES_WEBUI_HOST="0.0.0.0",HERMES_WEBUI_AGENT_DIR="/data/apps/hermes-agent",ONBOARDING_PATH="/data/config/onboarding.json",PATH="/usr/local/bin:/usr/bin:/bin"
 priority=40
+
+; ── llama-server (local AI fallback) ─────────────────────────────────────────
+; Bundled llama.cpp llama-server, OpenAI-compat HTTP at 127.0.0.1:8643. Issue
+; #9 — provides the local model when the user enables "Local fallback" in
+; Settings → Providers AND a GGUF model has been downloaded via the
+; /api/local-models manager (#10).
+;
+; autostart=false: no idle RAM cost for users who don't opt into local
+; fallback. api/local_fallback.py issues `supervisorctl start llama-server`
+; once a model file is present and the toggle is on. With
+; --sleep-idle-seconds 60 the process stays supervised but the model
+; weights unload after 60s of no requests — ~50 MB at idle, ~3.5 GB while
+; serving. (See #9 Phase 1 research: docs/decisions captured on issue.)
+;
+; -m points at /data/models/microsoft_Phi-4-mini-instruct-Q4_K_M.gguf
+; (matches the canonical filename the download manager writes). When that
+; file is missing, the program will fail-fast on start; api/local_fallback
+; declines to start it in that case so we don't spam restart loops.
+[program:llama-server]
+command=/app/llama-cpp/llama-server -m /data/models/microsoft_Phi-4-mini-instruct-Q4_K_M.gguf --host 127.0.0.1 --port 8643 -c 4096 -t 4 --sleep-idle-seconds 60
+user=foxinthebox
+autostart=false
+autorestart=true
+startretries=2
+stdout_logfile=/data/logs/llama-server.log
+stderr_logfile=/data/logs/llama-server.err
+priority=50


### PR DESCRIPTION
## Summary

Closes **#9**. Second of three v0.4.x releases. Together with v0.4.0's download manager (#10), this delivers the user-visible local-AI fallback experience.

**The flow**: user opens Settings → Providers, flips the **"Local fallback"** toggle ON. Phi-4-mini Q4_K_M starts downloading (~2.5 GB, sha256-pinned, lives on \`/data\`). Once on disk, supervisord starts the bundled \`llama-server\` (binary at \`/app/llama-cpp/\`, listening on \`127.0.0.1:8643\`, OpenAI-compat). When a remote provider call hits a transient failure (5xx, 429, connection drop), the existing agent-level retry path silently re-routes through the local model. No chat interruption, no modal.

### Container changes

- **\`Dockerfile\`**: install \`libgomp1\` + \`libcurl4\` (runtime deps for \`llama-server\`). Pin \`LLAMACPP_VERSION=b9026\`. Download the per-arch CPU tarball (\`ubuntu-x64\`/\`ubuntu-arm64\`) via the existing \`TARGETARCH\` switch (same pattern as Qdrant). \`RUNPATH=\$ORIGIN\` means bundled \`.so\` files resolve without \`LD_LIBRARY_PATH\` gymnastics — verified during Phase 1 research.

- **\`supervisord.conf\`**: new \`[program:llama-server]\` with \`autostart=false\` (zero idle RAM until user opts in) and \`--sleep-idle-seconds 60\` (process stays supervised, weights unload after 60s idle — ~50 MB at idle, ~3.5 GB while serving). Bound to \`127.0.0.1:8643\`.

### Backend (\`forks/hermes-webui\`)

- **\`api/local_fallback.py\`** (new) — orchestration:
  - \`is_enabled() / set_enabled()\` against \`settings.json:local_fallback_enabled\`
  - \`supervisor_status()\` / \`start_llama_server()\` / \`stop_llama_server()\` — soft-fail when supervisorctl absent (upstream Hermes / dev)
  - \`get_fallback_endpoint()\` — gated on **both** opted-in AND \`supervisor_status() == RUNNING\`. Two-condition gate prevents silent failover to a non-functional model.
  - \`should_failover()\` classifier — 5xx/429/connection-error eligible; **NEVER** for auth/quota/billing/model-not-found. NEVER list takes precedence even when an HTTP 5xx body says \"rate limit\".
  - \`enable()\` / \`disable()\` — \`enable\` triggers \`models_download.start_download(MODEL_ID)\` and either starts \`llama-server\` immediately (if model already on disk) or spawns a background watcher that starts it once the file lands. Handles 2.5 GB long downloads without blocking the toggle-on POST.

- **\`api/streaming.py\`** — surgical 12-line addition just after the existing \`fallback_model\` resolution at line 1768. If \`local_fallback\` is enabled and live, override the resolved fallback config. The agent's existing rate-limit-recovery / 5xx-retry path uses \`fallback_model\`, so failover comes for free without touching the exception classifier or retry orchestration.

- **\`api/config.py\`** — adds \`local_fallback_enabled\` to \`_SETTINGS_DEFAULTS\` and \`_SETTINGS_BOOL_KEYS\`. Without these the toggle would silently drop on save (caught during Phase 4 testing).

- **Routes**: \`GET /api/local-fallback/status\`, \`POST /api/local-fallback/{enable,disable}\`.

### UI

New tile in Settings → Providers, below Local Ollama. Status dot + native checkbox toggle + ui_state-driven copy:
- disabled → \"Off — toggle on to download (~2.5 GB) and enable failover\"
- needs-download → \"Will start downloading (~2.5 GB)…\"
- downloading → \"Downloading 1.2 GB / 2.5 GB (48%)\" (live, polls every 2.5s while Settings is open)
- ready → \"Ready — your provider failures will silently retry on the local model.\"
- no-supervisor → \"Supervisor not available — Local fallback only works inside the Fox container.\"

## Phase 1 plan / approval

- Bundle vs lazy-load: lazy-load chosen — image stays ~700 MB
- Default: opt-in, OFF
- Failover style: silent + retry (uses agent's existing fallback_model machinery)
- Recovery: stay on local until user manually switches (banner is v0.4.2 polish)

## Test plan

Verified e2e against a freshly built container with a deliberately broken \`MODEL_URL_PHI4MINI\` (so we exercise the toggle + classifier without pulling 2.5 GB):

- [x] Toggle OFF→ON: \`enabled\` flips, model download starts, ui_state transitions disabled→downloading→needs-download (download fails with bogus URL — expected)
- [x] Toggle ON→OFF: \`enabled\` flips back, settings.json persisted, llama-server confirmed STOPPED
- [x] settings.json contains \`local_fallback_enabled: false\` after off-toggle (persistence)
- [x] supervisorctl status reports llama-server correctly
- [x] streaming.py hook compiles and parses; integration validated by code review (full e2e requires real GGUF + provider failure to test silent retry — exercised on next release smoke against real Phi-4-mini)
- [ ] Multi-arch CI on PR will build llama.cpp tarball download for both x64 and arm64

## What's NOT in this PR (deferred)

- **Reactive modal for non-opted-in users.** Today, a user who hasn't enabled Local fallback sees the existing remote-provider error on a failure. A future v0.4.2 PR would add a one-time \"Try local model? (downloads ~2.5 GB once)\" prompt with a \"Always do this\" checkbox.
- **Recovery banner.** When the remote provider comes back, the user stays on local until they manually switch. v0.4.2 polish would add a passive \"Remote is back — switch?\" banner.
- **#69's conversational onboarding** that uses the local model when no Ollama is detected — also v0.4.2.

These are explicitly Phase 1-deferred polish items; v0.4.1 ships the headline feature (silent failover for opted-in users) and gates further UX work behind real-world testing.