### PR TITLE
fix(ci): stop auto-bumping :stable on every main push — release-tag only

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -199,13 +199,14 @@ jobs:
           fi
           echo "✅ Both linux/amd64 and linux/arm64 confirmed in manifest list"
 
-      - name: Re-tag :stable on non-PR events
-        if: github.event_name != 'pull_request'
-        run: |
-          # `imagetools create` operates registry-side and preserves the
-          # manifest list. Don't use `docker pull && docker tag` — that
-          # collapses to a single-platform image. (#82)
-          docker buildx imagetools create -t "${IMAGE}:stable" "${IMAGE}:${{ steps.tag.outputs.tag }}"
+      # NOTE: :stable is intentionally NOT re-tagged here. It used to be
+      # auto-bumped from :latest on every push to main, which meant any
+      # post-release commit (including docs-only PRs) shipped a build to
+      # all DMG users via :stable without a release tag — surfaced by
+      # FITB#122 where :stable diverged from :v0.5.0 within hours of the
+      # release. :stable is now bumped exclusively by release.yml's
+      # imagetools step (pinned to the wait-for-container index digest)
+      # so it tracks released versions only. Do NOT restore this step.
 
   # ── Pull the published manifest by INDEX digest on each platform's
   # native runner and run the smoke test. This proves the digest pin


### PR DESCRIPTION
## Summary

Removes the `Re-tag :stable on non-PR events` step from `build-container.yml`. From now on, `:stable` is bumped exclusively by `release.yml`'s `imagetools create` step (pinned to `wait-for-container`'s index digest), which only runs on release-tag pushes.

## The bug this fixes

Before: every push to main rebuilt `:latest` AND re-tagged `:stable` from it. After [v0.5.0 tagged](https://github.com/fox-in-the-box-ai/fox-in-the-box/releases/tag/v0.5.0) on 2026-05-05 at 19:09 UTC, the immediately-following PRs #120 (README) and #121 (docs cleanup) each rebuilt `:latest` and silently moved `:stable` away from the released digest. Within hours, `:stable`'s arm64 child manifest digest diverged from `:v0.5.0`'s.

```
:v0.5.0 arm64 digest = 6e3f3354b97619...d15cbf0
:stable arm64 digest = 9cc508eca77ca8...684aac0   ← different SHA, off-tag main HEAD build
```

These two builds were functionally identical at the moment (docs-only PRs), but the contract was already broken: a future regression landing on main would ship to every DMG user via `:stable` without a release tag, and without anyone running smoke checks.

Surfaced during [#122](https://github.com/fox-in-the-box-ai/fox-in-the-box/issues/122) reproduction.

## Why this is safe

- Nothing else in CI consumes `:stable` (verified via `grep -rn "stable" .github/workflows/`)
- `release.yml`'s `imagetools create -t "$IMG:stable" "$IMG@$DIGEST"` step is unchanged → tag pushes still update `:stable` to the released digest
- The smoke-cloud job pulls `:latest` (not `:stable`) for its post-build verification → no internal CI break
- Comment in place where the step used to be, explaining why it shouldn't be restored

## Side effect (intentional)

Between releases, hotfixes that land on main don't ship to `:stable` until the next release tag. That's correct: `:stable` = "what users get on a clean DMG install", which should equal "the latest released version", not "main HEAD".

## Test plan

- [x] `grep -rn ":stable" .github/workflows/` — only `release.yml:75-87` (the correct writer) remains as a writer; readers are documentation-only
- [ ] Merge → next push to main triggers `build-container.yml` → verify `:stable` digest does NOT change (only `:latest` does). Confirm via `docker manifest inspect ghcr.io/fox-in-the-box-ai/cloud:stable` before and after the merge commit lands.
- [ ] Next release-tag push triggers `release.yml` → verify `:stable` digest matches `:vX.Y.Z` digest (the existing release.yml verification step already enforces this).