### PR TITLE
docs(smoke): Section L for v0.5.2 + v0.5.3 plan refresh

### DIFF
--- a/qa/SMOKE_CHECKLIST.md
+++ b/qa/SMOKE_CHECKLIST.md
@@ -168,8 +168,10 @@ These checklists were testing gates from previous phases. Re-run before any mino
 |---|---|
 | #105 Phase 0 (v0.5.0) | All A–K above |
 | #122 v0.5.1 stabilization | (a) `/api/ollama/status` and `/api/local-fallback/status` return **200** (not 302) when onboarding incomplete · (b) "Use [model]" on Step 1 advances to Step 2 (NOT chat) and `onboarding.json` stays `completed: false` until Step 3's "Open Fox" · (c) Step 2 shows "Add OpenRouter (optional)" + "Continue with local only" button when state.localModel set · (d) `/api/tailscale/status` response includes `serve_state` + `serve_error` fields · (e) "Configure HTTPS" retry button visible in Settings → Tailscale tile after Connect · (f) Reactive modal fires on `auth_mismatch` and `quota_exhausted` (set OpenRouter key to garbage with fallback OFF, send chat) · (g) Recovery banner appears within 30s when fallback is enabled mid-session and provider is restored · (h) `:stable` digest equals `:vX.Y.Z` digest after release tag (no drift from main pushes) · (i) `/app/version.txt` populated with `dev-<sha>` or `vX.Y.Z` (never empty) |
-| #4 + #5 Phase 1 (v0.5.2 part) | Plugin loads cleanly · PII masking detects SSN/CC/phone/email · <30 ms p95 latency · toggle off = no impact |
-| #7 Phase 2 (v0.5.3) | All 5 starter rules tested positive + negative · rules don't false-positive on normal conversation |
+| #127 / #128 / #129 v0.5.2 stabilization | **#127:** (a) `ts-operator-watchdog` RUNNING in supervisord status · (b) Force-clear OperatorUser → restored within 35s · (c) `tailscale up` after force-logout produces auth URL (not `Access denied: checkprefs`). **#128:** (d) `localStorage.setItem('fitb.timeout_modal_ms','5000')` → bad provider key → modal in 5s · (e) "Switch now" with fallback OFF → 400 + reason=disabled with actionable copy · (f) With fallback READY → click Switch now → success + dismiss in ~2.5s · (g) Real SSE arrival post-modal → auto-dismisses. **#129:** (h) Bad cloud key + fallback ready → response includes `*Switched to phi4-mini — re-send your message…*` system note (NO red error) · (i) Fallback enabled but model NOT installed → confirm modal "Download local model to keep working?" with size hint · (j) Click Download → progress poll updates inline · (k) On ready → activate → "Ready. Re-send your message…" · (l) Already-local guard: with active = phi4, force a local-side failure → original error surfaces (no redundant `provider_switched`) · (m) Mid-stream truncate: partial tokens then fail → partial cleared, system note appended · (n) `/api/local-fallback/status` includes top-level `ready` field · (o) `/api/local-fallback/activate` registered (200 when ready, 400 + granular `reason` when not) |
+| #109 v0.5.3 (custom Ollama URL) | (a) Settings → Providers → Ollama tile has a "Custom Ollama URL" input · (b) Save with `http://192.168.1.50:11434` → probe uses the new URL · (c) Wizard's Ollama detection respects the custom URL · (d) Empty value falls back to host.docker.internal default. **#110** (Tailscale Serve retry button) was already shipped in v0.5.1 hermes-webui#9 — confirm working and close. |
+| #4 + #5 Phase 1 (v0.5.4) | Plugin loads cleanly · PII masking detects SSN/CC/phone/email · <30 ms p95 latency · toggle off = no impact |
+| #7 Phase 2 (v0.5.5) | All 5 starter rules tested positive + negative · rules don't false-positive on normal conversation |
 | #64 Phase 3 (v0.6.0) | Every page screenshot-compared · no overflow / truncation · mobile (375px) renders · onboarding still works |
 | #6 Phase 4 (v0.7.0) | Safe messages: zero impact · unsafe messages caught and wiped · hardware probe disables on 8 GB · all prior guards still work · cold start <10s |
 | #12 Phase 5 (v0.8.0) | Routine via conversation in <5 min · executes on schedule · failed routine surfaces clear error · all prior features unaffected |
@@ -191,4 +193,12 @@ These checklists were testing gates from previous phases. Re-run before any mino
 
 ---
 
-**Last updated:** v0.5.1 — #122 follow-on stabilization. Verification methodology now requires running against released `:stable` (or candidate `:latest` for pre-tag verification), not against a local `docker build` — the v0.5.0 release missed all 7 of #122's failures because verification was done against a local rebuild that happened to have all the source-tree fixes; the published `:stable` had drifted. See `feedback_qa_methodology.md` for the rule.
+**Last updated:** v0.5.2 — local fallback completion (#127, #128, #129). Verification methodology rule unchanged: run against released `:stable` (or candidate `:latest` for pre-tag), not against a local `docker build` from source. The DMG-equivalent install command is the canonical path:
+
+```bash
+docker run -d --name fox-in-the-box \
+  --cap-add=NET_ADMIN --device /dev/net/tun --sysctl net.ipv4.ip_forward=1 \
+  -p 127.0.0.1:8787:8787 \
+  -v "$HOME/Library/Application Support/Fox in the Box:/data" \
+  ghcr.io/fox-in-the-box-ai/cloud:stable
+```


### PR DESCRIPTION
Updates qa/SMOKE_CHECKLIST.md with: v0.5.2 regression entries (#127/#128/#129 — 15 sub-checks), v0.5.3 entry (#109 + #110 close-out), shifted Phase 1/2 to v0.5.4/v0.5.5 to honor Rule 1. Footer methodology note refreshed with canonical DMG-equivalent docker run.