### PR TITLE
fix(ci): populate FITB_VERSION on non-tag builds with dev-<sha>

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -67,10 +67,16 @@ jobs:
       - name: Determine FITB_VERSION
         id: meta
         run: |
+          # Tag pushes use the version tag verbatim. Other events (push to
+          # main, PRs) carry a dev marker derived from the short SHA so the
+          # in-app version display is never blank — previously these built
+          # with FITB_VERSION="" which surfaced as empty version strings on
+          # :latest / :stable images. FITB#122 cosmetic.
           if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
             echo "fitb_version=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
           else
-            echo "fitb_version=" >> "$GITHUB_OUTPUT"
+            SHORT_SHA="$(echo "${{ github.sha }}" | cut -c1-7)"
+            echo "fitb_version=dev-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build and push by digest


### PR DESCRIPTION
## Summary

Fixes a cosmetic but visible bug from FITB#122: the in-app version display showed blank on `:latest` / `:stable` images.

`build-container.yml` was passing `FITB_VERSION=""` to the Docker build for every event except tag pushes. The Dockerfile's `RUN echo \"\${FITB_VERSION}\" > /app/version.txt` then wrote a 1-byte file (just a newline). Verified during reproduction: pulled `:stable`, ran the container, `echo \$FITB_VERSION` returned empty, `cat /data/version.txt` returned a 1-byte file.

## The change

For non-tag events (push to main, PRs, manual workflow dispatch), pass `FITB_VERSION=dev-<7-char-sha>`. Tag pushes are unchanged — they continue to use the tag name verbatim (`vX.Y.Z`).

## Test plan

- [ ] After merge, next push to main → build → pull `:latest` → `echo \$FITB_VERSION` shows `dev-<sha>` and `/app/version.txt` matches
- [ ] Next release tag push → `:vX.Y.Z` and `:stable` both contain the tag name (existing behavior preserved)