### PR TITLE
fix(#127): supervisord watchdog re-asserts tailscale operator-grant every 30s

### DIFF
--- a/packages/integration/scripts/tailscale-operator-watchdog.sh
+++ b/packages/integration/scripts/tailscale-operator-watchdog.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Re-assert tailscaled's OperatorUser=foxinthebox preference every 30s.
+#
+# tailscaled drops the OperatorUser pref on the NeedsLogin transition that
+# follows a tailnet key expiry. Once dropped, the foxinthebox-owned webui
+# can no longer drive `tailscale up` — checkprefs returns "Access denied"
+# and the user's only recovery is `docker exec ... tailscale set --operator`
+# from a host shell. FITB#127.
+#
+# This watchdog runs as root (supervisord's UID) so it has the authority to
+# (re-)set OperatorUser even when tailscaled cleared it. The grant is a
+# no-op when already set, so the constant polling has no observable effect
+# on a healthy tailnet — only on the recovery path.
+#
+# 30s cadence picked over 60s in v0.5.2 architecture decisions
+# (project_v0_5_2_decisions.md): faster reaction matters more than the
+# trivial CPU cost.
+set -u
+
+while true; do
+    # Best-effort: a transient daemon-not-ready or socket EAGAIN should not
+    # crash the watchdog. supervisord's autorestart would respawn us, but
+    # the resulting log noise is unhelpful.
+    tailscale set --operator=foxinthebox >/dev/null 2>&1 || true
+    sleep 30
+done

--- a/packages/integration/supervisord.conf
+++ b/packages/integration/supervisord.conf
@@ -31,6 +31,24 @@ stdout_logfile=/data/logs/tailscaled.log
 stderr_logfile=/data/logs/tailscaled.err
 priority=10
 
+; ── tailscale operator watchdog (FITB#127) ────────────────────────────────────
+; tailscaled clears its OperatorUser preference on the NeedsLogin transition
+; that follows a tailnet key expiry. Once cleared, `tailscale up` from the
+; foxinthebox-owned webui returns "Access denied: checkprefs access denied".
+; The entrypoint's one-shot `tailscale set --operator=foxinthebox` only
+; covers boot — this loop covers the entire container lifetime, including
+; key-expiry recovery. Idempotent (no-op when already set). Runs as root
+; because OperatorUser can only be (re)set with root or current-operator
+; authority — and we just lost the latter when it was cleared.
+[program:ts-operator-watchdog]
+command=/app/scripts/tailscale-operator-watchdog.sh
+user=root
+autostart=true
+autorestart=true
+stdout_logfile=/data/logs/ts-operator-watchdog.log
+stderr_logfile=/data/logs/ts-operator-watchdog.err
+priority=15
+
 ; ── qdrant ───────────────────────────────────────────────────────────────────
 [program:qdrant]
 command=/app/qdrant/qdrant --config-path /data/config/qdrant.yaml


### PR DESCRIPTION
Closes #127. tailscaled drops OperatorUser on key-expiry NeedsLogin transition; the entrypoint's one-shot grant doesn't survive. Watchdog (priority 15, root UID, idempotent) re-asserts every 30s. Verified force-clear + force-logout scenarios both restore OperatorUser within one tick, and `tailscale up` from foxinthebox user no longer returns 'Access denied: checkprefs'. See commit message for full QA log.