### PR TITLE
fix(qa): v0.4.7 — bugfix pass; Tailscale desktop flow now actually works

### DIFF
--- a/packages/integration/entrypoint.sh
+++ b/packages/integration/entrypoint.sh
@@ -180,6 +180,16 @@ fi
 # Wizard / install.sh complete Tailscale *after* first boot, so we must not require
 # tailscaled.state at entrypoint start. Parent process execs supervisord below;
 # this subshell survives, waits for /health, then polls until BackendState=Running.
+#
+# QA fix v0.4.7: ALSO grant the foxinthebox user permission to talk to
+# tailscaled via `tailscale set --operator=foxinthebox`. Without this,
+# the webui module (which runs as foxinthebox per supervisord.conf) gets
+# "Access denied: checkprefs access denied" when calling `tailscale up`
+# from /api/tailscale/up. tailscaled runs as root for NET_ADMIN; the
+# operator-set is the supported way to delegate user-mode CLI access
+# without giving up root daemon privileges. Issue surfaced during the
+# v0.4.7 QA pass — the desktop Tailscale flow shipped in v0.4.4 was
+# never actually working because of this.
 (
     sleep 10
     _health_dead=240
@@ -195,6 +205,21 @@ fi
     if [ "$_hi" -ge "$_health_dead" ]; then
         echo "[entrypoint] Tailscale Serve helper: WebUI /health not ready within ${_health_dead}s."
         exit 0
+    fi
+    # Wait briefly for tailscaled to be ready, then grant the webui user
+    # operator access. Idempotent — tailscale stores this in its state
+    # file so re-running is harmless. Best-effort: log + continue on error.
+    _opi=0
+    while [ "$_opi" -lt 60 ]; do
+        if tailscale set --operator=foxinthebox 2>/dev/null; then
+            echo "[entrypoint] Granted foxinthebox tailscale operator access."
+            break
+        fi
+        _opi=$((_opi + 2))
+        sleep 2
+    done
+    if [ "$_opi" -ge 60 ]; then
+        echo "[entrypoint] WARNING: tailscale set --operator failed within 60s; webui /api/tailscale/up will fail until run by hand."
     fi
     # Up to ~15 min for user to finish Tailscale auth (wizard or manual).
     _ts_iters=450

--- a/packages/scripts/install.sh
+++ b/packages/scripts/install.sh
@@ -551,21 +551,35 @@ if [[ "$USE_TAILSCALE" == "true" ]]; then
       if [[ -n "${FITB_TS_UP_PID:-}" ]] && kill -0 "$FITB_TS_UP_PID" 2>/dev/null; then
         info "Waiting for Tailscale to finish (complete browser login — this step exits when the tunnel is up or after 15 min)…"
         _ts_wait_deadline=$(( $(date +%s) + 900 ))
+        # QA fix: track WHY the loop exited so the deadline-expired branch
+        # below can distinguish "Running was reached, SIGTERM'd cleanly"
+        # from "deadline hit, process never died". The previous code
+        # re-probed `kill -0` to make that decision and could double-fire
+        # the kill in racy timings.
+        _ts_exit_reason=""
         while [[ $(date +%s) -lt $_ts_wait_deadline ]]; do
           if ! kill -0 "$FITB_TS_UP_PID" 2>/dev/null; then
+            _ts_exit_reason="proc-exited"
             break  # tailscale up exited (either succeeded or hit its own --timeout)
           fi
-          if [[ "$(_tailscale_backend_state)" == "Running" ]]; then
+          # QA fix: wrap _tailscale_backend_state in set +e/-e — the
+          # helper docker-execs into the container and any transient
+          # failure under set -e propagates and aborts the install.
+          set +e
+          _ts_state="$(_tailscale_backend_state 2>/dev/null)"
+          set -e
+          if [[ "$_ts_state" == "Running" ]]; then
             info "Tailscale tunnel is Running — proceeding."
             kill "$FITB_TS_UP_PID" 2>/dev/null || true
+            _ts_exit_reason="running"
             break
           fi
           sleep 3
         done
-        # If still alive after the deadline, the tunnel never came up.
-        # Kill the bg process so the script can proceed to error reporting
-        # rather than hang. This is the #98 hang fix.
-        if kill -0 "$FITB_TS_UP_PID" 2>/dev/null; then
+        # If we left the loop because deadline hit (not because the proc
+        # exited or Running was reached), surface diagnostics and
+        # escalate to SIGKILL so the script doesn't hang on `wait`.
+        if [[ -z "$_ts_exit_reason" ]]; then
           warn "tailscale up still running after 15 minutes — tunnel didn't reach Running state."
           warn "Common causes on Linux: outbound UDP blocked by firewall, MTU mismatch, NAT type"
           warn "incompatibility, or SELinux/AppArmor restricting TUN access. Killing background"
@@ -573,11 +587,15 @@ if [[ "$USE_TAILSCALE" == "true" ]]; then
           warn "Inspect: $DOCKER_CMD exec $CONTAINER tail -80 /data/logs/tailscaled.err"
           warn "Retry:   $DOCKER_CMD exec $CONTAINER tailscale up --hostname=\"$FOX_HOSTNAME\""
           kill "$FITB_TS_UP_PID" 2>/dev/null || true
-          # Give SIGTERM a moment, then force-kill if still alive.
+          # Give SIGTERM a moment to land, then escalate.
           sleep 2
-          kill -9 "$FITB_TS_UP_PID" 2>/dev/null || true
-          wait "$FITB_TS_UP_PID" 2>/dev/null || true
+          if kill -0 "$FITB_TS_UP_PID" 2>/dev/null; then
+            kill -9 "$FITB_TS_UP_PID" 2>/dev/null || true
+          fi
         fi
+        # Reap the process regardless of exit reason; suppress shell's
+        # "not a child" noise if the proc was reaped externally already.
+        wait "$FITB_TS_UP_PID" 2>/dev/null || true
       fi
       FITB_TS_UP_PID=""
 


### PR DESCRIPTION
## Summary

Comprehensive QA + bugfix pass on v0.4.4–v0.4.6 features. **Two parallel review agents** found 18 bugs in the freshly-shipped code; **one adversarial reviewer** caught 12 more in my fixes; **running an actual test container** surfaced two showstoppers that mean the v0.4.4-shipped desktop Tailscale flow never actually worked.

**Net: ~32 bugs fixed across 7 commits in the submodule + 2 main-repo commits.**

## Why this matters: the v0.4.4 Tailscale flow was broken

Until this PR, clicking Connect on Settings → Network showed "Starting…" forever. **Two root causes**, both surfaced by ending the all-static-no-runtime-test pattern:

1. **webui process couldn't talk to tailscaled.** webui runs as `foxinthebox` (per supervisord); tailscaled runs as root for NET_ADMIN. Without `tailscale set --operator=foxinthebox`, every CLI call from webui errored `Access denied: login access denied`.
2. **Auth URL never reached the UI.** `tailscale up` block-buffers stdout when not on a TTY → Python's `readline()` returned nothing → state stuck at "Starting…" forever.

Both fixed in **Wave G** of the submodule PR (and this PR's `entrypoint.sh` change). End-to-end test in the v0.4.7 container: auth URL surfaces in <3s of clicking Connect.

## Changes in this PR

- **Submodule pointer bump** to land [hermes-webui#4](https://github.com/fox-in-the-box-ai/hermes-webui/pull/4) — see that PR for the full per-bug breakdown across 7 commits / 9 files.
- **`packages/scripts/install.sh`** (Wave E) — clean `_ts_exit_reason` tracking + `set +e/-e` wrap around `_tailscale_backend_state` in the bounded-poll loop (#98 hardening).
- **`packages/integration/entrypoint.sh`** (Wave G) — runs `tailscale set --operator=foxinthebox` after WebUI health + tailscaled reachable, with a 60s budget and a clear warning if the grant fails.

## End-to-end test matrix (against real v0.4.7 container)

| Scenario | Before | After |
|---|---|---|
| Tailscale Connect from desktop | ❌ stuck "Starting…" forever | ✅ auth URL in <3s |
| Logout cleanup (no orphan procs) | ❌ orphaned subprocess | ✅ clean |
| Reconnect after logout | ❌ untested | ✅ works idempotently |
| Hostname Apply + auto-mark prompted | ❌ untested | ✅ works |
| Local fallback enable/disable | ❌ untested | ✅ works |
| Multi-provider remote-health probe | ❌ OpenRouter-only (misleading) | ✅ tries 3 providers |
| Validator rejects flag-injection | ❌ no validator | ✅ 400 with reason |
| Validator rejects URL with shell metas | ❌ no validator | ✅ 400 with reason |
| Bool coercion `"false"` → False | ❌ became True (footgun) | ✅ correct |
| Persisted hostname survives Reconnect | ❌ dropped | ✅ included in argv |

## Test plan after merge

- [ ] CI builds clean (no regressions in build/smoke)
- [ ] Tag v0.4.7 → release pipeline produces 5 binaries
- [ ] Smoke test on a personal install: walk wizard, click Connect, verify auth URL opens in browser, complete auth, badge flips Connected

After this lands, **resume the strategic pause** — three open buckets (#96 Phase 3, #9 polish followups, v0.5 guardrails, revenue track). User picks the next direction.

Closes the QA-mode bugfix pass.