### PR TITLE
chore(issues): lower the bar for non-technical users to report problems

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
-  - name: Documentation
-    url: https://github.com/fox-in-the-box-ai/fox-in-the-box/tree/main/docs
-    about: Read the docs before opening an issue
   - name: Discussions
     url: https://github.com/fox-in-the-box-ai/fox-in-the-box/discussions
-    about: Questions and general discussion
+    about: Questions, ideas, or general help — start here if you're not sure it's a bug
+  - name: Documentation
+    url: https://github.com/fox-in-the-box-ai/fox-in-the-box/tree/main/docs
+    about: Reading the docs may answer your question faster


### PR DESCRIPTION
## Summary

Two friction points were silently keeping non-technical users from filing issues:

1. **`blank_issues_enabled: false`** forced every issue through the structured `issue.yml` form. Users who couldn't fit (or didn't want to) had no escape hatch — net result was zero report instead of a messy one. Flipping to `true` lets people file freeform issues; maintainers can re-triage.
2. **Discussions contact link was 404ing** — the link was advertised in `config.yml` but `has_discussions` was off at the repo level. Enabled Discussions via the repo API; the link now resolves.

Also reordered contact links so Discussions appears first — that's the right destination for "is this a bug or just a question?" cases that were previously dead-ending in the bug template.

## Verification

- Repo public ✅, issues enabled ✅, no interaction limits ✅, no org-level restrictions on issue creation ✅
- Anyone with a GitHub account can already open issues (GitHub default for public repos with `has_issues:true`).
- After this PR + Discussions enable: blank issues + Discussions both work.

## Test plan
- [ ] Logged out: visit https://github.com/fox-in-the-box-ai/fox-in-the-box/issues/new/choose → redirected to login (expected; GitHub requires auth to create)
- [ ] Logged in as a non-org user: same URL → see options including "Open a blank issue" + Discussions link
- [ ] Click Discussions → lands on real Discussions page (not 404)