### PR TITLE
feat(v0.4.4): hostname post-wizard prompt (#68) + Tailscale Phase 1 (#96)

### DIFF
--- a/packages/electron/src/docker-manager.js
+++ b/packages/electron/src/docker-manager.js
@@ -289,11 +289,14 @@ function getEffectiveAccessMode() {
 }
 
 /**
- * Windows first-run: choose how host publishes port 8787 / Tailscale caps.
- * No-op on other platforms or when prefs already exist.
+ * First-run: choose how host publishes port 8787 / Tailscale caps.
+ * Originally Windows-only (#issue-XX); macOS parity added for #96 so
+ * DMG users can opt into Tailscale before container creation. No-op on
+ * Linux (host-script users go through install.sh's chooser) and when
+ * prefs already exist.
  */
 async function ensureDockerAccessModeChosen() {
-  if (process.platform !== 'win32') return;
+  if (process.platform !== 'win32' && process.platform !== 'darwin') return;
   if (getSavedAccessMode() !== null) return;
   const { dialog } = require('electron');
   const { response } = await dialog.showMessageBox({


### PR DESCRIPTION
## Summary

v0.4.4 bundle: closes #68 and #96 Phase 1.

### #68 — Hostname post-wizard prompt
After onboarding completes, if Tailscale is running and `FOX_HOSTNAME` isn't set, surface a one-time modal pre-filled with `fox-<adjective>`. Save uses #44's endpoint; Skip uses a new dismiss endpoint. Both persist `settings.json:hostname_prompted=true`. Submodule PR: [hermes-webui#1](https://github.com/fox-in-the-box-ai/hermes-webui/pull/1) (already merged to master).

### #96 Phase 1 — Tailscale silent + interactive auth
Lets desktop users auth Tailscale from inside the app — no docker-exec. Closes Persona 1 (silent / already-auth'd) and Persona 2 (interactive auth) from the issue:

- **Backend** — new `api/tailscale.py`: 6 endpoints (status / up / up/poll / logout / serve get/post). Daemon thread spawns `tailscale up`, scrapes auth URL from stdout (Tailscale-cloud + headscale-style), state machine is idempotent.
- **Frontend** — Settings → Network tile above the existing hostname tile (#44). Connect / Disconnect buttons, status badge, tailnet URL display, advanced accordion exposes auth-key field.
- **Electron** — `packages/electron/src/docker-manager.js`: macOS access-mode chooser parity (was Windows-only).

argv builder already handles all 7 power-user flags (`--login-server`, `--advertise-routes`, `--advertise-tags`, `--accept-routes`, `--accept-dns`, `--exit-node`, `--hostname`) — Phase 2 will surface them in the UI.

Submodule PR: [hermes-webui#2](https://github.com/fox-in-the-box-ai/hermes-webui/pull/2) (already merged to master).

## Deferred to follow-up phases

- Wizard step injection during onboarding (#96 Phase 2)
- Power-user fields in Settings UI (#96 Phase 2)
- Reactive banner in chat UI (#96 Phase 3)
- #9 polish (reactive modal + recovery banner) — was originally v0.4.4, swapped for #96 Phase 1 after the user asked "did we fully ship Tailscale?" and the answer was "no, install.sh users only"

## Test plan

### #68
- [ ] Tailscale active, no `FOX_HOSTNAME` → modal appears once on first chat-UI load
- [ ] Save → tailnet hostname applied; modal never reappears
- [ ] Skip → no rename; modal never reappears
- [ ] Tailscale not running → no modal

### #96 Phase 1
- [ ] Persona 1 silent: pre-existing `tailscaled.state`, `BackendState=Running` on launch → Settings shows Connected + tailnet URL, no prompts
- [ ] Persona 2 interactive: fresh container, click Connect → auth URL opens in new tab, badge flips to Running within a minute
- [ ] Auth-key path: paste reusable key, Connect → Running within 30s without browser
- [ ] Disconnect: confirms, calls /logout, badge flips to Disconnected
- [ ] CLI not available (port-only mode): tile renders Unknown badge, Connect button hidden
- [ ] Idempotent /up: rapid Connect clicks don't double-spawn

### Electron macOS chooser
- [ ] First run on macOS DMG → chooser dialog appears (Port only / Tailscale only / Both / Cancel)
- [ ] After choice, prefs persist; subsequent launches don't re-prompt
- [ ] All 5 jest electron suites still pass (verified locally: 63/63)

Closes #68. Closes #96 Phase 1.