### PR TITLE
fix(install): bound post-login wait to prevent indefinite hang on Linux (#98)

### DIFF
--- a/packages/scripts/install.sh
+++ b/packages/scripts/install.sh
@@ -539,9 +539,45 @@ if [[ "$USE_TAILSCALE" == "true" ]]; then
         info "(Install 'qrencode' to display a QR code here.)"
       fi
 
+      # Bounded wait for `tailscale up` to finish OR for BackendState to
+      # become Running, whichever happens first. The unbounded `wait` we
+      # used before could hang indefinitely on Linux when the tunnel
+      # authenticated but failed to come up (firewall blocking outbound
+      # UDP, MTU mismatch, NAT-type incompatibility, SELinux/AppArmor
+      # restricting TUN access despite --device /dev/net/tun). `tailscale
+      # up --timeout=600` is *supposed* to give up after 10 minutes but
+      # in practice on Linux it sometimes doesn't honor that flag when
+      # the daemon stays in a half-authenticated state. Issue #98.
       if [[ -n "${FITB_TS_UP_PID:-}" ]] && kill -0 "$FITB_TS_UP_PID" 2>/dev/null; then
-        info "Waiting for Tailscale to finish (complete browser login — this step exits when the tunnel is up)…"
-        wait "$FITB_TS_UP_PID" 2>/dev/null || true
+        info "Waiting for Tailscale to finish (complete browser login — this step exits when the tunnel is up or after 15 min)…"
+        _ts_wait_deadline=$(( $(date +%s) + 900 ))
+        while [[ $(date +%s) -lt $_ts_wait_deadline ]]; do
+          if ! kill -0 "$FITB_TS_UP_PID" 2>/dev/null; then
+            break  # tailscale up exited (either succeeded or hit its own --timeout)
+          fi
+          if [[ "$(_tailscale_backend_state)" == "Running" ]]; then
+            info "Tailscale tunnel is Running — proceeding."
+            kill "$FITB_TS_UP_PID" 2>/dev/null || true
+            break
+          fi
+          sleep 3
+        done
+        # If still alive after the deadline, the tunnel never came up.
+        # Kill the bg process so the script can proceed to error reporting
+        # rather than hang. This is the #98 hang fix.
+        if kill -0 "$FITB_TS_UP_PID" 2>/dev/null; then
+          warn "tailscale up still running after 15 minutes — tunnel didn't reach Running state."
+          warn "Common causes on Linux: outbound UDP blocked by firewall, MTU mismatch, NAT type"
+          warn "incompatibility, or SELinux/AppArmor restricting TUN access. Killing background"
+          warn "process and continuing — your container is up; you can retry Tailscale later."
+          warn "Inspect: $DOCKER_CMD exec $CONTAINER tail -80 /data/logs/tailscaled.err"
+          warn "Retry:   $DOCKER_CMD exec $CONTAINER tailscale up --hostname=\"$FOX_HOSTNAME\""
+          kill "$FITB_TS_UP_PID" 2>/dev/null || true
+          # Give SIGTERM a moment, then force-kill if still alive.
+          sleep 2
+          kill -9 "$FITB_TS_UP_PID" 2>/dev/null || true
+          wait "$FITB_TS_UP_PID" 2>/dev/null || true
+        fi
       fi
       FITB_TS_UP_PID=""
 


### PR DESCRIPTION
## Summary

Fixes #98. On Linux, `install.sh` was hanging indefinitely after displaying the Tailscale login URL — even when the user successfully authenticated in the browser. Root cause: an unbounded `wait "$FITB_TS_UP_PID"` (line 544 in the v0.4.4 codebase) blocked on a `tailscale up` subprocess that itself was hanging because the WireGuard tunnel never reached Running.

`tailscale up --timeout=600` is supposed to give up after 10 minutes, but on Linux it sometimes doesn't honor the flag when the daemon stays in a half-authenticated state (firewall blocking outbound UDP, MTU mismatch, NAT-type incompatibility, SELinux/AppArmor restricting TUN access despite the `--device /dev/net/tun` grant). Linux Docker Engine inherits the host's network stack with all its weirdness; macOS Docker Desktop runs everything inside its own VM with predictable networking, so this surfaces on Linux specifically.

## Fix

Replace the unbounded `wait` with a bounded poll (`packages/scripts/install.sh:541-587`):

```bash
_ts_wait_deadline=$(( $(date +%s) + 900 ))
while [[ $(date +%s) -lt $_ts_wait_deadline ]]; do
  if ! kill -0 "$FITB_TS_UP_PID" 2>/dev/null; then break; fi
  if [[ "$(_tailscale_backend_state)" == "Running" ]]; then
    info "Tailscale tunnel is Running — proceeding."
    kill "$FITB_TS_UP_PID" 2>/dev/null || true
    break
  fi
  sleep 3
done
```

Followed by SIGTERM → 2s grace → SIGKILL escalation if the bg process is still alive at the deadline, plus actionable diagnostic hints pointing at `tailscaled.err`, common Linux causes (UDP/MTU/NAT/MAC), and the manual `docker exec ... tailscale up` retry.

## Why bounded poll vs. fixing `tailscale up`

- We don't control `tailscale up`'s timeout-honoring behavior on Linux
- The bounded poll is a pure shell-script fix — no bundled-binary changes
- It actually surfaces a *better* signal than `tailscale up`'s exit code: BackendState == Running is the truth source for "tunnel works"
- On success, it actually exits *faster* than the original: as soon as Running is observed (typically within 5-30s of the user clicking through), we kill the bg process rather than waiting for `tailscale up` to figure out it can stop blocking

## What changed

- `packages/scripts/install.sh` — replaced the unbounded `wait` at line 544 with a 900s bounded poll + SIGTERM/SIGKILL escalation + diagnostic hints
- Auth-key path is **untouched** — it's already bounded reliably by `tailscale up --timeout=600` because there's no browser-side wait involved
- `bash -n` syntax check passes

## Test plan

This needs real Linux + Docker to verify end-to-end. Manual test:

- [ ] **Happy path on Linux** (Ubuntu 22.04 in a VM): `install.sh` → choose Tailscale → click through browser auth → script proceeds within seconds of Running, no hang
- [ ] **Tunnel never comes up** (block outbound UDP via `iptables -A OUTPUT -p udp -j DROP` after auth-only completes): script hangs at most 15 min, then surfaces the diagnostic warnings and proceeds to `_tailscale_poll_until_running` which reports failure cleanly
- [ ] **User abandons** (closes browser tab, doesn't auth at all): `tailscale up --timeout=600` exits → loop sees `kill -0` returns false → break, proceeds to retry path
- [ ] **Auth-key path** (`FOX_TAILSCALE_AUTHKEY=tskey-...`): unchanged behavior, still bounded by `tailscale up`'s own timeout
- [ ] **macOS regression check**: existing flow on macOS Docker Desktop still works (the bug is Linux-specific but macOS exercises the same code path)

## Reference

See investigation note on #98 for the full debugging trace. Filed alongside #96 (end-to-end Tailscale flow for desktop users) — both touch Tailscale setup but are independent fixes.

Will land as v0.4.5 immediately after v0.4.4 (currently building — release pipeline run [25373622502](https://github.com/fox-in-the-box-ai/fox-in-the-box/actions/runs/25373622502)).

Closes #98.