### PR TITLE
docs: add v0.6.0 upstream-separation migration architecture

### DIFF
--- a/docs/architecture/hermes-webui-dependency-risk-assessment.md
+++ b/docs/architecture/hermes-webui-dependency-risk-assessment.md
@@ -1,0 +1,277 @@
+# hermes-webui Dependency Risk Assessment
+
+**Date:** 2026-05-16
+**Subject:** `nesquena/hermes-webui`
+**Author:** Architect 3 (Strategic Dependency Lane)
+**Posture:** RECOMMEND CHANGE — see Section 9.
+
+---
+
+## 1. Project identity & governance
+
+**Owner.** GitHub user `nesquena` (id 6511, account created 2008-04-11). Real name **Nathan Esquenazi**, location San Francisco, bio "Co-Founder @ CodePath.org". Linked GitHub orgs: `railsbridge`, `padrino`, `beanstalkd`, `codepath`. **No org membership in `NousResearch`.** This is an individual developer's personal project.
+
+**Personal vs institutional.** Owner is a User account, not an Organization. Repo is published on a personal namespace. There is no parent company, foundation, or sponsoring organization on the GitHub side. The companion website `get-hermes.ai` does not advertise a corporate sponsor.
+
+**License.** MIT, copyright "Hermes Web UI Contributors" (2025). MIT permits commercial use, modification, distribution, sublicense — Fox's bundling and redistribution are unambiguously allowed and require only attribution.
+
+**Public roadmap / RFCs.** A `ROADMAP.md` exists and is detailed (sprint history with test counts per sprint, currently up to v0.51.x), but it is a *retrospective* changelog, not a forward-looking RFC process. There is no RFC repository, no design-doc workflow, no public issue triage policy.
+
+**CLA / CoC / SECURITY.md.** **None.** `CONTRIBUTING.md` is one paragraph: "Thanks for contributing. … If your PR touches security-sensitive behavior, say so explicitly." No CODE_OF_CONDUCT.md. No SECURITY.md. No vulnerability disclosure address. No 2-factor enforcement signal. This means a CVE landed today would be reported in public Issues, not via coordinated disclosure.
+
+**Relationship to NousResearch / hermes-agent.**
+- Marketing relationship: README points users to `https://hermes-agent.nousresearch.com/`. The official hermes-webui homepage `get-hermes.ai` self-describes in its OG metadata as "Hermes — Community Web UI **(unofficial)**", with `og:url` of `nesquena.github.io/hermes-webui/`.
+- Technical relationship: hermes-webui imports hermes-agent Python modules via `sys.path` (filesystem dependency, not PyPI). README claims dynamic feature parity.
+- Reverse relationship: NousResearch's `hermes-agent` README contains **zero references to hermes-webui or nesquena**. The agent project does not acknowledge the WebUI as official.
+- Cross-reference traffic: 218 hermes-agent issues mention "nesquena" or "hermes-webui," but these are user-filed cross-refs, not project-level coordination.
+
+**Net governance assessment:** unincorporated personal project of a single individual, marketed as the WebUI for an institutional product (NousResearch's hermes-agent) **without that institution's endorsement**. Branding is "community/unofficial" by the project's own admission.
+
+---
+
+## 2. Maintainer health & bus factor
+
+**Project age.** First commit on master 2026-04-22; first commit anywhere (any branch) 2026-03-30. Total git history: **47 days**.
+
+**Top contributors (entire 47-day project history, `git shortlog -sn upstream/master`):**
+
+| Rank | Author | Commits | % of 1,723 |
+|------|--------|---------|-----------|
+| 1 | nesquena-hermes | 573 | 33.3% |
+| 2 | Hermes Agent (bot) | 231 | 13.4% |
+| 3 | Frank Song | 155 | 9.0% |
+| 4 | Michael Lam | 127 | 7.4% |
+| 5 | Hermes Bot (bot) | 95 | 5.5% |
+| 6 | "test" | 78 | 4.5% |
+| 7 | bergeouss | 57 | 3.3% |
+| 8 | ai-ag2026 | 45 | 2.6% |
+| 9 | Nathan Esquenazi | 44 | 2.6% |
+| 10 | dobby-d-elf | 38 | 2.2% |
+| ... | (79 more contributors) | | |
+
+**Lead maintainer share.** `nesquena-hermes` + `nesquena` + `Nathan Esquenazi` = **618 commits = 35.9% of all commits**. Add the bots `nesquena` operates (Hermes Agent + Hermes Bot + Hermes Release Agent = 328) and the maintainer-controlled commits are **946 / 1,723 = 54.9%** of upstream.
+
+**On the GitHub contributors API** (which counts across all branches): nesquena-hermes 800 + nesquena 273 = 1,073 — same conclusion, just larger denominator.
+
+**Bot identity.** "Hermes Agent" and "Hermes Bot" emit messages such as `Hermes Agent Stage 367: PR #2367 — fix: …` and `Hermes Agent stage-367: stamp CHANGELOG v0.51.74`. They are **the maintainer's own automation**: a release bot that batches merged PRs into "stage" branches, stamps the changelog, and cuts a tag. Email domain `agent@nesquena-hermes.local` and `hermes-bot@get-hermes.ai` confirm both are operated by nesquena. They are not third-party Dependabot equivalents.
+
+**Real human throughput.** Subtracting nesquena and his bots, the top non-maintainer contributors in 47 days:
+
+- Frank Song (155) — appears as core team
+- Michael Lam (127)
+- "test" (78) — likely test fixture commits, not human authorship
+- bergeouss (57)
+- ai-ag2026 (45) — ambiguous identity
+- dobby-d-elf (38), starship-s (33), Dennis Soong (27), Jordan SkyLF (25), fxd-jason (18)
+
+**Drive-by ratio.** 89 distinct contributors total. The long tail (rank 25-89) shows 65 contributors with ≤6 commits each. This is healthy drive-by traffic (a typical OSS distribution) but not an institution-scale contributor pool.
+
+**PR throughput vs. authorship.** 1,649 total PRs in 47 days = 35 PRs/day opened. 963 merged + 657 closed-unmerged + 22 open = 59% merge rate. Oldest open PR is 15 days old (#1418, opened 2026-05-01). PR triage is fast, but the merge filter is aggressive.
+
+**Maintainer absences.** **Zero.** nesquena has authored commits on **48 distinct days out of the 48-day project history.** Longest gap: 0 days. The project has not yet had a single weekend without maintainer activity. This is also a *symptom*: the project is too young to have demonstrated resilience to a maintainer absence.
+
+**Single point of failure.** If `nesquena` stops tomorrow:
+- Release bot stops cutting tags (it's operated from his machine — emails `@nesquena-hermes.local`).
+- Stage-batch merging stops (it's the bot's job).
+- The "official" upstream remote on GitHub remains owned by him personally — no org continuity plan exists.
+- Frank Song (#3) and Michael Lam (#4) combined are 282 commits; they could plausibly fork-and-continue, but neither has demonstrated release-management capability or owns the `get-hermes.ai` domain.
+- Bus factor: **1**.
+
+---
+
+## 3. Shipping velocity & quality signals
+
+**Commit cadence (all on master, last few days):** 2026-05-13: 130, 05-14: 77, 05-15: 100, 05-16 (partial): 33. Last 7 days: 660 commits = **94 commits/day**. Last 14 days: 1,328 = 95/day. The "60 commits/day" figure in the prior research underestimates current cadence by ~50%.
+
+**Tag cadence.** 421 git tags in 47 days = **8.96 tags/day**. 397 GitHub releases (~24 tags are not promoted to releases). Tag scheme is strict semver: `v0.51.74`, `v0.51.73`, etc. — every accepted stage-batch becomes a tag. Effectively, **tags are merge-commit markers, not stability signals**.
+
+**Major / minor / patch breakdown.** Project is on the v0.51.x series after 47 days of life — the minor number has incremented ~50 times. No v1.0 yet. The v0.x → v0.x+1 boundary appears to mean "started a new sprint," not "API broke." This makes semver effectively useless as a stability oracle for downstream pinning.
+
+**Revert / yank history.** No tags match `revert|yank|rollback|hotfix|patch`. 5 commits contain "revert" in the subject line, including:
+- `stage-362: revert #2323 — Opus caught silent regression in profile routing`
+- `Revert "Merge pull request #2323 into stage-362"`
+- `release: v0.50.242 — revert assistant serif font + remove Calm theme (#1299)`
+
+This is healthy — reverts happen and are explicit. No history of yanked releases, but the project is too young (47 days) to show a long-term pattern.
+
+**Commit type breakdown (from subject-line keywords):**
+- "fix" / "bug": 622 / 1,724 = **36.1%**
+- "feat" / "feature": 130 / 1,724 = **7.5%**
+- "refactor" / "cleanup" / "chore": 95 / 1,724 = **5.5%**
+- Remaining ~50% are stage merges, test commits, locale/i18n commits, and CHANGELOG stamps.
+
+The fix:feat ratio of ~5:1 is high. Interpretation: either a mature stabilization sprint, or a high churn/regression rate. Given the 95-commit/day cadence and the volume of "Opus-caught" advisory commits (e.g., "stage-364: Opus-caught live SSE event_id fix (side-channel approach)"), the more likely read is **lots of regressions caught fast** — high agility but elevated regression risk per merge.
+
+**Test count over time.** ROADMAP.md tracks test counts per sprint. Sprint 23: 424 tests. Sprint 34 (v0.50.0): 742 tests. Currently: 313 test files (rough count) representing ~3,936 tests collected per the v0.50.278 ROADMAP entry. Test count grows every sprint — positive maturity signal.
+
+**Open / closed issue ratio.** 79 open / 640 closed = **11.0% open**. Healthy for an active project. Oldest open issue: #195 (37 days old, "Reliability: os.environ race condition between concurrent agent sessions"). A meaningful reliability bug has sat 37 days without a fix.
+
+**Stale PR rate.** 22 open / 1,649 total = 1.3% open. Oldest open PR is 15 days old. **Triage is excellent.**
+
+---
+
+## 4. Alignment with hermes-agent
+
+**Coupling model.** WebUI imports hermes-agent modules via `sys.path` injection at startup. There is no version pin, no requirements.txt entry — webui adapts to whatever agent it finds on disk.
+
+**Release coupling.** hermes-agent's latest release is `v2026.5.7` (date-stamped, 2026-05-07, internal version `v0.13.0`). hermes-webui's latest is `v0.51.74` (2026-05-16). The two projects are **on completely independent versioning schemes** with no coordinated release notes.
+
+**Lag time when agent changes APIs.** Cannot be measured precisely from git logs alone, but the absence of any version pin and the in-tree references to "WebUI run state consistency contract" (e.g., PR #2363, "Document WebUI run state consistency contract") suggest **the contract is being discovered and documented in-flight**, not designed up-front. There is risk that an agent change ships and webui is silently broken until someone notices.
+
+**Does WebUI surface new agent hooks promptly?** PR titles like "feat(mcp): Option A rewrite — import api.models/api.profiles canonically" and "Stage 323: PR #1895 — MCP Option A rewrite" suggest webui follows agent's MCP changes within days. Cadence is fast on the surface; quality is unknown.
+
+**Does webui ever lead the agent?** No evidence in git logs of webui shipping UI for unreleased agent features. The directionality is consistently agent-first, webui-follows.
+
+**Operational implication.** If Fox bumps hermes-agent independently, it can desync webui without warning. Fox's CI must test the *pair* end-to-end at every bump.
+
+---
+
+## 5. Alignment with Fox's needs
+
+**Fox's modification footprint** (from the upstream-separation-plan, file-level audit):
+- 22 NEW files (Tailscale, local fallback, Ollama URL, hostname, onboarding wizard, Fox visual shell, etc.)
+- 29 MODIFIED files (api/routes.py +1510/-98; static/panels.js +1181/-7; static/index.html +174/-31)
+- 7 DELETED files (upstream onboarding entirely)
+- "Always-conflict" set: `api/routes.py`, `api/onboarding.py`, `api/streaming.py`, `api/config.py`, `static/index.html`, `static/panels.js`
+
+**Recent upstream features Fox wants vs. doesn't:**
+
+Recent (last 30 days) upstream features identifiable from changelog/commit subjects:
+- Kanban v1 launch (Sprint 329, multiple commits, modal/i18n/profile-cache/dispatcher work) — **ambiguous for Fox**: Fox audience is non-technical; kanban as task tracker may or may not surface in onboarding.
+- Compression / context-window indicators (live usage ring, compression reference cards) — **wanted**.
+- WebUI run event journal replay (PR #2283) — **probably wanted** (resilience feature).
+- i18n locale parity (DE, multiple zh-Hant fixes, settings sidebar i18n) — **neutral / mildly wanted** for global rollout.
+- MCP server "Option A rewrite" — **wanted** (Fox audience wants MCP).
+- Markdown table cell paragraph spacing fixes — **neutral**.
+- Skills sidebar management (#268), real-time bidirectional sync between Gateway sessions (#272) — **wanted**.
+- WebUI extension hooks (`api/extensions.py`, added 2026-05-01) — **directly relevant** to Fox's overlay strategy.
+
+**Collisions with Fox-specific work:**
+- Onboarding: Fox replaced upstream's onboarding entirely (deletes 689 LOC net, deletes 6 upstream onboarding tests). Every upstream onboarding change is a guaranteed conflict.
+- Local-fallback: Fox added 616 LOC for Ollama-fallback orchestration. If upstream ever ships a similar feature, the duplication will be painful.
+- Tailscale (877 LOC): pure Fox surface. No upstream equivalent. Safe.
+- Hostname (279 LOC): pure Fox. Safe.
+- Custom Ollama URL (#109): Fox-added. Upstream may add this themselves under a different env-var name and conflict.
+
+**Extensibility surface upstream provides.**
+- `api/extensions.py` (added 2026-05-01, 14 days old): script-injection + sandboxed-static extension hooks via env vars `HERMES_WEBUI_EXTENSION_DIR`, `HERMES_WEBUI_EXTENSION_SCRIPT_URLS`, `HERMES_WEBUI_EXTENSION_STYLESHEET_URLS`. Cap of 32 URLs per env var. **This is a brand-new surface Fox should evaluate, but it covers static-asset overlays and JS injection only — it cannot cover Python route additions or onboarding rewrites.** Fox's 22 new Python files cannot live here.
+- `HERMES_WEBUI_AGENT_DIR` env var: hermes-agent path discovery. Fox uses.
+- `SKIP_ONBOARDING` env var: skip upstream wizard. Fox uses.
+- `HERMES_WEBUI_EXTENSION_*`: script/style injection. Fox does NOT yet use; could replace some of `static/fox-in-the-box.{css,js}` overlay.
+
+**Verdict on extensibility.** Upstream's extension surface is intentionally narrow ("self-hosted extension surface: configured same-origin script/style injection plus sandboxed static file serving"). It is sufficient for branding overlays, **insufficient for Fox's Python additions**. Fox's overlay needs will not be served by upstream's extension model alone.
+
+---
+
+## 6. Stability & restructure risk
+
+**Large-scale rewrites observed.** From ROADMAP.md Sprint history:
+- Sprint 5: `server.py` 1778→1042 lines (JS extraction)
+- Sprint 9: "app.js deleted and replaced by 6 modules"
+- Sprint 10: "server.py split into api/ modules"
+- Sprint 11: "routes extracted to api/routes.py (server.py 704→76 lines)"
+- Sprint 23/34/40: rendering rewrites (renderMd hardening, autolink ordering, _ob_stash)
+- "v0.50.0 UI overhaul (Sprint 34)": composer-centric controls, workspace state machine
+- "MCP server Option A rewrite" (Sprint 322-323)
+- "Three-column layout with left rail + main-view migration" (#899)
+
+**Frequency:** roughly one structural change per sprint (1-2 weeks). For a 47-day-old project, that is **continuous architectural churn**, not a stable foundation.
+
+**API stability.** Two examples of removal-without-deprecation in the recent log:
+- "fix: remove deprecated btnCancel; localise composer tooltips with disabled reason branching"
+- "chore: remove deprecated DeepSeek V3/R1 models, keep only V4"
+
+Pattern: things get deprecated and removed within the same sprint cycle. There is no observable LTS / deprecation-window discipline.
+
+**Database schema changes.** Recent commits include:
+- "fix(auth): HMAC length migration bridge and restore Secure cookie heuristic" (32→64 char HMAC migration)
+- "fix(recovery): preserve worktree metadata + workspace + message_count on state.db sidecar rebuild"
+- "fix(recovery): close concurrency hazards in state.db sidecar reconciliation"
+
+The SQLite `state.db` has had at least one schema migration with a "bridge" — meaning upstream is willing to break backward compat as long as a one-shot bridge exists. Fox's snapshots/backups must be tested across these.
+
+**In-flight rewrites visible in branches.** Active upstream branches: `master`, `gh-pages`, `docs/contributors-v0.51.58-refresh`, `fix-2083-title-retry`, `fix/2177-nvidia-prefix-strip`, and `stage-363` through `stage-367`. The "stage-N" branches are the release-batch staging branches — not long-lived feature branches. **No evidence of an in-flight large-scale rewrite (no `react-rewrite/`, `vue-port/`, etc.).** This is a positive: nothing major is hidden in branches waiting to land.
+
+---
+
+## 7. Three options compared
+
+| Dimension | Stay + separate (12d plan) | Stay + minimal patch | Fork-and-stop | Replace (build) |
+|---|---|---|---|---|
+| **Up-front cost** | 12 eng-days | 2-3 eng-days | 0 days | (out of scope — separate architect) |
+| **Ongoing maintenance** | 0.5-1 day/week to rebase patch series against ~95 commits/day upstream | 1-2 days/week as drift accumulates; faster decay | Near-zero, pinned to a tag | Variable |
+| **Security posture** | Strong: pull weekly, get CVE fixes | Moderate: periodic catch-up, possibly missing fixes | **Weak**: any post-pin CVE requires manual patch on a stale base | Strong (we own surface) |
+| **Feature freshness** | High: ride the 95-commit/day train | Medium: take features on a delay | **Frozen** at pin date | Whatever Fox decides to ship |
+| **Ability to diverge** | Medium: every Fox-only feature fights routes.py / onboarding.py / panels.js | Low: divergence amplifies conflict cost | **High**: total freedom, no merges | **Highest**: greenfield |
+| **Dependency-graph simplification** | None — still couples to upstream weekly | None | Yes — eliminates upstream-tracking workflow | Yes — eliminates upstream entirely |
+| **Risk if maintainer disappears** | Moderate: stage-batches stop, but Fox can pick from existing tagged release | Same as Stay+separate | **Zero** — Fox already self-sufficient | Zero |
+| **Risk if NousResearch ships official WebUI** | High — upstream may pivot or get abandoned | High — same | Insulated (Fox has frozen base) | Insulated |
+| **Risk if upstream relicenses or commercializes** | High (must fork at the cut) | High | **Zero** (already past the cut) | Zero |
+
+**Note on "Replace":** I am not sizing it per brief. Reference only — it is the option a separate architect is studying.
+
+---
+
+## 8. "What if upstream pivots" scenarios
+
+**Scenario A: nesquena rewrites the frontend in React.**
+- *Detection:* No tripwire today. The first signal would be a feature branch like `react-rewrite/` appearing on the upstream remote, or a series of commits with `feat(react): …` subjects. Fox would notice on the next `git fetch upstream && git log upstream/master`.
+- *Reaction time:* Fox's overlay (`static/fox-in-the-box.{css,js}`, all of `static/panels.js` modifications) is built against vanilla-JS DOM. A React rewrite would invalidate **100% of Fox's static/ patches** (the ~3,000+ LOC of static modifications).
+- *Probability assessment:* No git evidence of this in any current branch. Risk over 6 months: low-to-moderate. Maintainer is on a feature treadmill, not a rewrite.
+
+**Scenario B: NousResearch decides to ship their own official WebUI.**
+- *Detection:* A commit landing in `NousResearch/hermes-agent` referencing a new internal `webui/` directory, or an announcement on `nousresearch.com`. No upstream cross-reference exists today.
+- *Reaction time:* Fox could continue with nesquena's "community/unofficial" version indefinitely under MIT, but the marketing claim (in WebUI's own README) of "the WebUI for hermes-agent" would become untrue and a NousResearch official UI would likely be the user expectation.
+- *Probability:* Materially elevated by the asymmetric relationship (webui name-drops agent; agent ignores webui). NousResearch has institutional capacity (orgs, 152K stars) to ship one in days if they want.
+
+**Scenario C: Upstream introduces a paid tier or relicenses.**
+- *Detection:* License file change on master. Easily monitored.
+- *Mitigation:* MIT is irrevocable for prior versions. Fox can fork at the last MIT commit. Cost: lose all post-cut features.
+- *Probability:* Personal projects rarely relicense; corporate ones do. Risk is low *unless* nesquena monetizes get-hermes.ai, in which case risk jumps.
+
+**Scenario D: CVE drops, upstream patches, Fox is too far behind to absorb.**
+- *Today's state:* Fox is 1,250 commits behind, growing by ~95/day. A critical CVE patch lands in commit X on `upstream/master`; cherry-picking X cleanly may require pulling 50-200 prerequisite commits.
+- *Mitigation:* The 12-day separation plan would establish patch-series discipline that makes cherry-picks straightforward. Fork-and-stop would require Fox to write the security patch independently against a stale base.
+
+---
+
+## 9. Recommendation
+
+**Recommendation: Adopt the 12-day separation plan, BUT cap further investment in upstream-tracking at 60 days. Use that window to validate whether the cadence is sustainable for Fox, and parallelize discovery on the React-replacement option (separate architect) so it is shovel-ready if the answer is no.**
+
+This is not "stay" and not "fork-and-stop." It is "stay, instrumented, with an exit ramp."
+
+**The reasoning, in one paragraph.** Upstream is one human, his bots, and 87 drive-by contributors, on a 47-day-old codebase, shipping 95 commits per day, on a contract with hermes-agent that is "discovered in-flight," with no governance scaffolding (no CLA, no SECURITY.md, no CoC), branded by its own homepage as "unofficial," and structurally rewritten roughly once per sprint. Fork-and-stop forfeits security patches on a project too immature to predict the CVE arrival rate of. Build-from-scratch is the obvious long-term answer but the right-now answer is to buy time at the lowest cost. The 12-day separation plan buys ~3-4 months of feature parity and CVE-tracking at ~0.5-1 day/week steady-state — that is a defensible bet **provided the bet is reviewed at day 60.**
+
+**The single precondition that would change my answer to "fork-and-stop now":** if maintenance cost in the first 4 weeks of the separated state exceeds 1.5 days/week (i.e., upstream cadence forces more rebase work than predicted), fork-and-stop becomes correct because the separation investment did not pay back.
+
+**The single precondition that would change my answer to "replace now":** if NousResearch announces or visibly begins work on an official hermes-webui (detection: any commit in `NousResearch/hermes-agent` referencing a `webui/` directory, or a press release), the upstream becomes a deprecating asset and Fox should pivot to the build-our-own track immediately.
+
+---
+
+## 10. Tripwires Fox should set up either way
+
+These are mechanical signals that route information to Fox without depending on Fox engineers proactively reading upstream commits.
+
+1. **Daily `git fetch upstream && git log` digest.** Cron job (GitHub Action or local) that:
+   - Posts a Slack/email summary of the previous day's upstream commit subjects, grouped by author.
+   - Highlights any commit mentioning `breaking|deprecat|migration|rewrite|schema|password|auth|csrf|xss|injection`.
+   - Highlights any commit touching the "always-conflict" set: `api/routes.py`, `api/onboarding.py`, `api/streaming.py`, `api/config.py`, `static/index.html`, `static/panels.js`.
+
+2. **License watch.** GitHub Action that diffs `LICENSE` between `upstream/master` and the previous fetch. Page Dennis on any change.
+
+3. **Branch-creation watch.** Action that lists all upstream branches daily; alerts on any new branch matching `react|vue|svelte|preact|rewrite|v1|next|major`.
+
+4. **NousResearch official-UI watch.** Daily check of `NousResearch/hermes-agent`'s tree for a `webui/` or `frontend/` or `static/` directory; alert on appearance.
+
+5. **Maintainer absence canary.** Alert if `nesquena` has zero commits to `upstream/master` for 5 consecutive days. (Today's baseline: zero such gaps in 48 days. Any 5-day gap is a 100x deviation from baseline.)
+
+6. **CVE feed.** Subscribe to GitHub Security Advisories for `nesquena/hermes-webui`. Subscribe to Python advisory DB for any pinned dependency in `requirements.txt`.
+
+7. **Stage-batch monitoring.** The "Hermes Agent" bot stamps every release. If that stamp pattern (`Hermes Agent stage-NNN: stamp CHANGELOG vX.Y.Z`) breaks for >48 hours, the maintainer's release pipeline is down — early signal of a maintainer outage even if commits are still flowing from contributors.
+
+8. **End-to-end pair test in Fox CI.** Every Fox build runs hermes-webui (current pin) against hermes-agent (current pin). Any pair-mismatch failure triggers a webui-pin freeze rather than auto-bumping.
+
+9. **Patch-series rebase clock.** Track time-to-rebase per upstream pull. If average time-to-rebase exceeds 4 hours per pull for 3 consecutive pulls, escalate to a pin freeze and a strategic re-evaluation.
+
+10. **Open-issue-age sentry.** Track the age of the oldest unresolved upstream issue. The current value is 37 days (#195). If that ever exceeds 90 days while the project is still <12 months old, treat it as a maintenance-bandwidth red flag.

--- a/docs/architecture/upstream-migration-execution-plan.md
+++ b/docs/architecture/upstream-migration-execution-plan.md
@@ -1,0 +1,1109 @@
+# Upstream Migration Execution Plan
+**Status:** READY FOR DECISION (BLOCKING: see Open Questions)
+**Date:** 2026-05-16
+**Author:** Architect 1 (commissioned by Dennis Vorobyov)
+**Builds on:** `docs/architecture/upstream-separation-plan.md` (the 827-line research synthesis)
+**Repo:** `/Users/macpro/Documents/Fox-In-the-Box/project` (v0.5.4 in tree)
+**Drift at time of writing:** 1,526 commits behind on `hermes-agent`, 1,238 behind on `hermes-webui`, growing ~70/day
+
+---
+
+## 1. Executive summary
+
+The 2026-05-08 research synthesis recommended a **hybrid** end state: re-point the `forks/hermes-{agent,webui}` submodules at virgin upstream pinned to a tag, hold all Fox-specific code in a sibling `packages/fox-overlay/` package, ship a curated patch series of ~9 lines / 2 files in webui (0 in agent), and adopt upstream's plugin manager (now 17 hooks) plus the `HERMES_WEBUI_EXTENSION_DIR` mechanism for everything additive. The Dockerfile gains three short stages: COPY upstream → apply patches → overlay. The Electron app, install scripts, supervisord, qdrant/llama.cpp tarballs, and the release/signing pipeline are all out of scope and untouched.
+
+This plan operationalizes that recommendation as a **10-phase migration** (one phase split out of the original 9 to honor anti-regression Rule 1: "one big change per release"). Total effort is **~14 engineering days** over a **~5-week calendar window** including the mandatory 48-hour soak after every tag bump that exposes user-facing change. Each phase produces a green Docker container and an individually revertible PR.
+
+The single highest-value early action is **Phase 0 (Upstream-PR campaign)**: send the 5 bug-fix-class FITB commits to NousResearch and nesquena. Each accepted PR shrinks the patch series forever, and three of the five (`runtime_provider.py`, `auxiliary_client.py`, `models.py` #1558) are textbook upstream candidates.
+
+The work is reversible at every phase. The only point-of-no-return is Phase 7 (submodule re-point), and even that is one `git revert` away from rollback because the submodule pointer is just a SHA in the parent repo.
+
+**Recommendation:** GO once the three Open Questions are resolved. The drift gap closes by ~70 commits per day; every week of delay adds ~2 days of patch resolution at first sync.
+
+---
+
+## 2. Dependency graph
+
+```
+                Phase 0 (PR campaign, async)
+                    │
+                    ▼
+Phase 1 ── Phase 2 ── Phase 3 ── Phase 4 ── Phase 5 ── Phase 6 ── Phase 7 ── Phase 8 ── Phase 9
+(scaffold) (statics)  (agent)   (patches) (additive) (modified) (onboard)  (re-point) (CI watch)
+                                                                                         │
+                                                                                         ▼
+                                                                              Phase 10 (cleanup)
+
+PARALLEL SAFE:
+  • Phase 0 runs throughout — async, depends on upstream review velocity, never blocks.
+  • Phase 2 and Phase 3 can run in parallel (different repos, different concerns).
+  • Phase 5's per-module migrations are independent; can be parallelized across one engineer
+    (commit-by-commit) or two (if a second pair of hands is available).
+
+STRICT SERIAL:
+  • Phase 4 must precede Phase 5/6 — the 9-line dispatcher patches are the ONLY way
+    additive Python modules can register routes.
+  • Phase 7 must follow Phases 1–6 — re-pointing the submodule before the overlay
+    can host everything Fox needs would break the build.
+  • Phase 8 (CI nightly upstream-watch) must follow Phase 7 — it has nothing to bump
+    until the submodule points at virgin upstream.
+  • Phase 9 cleanup must be last — deletes scaffolding the prior phases relied on.
+
+48-HOUR SOAK GATES (anti-regression Rule 2):
+  • Required after Phase 7 (submodule re-point — first user-visible structural change).
+  • Required after Phase 9 if any user-facing wording / asset / route changes during cleanup.
+  • Not required after intermediate phases that produce byte-identical runtime.
+```
+
+---
+
+## 3. Go / No-Go preconditions
+
+Do NOT start Phase 1 until **all** of the following are true.
+
+### Code preconditions
+
+- [ ] `main` is at v0.5.4 stable; no in-flight feature branches blocking on shared files (`api/routes.py`, `static/index.html`, `static/panels.js`, `api/streaming.py`, `api/onboarding.py`, `api/config.py`).
+- [ ] All v0.5.4 follow-on stabilization issues (#138/#139/#140) closed; smoke checklist Section L row for v0.5.4 passes against `:stable`.
+- [ ] No open PR on the fox-in-the-box-ai/hermes-{webui,agent} forks awaiting merge — they will be invalidated by the submodule re-point.
+- [ ] `.github/workflows/sync-submodules.yml` is **paused** (workflow_dispatch only, no `repository_dispatch`) for the duration of the migration. Auto-bumping mid-migration would whipsaw the pin.
+
+### Roadmap preconditions
+
+- [ ] Phase 1 (v0.5.5: `fox-guardrails` + Presidio PII per `project_roadmap_v0_5_to_v0_9.md`) is explicitly **paused** by Dennis, or the migration is sequenced to ship as v0.5.5 in place of guardrails. Per anti-regression Rule 1 ("one large change per release") the two cannot share a version.
+- [ ] Decision recorded on Open Question #1 (where this slots in roadmap).
+- [ ] Decision recorded on Open Question #2 (cadence: dedicated sprint vs. interleaved).
+- [ ] Decision recorded on Open Question #3 (Phase 0 PR campaign first or skip).
+
+### Team capacity preconditions
+
+- [ ] One engineer with 14 days of focused capacity over a 5-week window, OR two engineers with explicit ownership split (engineer A: Phases 1–4, 7; engineer B: Phases 5, 6, 8). Phase 5/6 splits naturally on per-module boundaries.
+- [ ] Dennis available for two scheduled review checkpoints: end of Phase 4 (patch series locked), end of Phase 7 (submodule re-point passed smoke).
+- [ ] Real-hardware tester available for the Phase 7 smoke (full SMOKE_CHECKLIST.md A–L, est. 30 min if green).
+
+### Infrastructure preconditions
+
+- [ ] Verification container pattern from `reference_test_container.md` works cleanly on Apple Silicon and an x86_64 host. Both required to catch architecture regressions like #114.
+- [ ] Standalone clones at `~/Documents/Fox-In-the-Box/hermes-{agent,webui}` have `upstream` remote configured with `push = DISABLED` (verified — they do).
+- [ ] Branch protection rules on `fox-in-the-box-ai/hermes-{webui,agent}` are confirmed not to block the planned `fitb-overlay-archive` tag push (Phase 7 step 7.3).
+
+If any box is unchecked, do not proceed. Document the blocker in the issue tracker.
+
+---
+
+## 4. Phases
+
+Each phase below includes: Goal, Prerequisites, Concrete file operations, Code skeletons (where load-bearing), Validation gates, Rollback procedure, Effort estimate, Suggested PR/issue split, and Risks specific to this phase.
+
+---
+
+### Phase 0 — Upstream-PR campaign (async, runs parallel to all other phases)
+
+**Goal.** Each accepted upstream PR removes one commit from Fox's permanent patch surface. Even partial acceptance reduces ongoing maintenance.
+
+**Prerequisites.** None. Runs entirely on the standalone clones; does not touch the monorepo.
+
+**Concrete file operations.** None in monorepo. In standalone clones, branch and PR per below.
+
+Targets (in priority order — bug fixes first, new behavior last):
+
+| # | Source path | Upstream | Branch | One-line scope |
+|---|---|---|---|---|
+| 1 | `hermes_cli/runtime_provider.py` | NousResearch/hermes-agent | `fitb/fix-target-model-bedrock` | One-line `target_model` fix for Bedrock api_mode routing |
+| 2 | `api/models.py` (#1558) | nesquena/hermes-webui | `fitb/fix-1558-metadata-save` | P0 metadata-only Session.save guard (data-loss class) |
+| 3 | `agent/auxiliary_client.py` | NousResearch/hermes-agent | `fitb/fix-provider-auto-fallback` | `provider=auto` resolution + `auxiliary.default` fallback |
+| 4 | `cron/{jobs,scheduler}.py` + `tools/cronjob_tools.py` | NousResearch/hermes-agent | `fitb/feat-cron-failure-diagnostics` | Rolling-5 failure history + diagnostics fields |
+| 5 | `api/providers.py` | nesquena/hermes-webui | `fitb/fix-providers-hot-reload` | Gateway hot-reload after key change |
+
+**Validation gates.** Each upstream PR must (a) include unit tests if the file has tests, (b) declare `Upstream-Status: Submitted <PR-URL>` in the corresponding Fox commit message in the standalone clone, (c) reference the FITB issue if any.
+
+**Rollback.** N/A — these are upstream PRs. If rejected, the patch stays in Fox's series; no monorepo state changes.
+
+**Effort estimate.** 1.5 engineering days spread across 1–4 weeks of upstream review latency. Assume ~30% acceptance rate → 1–2 commits removed.
+
+**Suggested PR/issue split.**
+- Issue: "Phase 0: Upstream PR campaign — track 5 candidate fixes" (parent tracking issue)
+- 5 PRs against upstreams as listed above; one Fox-side issue per PR to track upstream review.
+
+**Risks.**
+- Maintainers reject or sit on PRs for weeks. **Mitigation:** time-boxed; do not block the migration on Phase 0 outcomes.
+- A PR is accepted but lands with significant rework that conflicts with our patch. **Mitigation:** carry both versions until the corresponding Fox patch can be retired cleanly, then drop in Phase 9.
+
+---
+
+### Phase 1 — Scaffold `packages/fox-overlay/` skeleton
+
+**Goal.** Empty overlay package exists at `packages/fox-overlay/`, installable via `pip install -e`. Container builds and runs identically to today (overlay imports nothing, registers nothing). PR is mergeable to `main` with zero behavior change.
+
+**Prerequisites.** Go/No-Go checklist passed. No prior phase required.
+
+**Concrete file operations.**
+
+```
+packages/fox-overlay/
+├── pyproject.toml                          # NEW
+├── MANIFEST.toml                           # NEW (empty inventory placeholder)
+├── README.md                               # NEW (one-paragraph description + link to this doc)
+├── .fox-removals                           # NEW (empty file; one-path-per-line manifest)
+├── fox_overlay/                            # NEW package
+│   ├── __init__.py                         # NEW (empty)
+│   ├── bootstrap.py                        # NEW (no-op skeleton — see code below)
+│   ├── webui_modules/                      # NEW (empty package, ready for Phase 5)
+│   │   └── __init__.py
+│   ├── webui_patches/                      # NEW (empty package, ready for Phase 6)
+│   │   └── __init__.py
+│   └── agent_plugins/                      # NEW (empty package, ready for Phase 3)
+│       └── __init__.py
+├── webui_static/                           # NEW (empty dir, .gitkeep)
+│   └── .gitkeep
+├── patches/                                # NEW
+│   ├── webui/
+│   │   └── series                          # NEW (empty)
+│   └── agent/
+│       └── series                          # NEW (empty)
+└── scripts/
+    └── check-overlay-basis.sh              # NEW (no-op stub returning 0)
+```
+
+`pyproject.toml` skeleton:
+
+```toml
+[project]
+name = "fox-overlay"
+version = "0.0.1"
+description = "Fox in the Box overlay for hermes-agent and hermes-webui"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.entry-points."hermes_agent.plugins"]
+# fox_overlay = "fox_overlay:register"   # commented until Phase 3
+
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["fox_overlay*"]
+```
+
+`fox_overlay/bootstrap.py` (load-bearing skeleton, will grow in Phases 4/6):
+
+```python
+"""Fox overlay bootstrap. Imported by hermes-webui's server.py before any api.* imports.
+
+Phase 1: no-op. Phases 4–6 will populate install() with monkey-patches and dispatcher
+registration. Until then this module exists so the import line in server.py is harmless.
+"""
+import logging
+
+_log = logging.getLogger("fox_overlay.bootstrap")
+_INSTALLED = False
+
+
+def install() -> None:
+    """Apply Fox overlay to a running hermes-webui process. Idempotent."""
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    _INSTALLED = True
+    _log.info("[fox-overlay] bootstrap installed (no-op skeleton)")
+
+
+# Auto-install on import. Anything that imports fox_overlay.bootstrap gets the patch.
+install()
+```
+
+**Dockerfile changes (this phase): none.** The overlay package exists in the tree but isn't `pip install`'d yet. Behavior is unchanged.
+
+**Validation gates.**
+- `pip install -e packages/fox-overlay` from a fresh venv succeeds without errors.
+- `python -c "import fox_overlay.bootstrap"` prints the install log line and exits 0.
+- Build the verification container (port 8788) per `reference_test_container.md`. Run smoke A1–A4 only. All green.
+- `git diff main...HEAD` — only adds files under `packages/fox-overlay/`. No edits to existing files.
+
+**Rollback.** `git revert <merge-commit>`. The overlay dir disappears; no other code touched.
+
+**Effort estimate.** 4 hours.
+
+**Suggested PR/issue split.**
+- PR: "phase 1: scaffold packages/fox-overlay/ (no behavior change)"
+
+**Risks.**
+- `pip install -e` interaction with existing `packages/electron/` workspace if pnpm-workspace.yaml accidentally globs it. **Mitigation:** verify `pnpm-workspace.yaml` only enumerates JS packages.
+- Future `setuptools.packages.find` ambiguity if other dirs are added under `packages/`. **Mitigation:** `include = ["fox_overlay*"]` is explicit.
+
+---
+
+### Phase 2 — Move static files into overlay; wire `HERMES_WEBUI_EXTENSION_DIR`
+
+**Goal.** Every Fox-only static asset (CSS, JS, fonts, images, setup wizard HTML) lives in `packages/fox-overlay/webui_static/`. The container serves them through upstream's existing `extensions.py` mechanism. The fork's `static/` directory shrinks by exactly the count of Fox-only files. Runtime is byte-identical to today (verified by checksum diff).
+
+**Prerequisites.** Phase 1 merged.
+
+**Concrete file operations.**
+
+Move (preserving git history with `git mv`):
+
+```
+forks/hermes-webui/static/fox-in-the-box.css   → packages/fox-overlay/webui_static/fox-in-the-box.css
+forks/hermes-webui/static/fox-in-the-box.js    → packages/fox-overlay/webui_static/fox-overlay.js
+forks/hermes-webui/static/fox_avatar_cropped.jpg → packages/fox-overlay/webui_static/images/fox_avatar_cropped.jpg
+forks/hermes-webui/static/fonts/*              → packages/fox-overlay/webui_static/fonts/
+forks/hermes-webui/static/setup.html           → packages/fox-overlay/webui_static/setup.html
+forks/hermes-webui/static/setup.css            → packages/fox-overlay/webui_static/setup.css
+forks/hermes-webui/static/setup.js             → packages/fox-overlay/webui_static/setup.js
+forks/hermes-webui/static/onboarding-preview.js → packages/fox-overlay/webui_static/onboarding-preview.js
+forks/hermes-webui/static/fallback-polish.js   → packages/fox-overlay/webui_static/fallback-polish.js
+forks/hermes-webui/static/hostname-prompt.js   → packages/fox-overlay/webui_static/hostname-prompt.js
+forks/hermes-webui/static/apple-touch-icon.png → packages/fox-overlay/webui_static/apple-touch-icon.png
+```
+
+(NOTE: `git mv` across submodule boundary requires per-submodule branches: branch in standalone hermes-webui clone for the deletion, branch in monorepo for the addition; merge fork-side first, then bump the submodule pointer atomically with the monorepo PR per `feedback_cross_repo_cohesion.md`.)
+
+Append to `packages/fox-overlay/MANIFEST.toml`:
+
+```toml
+[static]
+fox-in-the-box.css   = "fox-only"
+fox-overlay.js       = "fox-only"
+setup.html           = "fox-only"
+setup.css            = "fox-only"
+setup.js             = "fox-only"
+# ... etc
+```
+
+Add to `packages/fox-overlay/.fox-removals` — these are upstream onboarding files Fox deletes:
+
+```
+static/onboarding.js
+tests/test_issue1499_keyless_onboarding.py
+tests/test_issue1499_onboarding_probe.py
+tests/test_onboarding_existing_config.py
+tests/test_onboarding_mvp.py
+tests/test_onboarding_network.py
+tests/test_onboarding_static.py
+```
+
+Edit `packages/integration/Dockerfile` — insert immediately after the existing line 128 (`COPY forks/hermes-webui /app/hermes-webui`):
+
+```dockerfile
+# ── Fox overlay: static files ─────────────────────────────────────────────────
+COPY packages/fox-overlay/webui_static /app/fox-overlay/webui_static
+ENV HERMES_WEBUI_EXTENSION_DIR=/app/fox-overlay/webui_static \
+    HERMES_WEBUI_EXTENSION_SCRIPT_URLS=/extensions/fox-overlay.js \
+    HERMES_WEBUI_EXTENSION_STYLESHEET_URLS=/extensions/fox-in-the-box.css
+```
+
+Edit `forks/hermes-webui/static/index.html` (in the standalone fork): remove the explicit `<link>` to `fox-in-the-box.css` and the explicit `<script>` for `fox-in-the-box.js` — the `extensions.py` injector will now provide them.
+
+**Validation gates.**
+- Smoke checklist Section A (container health) all green.
+- Section B (onboarding wizard B1–B9) all green — the wizard is the highest-risk asset because it's served from `setup.html`.
+- Section C (settings persistence) green — fonts/CSS unaffected.
+- View-source comparison: `curl http://127.0.0.1:8788/` before vs after must contain (a) the `<link rel="stylesheet" href="/extensions/fox-in-the-box.css">` injection, (b) the `<script defer src="/extensions/fox-overlay.js">` injection, (c) all other markup byte-identical except those two diffs.
+- HTTP status 200 on `/extensions/fox-in-the-box.css`, `/extensions/fox-overlay.js`, `/extensions/setup.html`, `/extensions/setup.js`, `/extensions/setup.css`, all font files.
+- File checksums (sha256) of every moved asset match before vs. after.
+
+**Rollback.** Two-step revert: (a) revert monorepo PR (drops the COPY + ENV vars and the .fox-removals append); (b) revert hermes-webui fork PR (restores `static/*` files). Both are clean reverts. Submodule pointer rolls back automatically when the monorepo PR is reverted.
+
+**Effort estimate.** 1 engineering day (1 day fork-side, 0.5 day monorepo-side; overlap with the cohesion sequencing).
+
+**Suggested PR/issue split.**
+- Fork PR: "phase 2a (webui): move Fox-only static assets out of static/ — to be served via HERMES_WEBUI_EXTENSION_DIR"
+- Monorepo PR: "phase 2b: serve Fox static via overlay extension dir; bump hermes-webui submodule"
+
+**Risks.**
+- Some upstream code (e.g. `static/index.html` or `boot.js`) hard-references one of the moved file paths (e.g. `/static/fox-in-the-box.css` literal). **Mitigation:** `grep -r "fox-in-the-box\|fox_avatar\|setup.html\|setup.js" forks/hermes-webui/` before moving; rewrite or proxy.
+- Service worker (`sw.js`) caches the old paths. **Mitigation:** the smoke checklist mandates `sw.js` cache disable verification (Section A2). Bump the SW version string in the overlay JS to invalidate.
+- Font MIME types not in `extensions.py`'s `_EXTENSION_MIME` map. **Mitigation:** verify `_EXTENSION_MIME` covers `woff`, `woff2`, `ttf`, `otf`; if not, this becomes a 1-line upstream PR (Phase 0 candidate #6) OR a one-line monkey-patch in the bootstrap shim.
+- Cap of 32 URLs per env var (per `extensions.py`). Fox's overlay JS/CSS is comma-separated; comma-joining stays under cap.
+
+---
+
+### Phase 3 — Migrate hermes-agent plugin + bootstrap monkey-patches
+
+**Goal.** All hermes-agent customizations live in `packages/fox-overlay/fox_overlay/agent_plugins/` and are loaded via the upstream plugin manager's `hermes_agent.plugins` entry-point. The `mem0_oss` plugin gets the missing `kind: backend` field added to its manifest. The 5 modified-file customizations in hermes-agent become monkey-patches applied at agent startup. **Zero patches** in hermes-agent fork.
+
+**Prerequisites.** Phase 1 merged. Can run concurrently with Phase 2.
+
+**Concrete file operations.**
+
+In monorepo:
+
+```
+packages/fox-overlay/fox_overlay/agent_plugins/
+├── __init__.py                              # NEW (entry-point target — see below)
+├── fox_overlay_plugin/                      # NEW
+│   ├── __init__.py                          # NEW (register() function — see below)
+│   ├── plugin.yaml                          # NEW (manifest with kind: backend)
+│   └── monkey_patches/
+│       ├── __init__.py
+│       ├── runtime_provider.py              # NEW (target_model fix as patch)
+│       ├── auxiliary_client.py              # NEW (provider=auto fallback as patch)
+│       └── cron_diagnostics.py              # NEW (3 cron file changes as patches)
+└── mem0_oss/                                # MOVED from forks/hermes-agent/plugins/memory/mem0_oss/
+    ├── __init__.py                          # (unchanged source)
+    ├── README.md                            # (unchanged source)
+    └── plugin.yaml                          # MODIFIED: add `kind: backend`
+```
+
+Update `pyproject.toml` entry-points:
+
+```toml
+[project.entry-points."hermes_agent.plugins"]
+fox_overlay = "fox_overlay.agent_plugins:register"
+mem0_oss = "fox_overlay.agent_plugins.mem0_oss:register"
+```
+
+`fox_overlay/agent_plugins/__init__.py` skeleton:
+
+```python
+"""Fox overlay registration for hermes-agent's plugin manager.
+
+Called by hermes_cli.plugins.PluginManager.discover_and_load via the
+'hermes_agent.plugins' entry-point group. Applies bootstrap monkey-patches
+at register() time so they're in place before any code path runs.
+"""
+from .fox_overlay_plugin.monkey_patches import (
+    runtime_provider, auxiliary_client, cron_diagnostics,
+)
+
+
+def register(ctx):
+    """Entry point. ctx is a PluginContext from hermes_cli.plugins."""
+    runtime_provider.apply()
+    auxiliary_client.apply()
+    cron_diagnostics.apply()
+    # Future: ctx.register_hook("transform_llm_output", fox_guardrails.transform)
+```
+
+Each monkey-patch module follows this pattern (example — `runtime_provider.py`):
+
+```python
+"""Fox patch: use target_model for Bedrock api_mode routing.
+
+Replaces the 1-line bug in upstream resolve_runtime_provider. If accepted
+upstream (Phase 0 PR #1), this module becomes dead code and is removed in Phase 9.
+"""
+import inspect
+from hermes_cli import runtime_provider
+
+_PATCHED_SENTINEL = "_fox_patched_target_model"
+
+
+def apply():
+    if getattr(runtime_provider.resolve_runtime_provider, _PATCHED_SENTINEL, False):
+        return
+    original = runtime_provider.resolve_runtime_provider
+    sig = inspect.signature(original)
+    assert "target_model" in sig.parameters or "model" in sig.parameters, (
+        "[fox-overlay] upstream signature changed; refresh patch")
+
+    def patched(*args, **kwargs):
+        # ... fixed body here ...
+        return original(*args, **kwargs)
+
+    patched._fox_patched_target_model = True
+    runtime_provider.resolve_runtime_provider = patched
+    import logging
+    logging.getLogger("fox-overlay").info(
+        "[fox-overlay] patched hermes_cli.runtime_provider.resolve_runtime_provider")
+```
+
+In hermes-agent fork (standalone clone), branch `fitb/phase3-restore-upstream`:
+- Delete the 5 modified-file Fox edits (`hermes_cli/runtime_provider.py`, `agent/auxiliary_client.py`, `cron/jobs.py`, `cron/scheduler.py`, `tools/cronjob_tools.py`) — restore upstream content.
+- Delete `plugins/memory/mem0_oss/` — relocated.
+- Keep `.github/workflows/notify-monorepo.yml` as-is (Fox-side CI).
+
+Edit `packages/integration/Dockerfile` (after the existing line 130 `pip install -e /app/hermes-agent`):
+
+```dockerfile
+# ── Fox overlay: install package; entry-points wire into hermes_agent.plugins ─
+COPY packages/fox-overlay /app/fox-overlay
+RUN pip install --no-cache-dir -e /app/fox-overlay
+```
+
+**Validation gates.**
+- `hermes plugins list` (executed inside the container) shows `fox_overlay` and `mem0_oss` registered.
+- `hermes` startup logs include four `[fox-overlay] patched ...` lines.
+- mem0 memory operations succeed end-to-end (Section D scenarios in smoke).
+- Cron failure diagnostics still surface in `cron list-failures` (carry forward from v0.4.x cron tests).
+- Agent boots cleanly with `--check` (no missing-attribute traceback from the monkey-patch self-tests).
+
+**Rollback.** Two-step revert: (a) monorepo PR revert removes the overlay install line and entry-points; (b) hermes-agent fork PR revert restores the 5 modified files + mem0_oss directory. Submodule pointer rolls back via the monorepo revert.
+
+**Effort estimate.** 1.5 engineering days (heavier than Phase 2 because of the inspect-based safety checks).
+
+**Suggested PR/issue split.**
+- Fork PR: "phase 3a (agent): restore upstream content for 5 files; remove mem0_oss (relocated to fox-overlay)"
+- Monorepo PR: "phase 3b: implement fox-overlay agent plugin + monkey-patches; bump hermes-agent submodule"
+
+**Risks.**
+- One of the 5 files has been refactored upstream beyond what the monkey-patch can wrap. **Mitigation:** the `inspect.signature` self-test fires at startup; CI catches it.
+- mem0_oss `plugin.yaml` schema requires more than `kind` (per upstream v0.13.0 plugin manifest validation). **Mitigation:** follow `forks/hermes-agent/plugins/memory/mem0/plugin.yaml` (sibling reference plugin) as the schema oracle.
+- Entry-point name collision with another plugin in `~/.hermes/plugins/`. **Mitigation:** namespace as `fox_overlay` (already done).
+
+---
+
+### Phase 4 — Land 9-line webui patches (the only mid-file edits)
+
+**Goal.** Two minimal patches exist in `packages/fox-overlay/patches/webui/`. The fork's `server.py` has a 3-line bootstrap import; the fork's `api/routes.py` has 6 lines (3 in `handle_get`, 3 in `handle_post`) calling `fox_overlay.dispatch()` before falling through. With overlay absent, the patches are no-ops (the `import` fails silently in a `try/except`; the dispatch returns False). Patch series file is populated and ordered.
+
+**Prerequisites.** Phases 1, 3 merged. Phase 2 strongly recommended (so the static side already proves the overlay is loadable).
+
+**Concrete file operations.**
+
+Create `packages/fox-overlay/patches/webui/series`:
+
+```
+001-server-py-bootstrap.patch
+002-routes-py-dispatch-hook.patch
+```
+
+Create `packages/fox-overlay/patches/webui/001-server-py-bootstrap.patch`:
+
+```diff
+--- a/server.py
++++ b/server.py
+@@ -1,5 +1,8 @@
+ import os
+ import sys
++try:
++    import fox_overlay.bootstrap  # noqa: F401  -- installs Fox patches at import
++except ImportError:
++    pass
+ import threading
+```
+
+Create `packages/fox-overlay/patches/webui/002-routes-py-dispatch-hook.patch`:
+
+```diff
+--- a/api/routes.py
++++ b/api/routes.py
+@@ -42,6 +42,9 @@
+ def handle_get(handler, parsed):
++    from fox_overlay import dispatch  # lazy import — no-op if unavailable
++    if dispatch.handle_get(handler, parsed):
++        return True
+     # existing upstream body unchanged below
+@@ -612,6 +615,9 @@
+ def handle_post(handler, parsed):
++    from fox_overlay import dispatch  # lazy import — no-op if unavailable
++    if dispatch.handle_post(handler, parsed):
++        return True
+     # existing upstream body unchanged below
+```
+
+Create `packages/fox-overlay/fox_overlay/dispatch.py`:
+
+```python
+"""Fox dispatcher. Called by the 6-line patch in api/routes.py before upstream body.
+
+Phase 4: skeleton — handle_get/handle_post return False (no-op) until Phase 5
+populates the dispatch table.
+"""
+from typing import Any
+
+_GET_TABLE: dict = {}
+_POST_TABLE: dict = {}
+
+
+def register_get(path_prefix: str, handler):
+    _GET_TABLE[path_prefix] = handler
+
+
+def register_post(path_prefix: str, handler):
+    _POST_TABLE[path_prefix] = handler
+
+
+def handle_get(handler, parsed) -> bool:
+    for prefix, fn in _GET_TABLE.items():
+        if parsed.path.startswith(prefix):
+            return bool(fn(handler, parsed))
+    return False
+
+
+def handle_post(handler, parsed) -> bool:
+    for prefix, fn in _POST_TABLE.items():
+        if parsed.path.startswith(prefix):
+            return bool(fn(handler, parsed))
+    return False
+```
+
+Edit Dockerfile to apply patches between the upstream COPY and the overlay COPY (insert between lines 128 and 130):
+
+```dockerfile
+# ── Fox patch series (mid-file edits we cannot express as overlay) ────────────
+COPY packages/fox-overlay/patches/webui /tmp/p
+RUN cd /app/hermes-webui \
+ && for p in $(grep -v '^\s*$\|^\s*#' /tmp/p/series); do \
+        echo "Applying $p"; \
+        git apply --check "/tmp/p/$p" || { echo "::error::patch $p failed --check"; exit 1; }; \
+        git apply "/tmp/p/$p"; \
+    done \
+ && rm -rf /tmp/p
+```
+
+(NOTE: `git apply` requires `git` in the image — already installed.)
+
+In hermes-webui standalone fork, on a `fitb/phase4-restore-upstream-server-routes` branch: revert the existing Fox edits to `server.py` and `api/routes.py`. The patches in monorepo are now the source of truth for those edits.
+
+**Validation gates.**
+- `git apply --check` succeeds against the pinned upstream during build (it currently still points at fox fork — that's fine; the patch file is small enough to apply cleanly to either base).
+- Container starts; `[fox-overlay] bootstrap installed` log line appears.
+- All Section A–B–C smoke checks green.
+- `curl /api/setup/skip` (POST) returns 200 — confirms Phase 5/6 dispatch path is wired but empty.
+- Behavior is byte-identical to before this phase for any path Fox has not yet migrated (because the dispatch table is empty).
+
+**Rollback.** (a) revert monorepo PR (drops the patches + Dockerfile changes); (b) revert hermes-webui fork PR (restores `server.py` and `api/routes.py` Fox edits inline).
+
+**Effort estimate.** 0.5 engineering days.
+
+**Suggested PR/issue split.**
+- Fork PR: "phase 4a (webui): restore upstream server.py + api/routes.py (Fox edits move to overlay patch series)"
+- Monorepo PR: "phase 4b: introduce fox-overlay patch series + Dockerfile apply step + dispatcher skeleton"
+
+**Risks.**
+- The 3-line `import fox_overlay.bootstrap` block runs before logging is configured. **Mitigation:** swallow the ImportError silently; log line emits later from inside `install()`.
+- A future upstream refactor of `handle_get` shifts line numbers beyond `git apply`'s default fuzz tolerance (3 lines). **Mitigation:** the patches use anchor lines (`def handle_get(handler, parsed):`) that are extremely stable; if drift exceeds tolerance, refresh the patch in CI before bump.
+- The `_ensure_active_branch()` startup hook (still present in current `server.py`) is now misaligned with the new model. **Mitigation:** delete `_ensure_active_branch()` in the same fork PR (it becomes dead code once the submodule re-points in Phase 7; deleting it now is harmless).
+
+---
+
+### Phase 5 — Migrate additive webui Python modules into overlay
+
+**Goal.** Six fully-additive Python modules (`api/ollama.py`, `api/tailscale.py`, `api/local_fallback.py`, `api/models_download.py`, `api/hostname.py`, `api/session_recovery.py`) live in `packages/fox-overlay/fox_overlay/webui_modules/`. Each registers its routes via the dispatcher introduced in Phase 4. Fork's `api/` directory shrinks by 6 files. No mid-file upstream edits in this phase.
+
+**Prerequisites.** Phase 4 merged.
+
+**Concrete file operations.**
+
+For each of the 6 modules, repeat:
+
+1. In standalone hermes-webui fork: `git rm api/<module>.py`.
+2. In monorepo: place the same file at `packages/fox-overlay/fox_overlay/webui_modules/<module>.py`.
+3. Adapt imports: `from api.helpers import ...` becomes `from api.helpers import ...` (still works — these still ship as upstream; the overlay imports them at module-load time).
+4. At the bottom of each migrated module, register routes:
+
+```python
+# At bottom of fox_overlay/webui_modules/ollama.py:
+from fox_overlay import dispatch
+
+def _register():
+    dispatch.register_get("/api/ollama/", handle_ollama_get)
+    dispatch.register_post("/api/ollama/", handle_ollama_post)
+
+_register()
+```
+
+5. Update `packages/fox-overlay/MANIFEST.toml`:
+
+```toml
+[python]
+"fox_overlay.webui_modules.ollama"           = "fox-only-additive"
+"fox_overlay.webui_modules.tailscale"        = "fox-only-additive"
+"fox_overlay.webui_modules.local_fallback"   = "fox-only-additive"
+"fox_overlay.webui_modules.models_download"  = "fox-only-additive"
+"fox_overlay.webui_modules.hostname"         = "fox-only-additive"
+"fox_overlay.webui_modules.session_recovery" = "fox-only-additive"
+```
+
+6. Add eager imports to `fox_overlay/__init__.py` so registration fires on import:
+
+```python
+from .webui_modules import (
+    ollama, tailscale, local_fallback, models_download, hostname, session_recovery,
+)
+```
+
+**Validation gates.** Per migrated module, run the corresponding smoke checklist section:
+- `ollama.py` → Section D5–D7
+- `tailscale.py` → Section E full
+- `local_fallback.py` + `models_download.py` → Section F full + G + H
+- `hostname.py` → Section I
+- `session_recovery.py` → Section L (#127–#129 carry-forward)
+
+**Rollback.** Per-module revert. Each migration is a standalone PR with its own fork-PR pair and monorepo-PR pair.
+
+**Effort estimate.** 2 engineering days (one ~1.5h slot per module; the `local_fallback`/`tailscale`/`session_recovery` triad takes longer because their smoke sections take longer).
+
+**Suggested PR/issue split.** One PR per module pair (fork side + monorepo side):
+- "phase 5a (webui-fork): remove api/ollama.py — migrated to overlay"
+- "phase 5b (monorepo): host api/ollama via fox-overlay; bump hermes-webui submodule"
+- ... repeat for each of the 6 modules
+
+**Risks.**
+- A migrated module references a private upstream symbol that gets renamed. **Mitigation:** import-time check for symbol existence with `getattr(module, "_private_thing", None)`; log + degrade gracefully.
+- Two migrated modules accidentally register overlapping path prefixes in the dispatcher. **Mitigation:** dispatcher logs every registration at INFO; unit-test in `packages/fox-overlay/tests/test_dispatch_no_overlap.py` (add in this phase).
+- The dispatcher's `startswith()` matching is too permissive (e.g. `/api/ollamax` would match `/api/ollama/`). **Mitigation:** require trailing slash in registered prefixes, OR switch to exact-prefix-with-segment-boundary; document the contract in `dispatch.py` docstring.
+
+---
+
+### Phase 6 — Migrate modified-upstream webui patches as monkey-patches
+
+**Goal.** Five files Fox edits mid-stream (`api/streaming.py`, `api/models.py`, `api/config.py`, `api/providers.py`, `api/updates.py`) become monkey-patches in `packages/fox-overlay/fox_overlay/webui_patches/`. Fork restores those files to upstream content. Each monkey-patch logs at startup. No corresponding patch in the patch series — these are runtime mutations, not static patches.
+
+**Prerequisites.** Phase 4 merged. Phase 5 strongly recommended (proves the overlay-import lifecycle works end-to-end before adding monkey-patches that depend on it).
+
+**Concrete file operations.**
+
+For each modified file, create a `webui_patches/<name>.py`. Skeleton example for `streaming.py` (silent-failover-to-local-on-remote-error):
+
+```python
+"""Fox patch: silent failover to local model on remote provider error (#129b)."""
+import inspect
+from api import streaming as _u
+
+_PATCHED = "_fox_patched_streaming"
+
+
+def apply():
+    if getattr(_u._handle_provider_error, _PATCHED, False):
+        return
+    original = _u._handle_provider_error
+    # signature self-check
+    sig = inspect.signature(original)
+    assert {"context", "error"}.issubset(sig.parameters), (
+        "[fox-overlay] api.streaming._handle_provider_error signature changed; "
+        "refresh patch fox_overlay/webui_patches/streaming.py")
+
+    def patched(context, error, *a, **kw):
+        # ... Fox failover body here ...
+        return original(context, error, *a, **kw)
+
+    patched._fox_patched_streaming = True
+    _u._handle_provider_error = patched
+    import logging
+    logging.getLogger("fox-overlay").info(
+        "[fox-overlay] patched api.streaming._handle_provider_error")
+```
+
+Repeat for: `models.py` (Session.save metadata-only fix #1558), `config.py` (Tailscale + fallback + Ollama URL config keys), `providers.py` (gateway hot-reload), `updates.py` (rewritten or deleted — Phase 9 may delete entirely).
+
+Append all patch invocations to `fox_overlay/bootstrap.py`:
+
+```python
+def install() -> None:
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    _INSTALLED = True
+    from .webui_patches import streaming, models, config, providers
+    streaming.apply(); models.apply(); config.apply(); providers.apply()
+    _log.info("[fox-overlay] bootstrap installed (5 webui patches)")
+```
+
+In standalone hermes-webui fork: revert the 5 files to upstream content.
+
+**Validation gates.**
+- All 4 `[fox-overlay] patched api.<file>.<symbol>` log lines appear in container startup logs.
+- Smoke Section D (provider switching) green — covers `models.py`, `providers.py`, `config.py`.
+- Smoke Section G (reactive failover) and Section H (recovery banner) green — covers `streaming.py`.
+- Settings persistence (Section C) green — covers `config.py`.
+- Specifically test #1558 regression: existing `test_metadata_save_wipe_1558.py` (which stays in fork's `tests/` since it's a Fox-authored test) must pass.
+
+**Rollback.** Per-patch revert — each patch is a separate file. The monorepo PR can be staged as 5 sequential commits (one per patch) so individual reverts don't disturb other patches.
+
+**Effort estimate.** 3 engineering days. This is the highest-effort phase because each monkey-patch needs a signature check, a smoke section, and a rollback test.
+
+**Suggested PR/issue split.** Five PRs in monorepo (one per patch), one fork PR per release of monorepo PRs. Per anti-regression Rule 1 ("one large change per release"), Phase 6 itself is one logical change so the 5 sub-PRs can land in one merge window.
+- "phase 6 (webui-fork): restore upstream content for streaming.py, models.py, config.py, providers.py, updates.py"
+- "phase 6a (monorepo): monkey-patch streaming silent failover"
+- "phase 6b (monorepo): monkey-patch models Session.save #1558"
+- "phase 6c (monorepo): monkey-patch config Fox env vars"
+- "phase 6d (monorepo): monkey-patch providers gateway hot-reload"
+- "phase 6e (monorepo): patch or delete updates.py (covered by submodule re-point in Phase 7)"
+
+**Risks.**
+- Order of monkey-patches matters: `config.py` must apply before any module reads its settings. **Mitigation:** `bootstrap.install()` orders `config` first; document the order constraint.
+- Upstream renamed `_handle_provider_error`. **Mitigation:** the inspect.signature self-test fires at import; CI fails fast.
+- A monkey-patch double-applies because two import paths hit `bootstrap.install()`. **Mitigation:** `_INSTALLED` global gate (already in skeleton).
+
+---
+
+### Phase 7 — Wholesale-replace `api/onboarding.py` and handle deleted `static/onboarding.js`
+
+**Goal.** Fox's onboarding flow lives entirely in `packages/fox-overlay/fox_overlay/webui_modules/onboarding.py`, registered via the dispatcher. Upstream's `api/onboarding.py` is unchanged (no patch); when both are loaded, Fox's dispatcher fires first and upstream's becomes dead code. The `static/onboarding.js` file is removed via the `.fox-removals` manifest.
+
+**Prerequisites.** Phases 4 and 5 merged.
+
+**Concrete file operations.**
+
+Move `forks/hermes-webui/api/onboarding.py` → `packages/fox-overlay/fox_overlay/webui_modules/onboarding.py` (same `git mv` cross-submodule pattern as Phase 5).
+
+Wrap the module so it claims the relevant route prefixes:
+
+```python
+# At bottom of fox_overlay/webui_modules/onboarding.py:
+from fox_overlay import dispatch
+dispatch.register_get("/api/onboarding/", _fox_onboarding_get)
+dispatch.register_post("/api/onboarding/", _fox_onboarding_post)
+dispatch.register_get("/setup", _fox_setup_html)        # Fox's setup wizard HTML
+dispatch.register_post("/api/setup/", _fox_setup_post)  # Fox's setup wizard endpoints
+```
+
+Append to `.fox-removals`:
+
+```
+static/onboarding.js
+```
+
+(Already added in Phase 2; verify no duplication.)
+
+In standalone hermes-webui fork: `git rm api/onboarding.py`. Restore upstream onboarding tests that we deleted (`test_issue1499_*`, `test_onboarding_*`) — they will now run against the upstream module; if they pass, great; if they fail because Fox's dispatcher intercepts, document and skip-mark them with `pytest.mark.skipif(os.environ.get("FOX_OVERLAY"))` upstream-rebased.
+
+Add to Dockerfile (after the `pip install -e fox-overlay` line):
+
+```dockerfile
+# ── Apply Fox removals: upstream files Fox does not ship ──────────────────────
+RUN cd /app/hermes-webui \
+ && grep -v '^\s*$\|^\s*#' /app/fox-overlay/.fox-removals \
+    | xargs -r -I{} rm -f -- {}
+```
+
+**Validation gates.**
+- Smoke Section B (B1–B9) all green — full wizard walk-through.
+- Smoke Section L row for #122 (always-3-step flow) green.
+- `curl /api/onboarding/status` returns Fox's response shape, not upstream's.
+- `curl /static/onboarding.js` returns 404.
+- Upstream onboarding tests skip cleanly (no errors).
+
+**Rollback.** Per the Phase 2/Phase 5 pattern: revert monorepo PR + revert fork PR. The `.fox-removals` manifest reverts atomically with the monorepo PR.
+
+**Effort estimate.** 1 engineering day.
+
+**Suggested PR/issue split.**
+- Fork PR: "phase 7a (webui): remove api/onboarding.py — Fox dispatcher takes over"
+- Monorepo PR: "phase 7b: host Fox onboarding via overlay; remove upstream onboarding.js via .fox-removals"
+
+**Risks.**
+- Upstream's onboarding has shipped Codex OAuth + new flows since Fox forked. Hidden routes (e.g. `/api/onboarding/codex-callback`) Fox doesn't claim get served by upstream and confuse users. **Mitigation:** Fox's dispatcher claims `/api/onboarding/` (full prefix) — upstream's body never runs for those URLs. If Codex OAuth is desired, ship as a separate Fox feature later.
+- `_ensure_active_branch()` in fork's `server.py` was already deleted in Phase 4. Re-confirm it's gone.
+
+---
+
+### Phase 8 — Re-point submodules at upstream tags; switch Dockerfile to multi-stage
+
+**Goal.** `forks/hermes-webui` submodule URL = `https://github.com/nesquena/hermes-webui.git`, pinned to tag `v0.51.22` (or current latest). `forks/hermes-agent` submodule URL = `https://github.com/NousResearch/hermes-agent.git`, pinned to `v2026.5.7` (= v0.13.0). `versions.toml` records both. The Dockerfile gains a multi-stage layout. **This is the point of structural change** — first phase requiring the 48-hour soak per anti-regression Rule 2.
+
+**Prerequisites.** Phases 1–7 merged. All smoke checks green against the existing Fox-fork-pinned submodules. Patch series in `packages/fox-overlay/patches/webui/` confirmed to apply against the chosen upstream tag (dry-run before merging this phase's PR).
+
+**Concrete file operations.**
+
+Create `versions.toml` at repo root:
+
+```toml
+[upstream]
+hermes_agent_tag = "v2026.5.7"          # = hermes-agent v0.13.0, 2026-05-07
+hermes_webui_tag = "v0.51.22"           # 2026-05-07
+```
+
+Edit `.gitmodules`:
+
+```ini
+[submodule "forks/hermes-agent"]
+        path = forks/hermes-agent
+        url = https://github.com/NousResearch/hermes-agent.git
+        branch = v2026.5.7
+[submodule "forks/hermes-webui"]
+        path = forks/hermes-webui
+        url = https://github.com/nesquena/hermes-webui.git
+        branch = v0.51.22
+[submodule "forks/figma-mcp"]
+        # unchanged
+```
+
+Re-pin the submodule SHAs:
+
+```bash
+cd /Users/macpro/Documents/Fox-In-the-Box/project
+git submodule sync forks/hermes-webui
+git submodule sync forks/hermes-agent
+git -C forks/hermes-webui fetch --tags origin
+git -C forks/hermes-webui checkout v0.51.22
+git -C forks/hermes-agent fetch --tags origin
+git -C forks/hermes-agent checkout v2026.5.7
+git add forks/hermes-{webui,agent}
+```
+
+Restructure Dockerfile (replace lines 127–139 of current Dockerfile with):
+
+```dockerfile
+# ── Hermes app source (virgin upstream submodules) ────────────────────────────
+COPY forks/hermes-agent /app/hermes-agent
+COPY forks/hermes-webui /app/hermes-webui
+
+# ── Apply Fox patch series ────────────────────────────────────────────────────
+COPY packages/fox-overlay/patches /tmp/fox-patches
+RUN set -eux; \
+    for sub in webui agent; do \
+        if [ -f "/tmp/fox-patches/$sub/series" ]; then \
+            cd "/app/hermes-$sub"; \
+            for p in $(grep -v '^\s*$\|^\s*#' "/tmp/fox-patches/$sub/series"); do \
+                echo "[fox-patch] applying $sub/$p"; \
+                git apply --check "/tmp/fox-patches/$sub/$p" \
+                  || { echo "::error::patch $sub/$p failed --check against pinned upstream"; exit 1; }; \
+                git apply "/tmp/fox-patches/$sub/$p"; \
+            done; \
+        fi; \
+    done; \
+    rm -rf /tmp/fox-patches
+
+# ── Install upstream packages ─────────────────────────────────────────────────
+RUN set -eux; \
+    pip install --no-cache-dir -e /app/hermes-agent --quiet; \
+    if [ -f /app/hermes-webui/pyproject.toml ] || [ -f /app/hermes-webui/setup.py ]; then \
+        pip install --no-cache-dir -e /app/hermes-webui --quiet; \
+    elif [ -f /app/hermes-webui/requirements.txt ]; then \
+        pip install --no-cache-dir -r /app/hermes-webui/requirements.txt --quiet; \
+    fi
+
+# ── Install Fox overlay ───────────────────────────────────────────────────────
+COPY packages/fox-overlay /app/fox-overlay
+RUN pip install --no-cache-dir -e /app/fox-overlay
+
+# ── Apply .fox-removals (deleted-upstream-files manifest) ─────────────────────
+RUN cd /app/hermes-webui \
+ && grep -v '^\s*$\|^\s*#' /app/fox-overlay/.fox-removals \
+    | xargs -r -I{} rm -f -- {}
+
+# ── Static overlay env vars ───────────────────────────────────────────────────
+ENV HERMES_WEBUI_EXTENSION_DIR=/app/fox-overlay/webui_static \
+    HERMES_WEBUI_EXTENSION_SCRIPT_URLS=/extensions/fox-overlay.js \
+    HERMES_WEBUI_EXTENSION_STYLESHEET_URLS=/extensions/fox-in-the-box.css
+
+RUN chown -R foxinthebox:foxinthebox /app/hermes-agent /app/hermes-webui /app/fox-overlay
+```
+
+Implement `packages/fox-overlay/scripts/check-overlay-basis.sh` (was a stub since Phase 1 — make it real):
+
+```bash
+#!/bin/sh
+# Detect upstream rename/delete of any file referenced in .fox-removals.
+# Runs as a CI gate before Docker build; failure means Phase 7's submodule
+# pin needs to be rolled back to the previous tag and the migration plan
+# updated for the upstream restructure.
+set -eu
+REPO_ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+FORK="$REPO_ROOT/forks/hermes-webui"
+REMOVALS="$REPO_ROOT/packages/fox-overlay/.fox-removals"
+fail=0
+while IFS= read -r line; do
+  case "$line" in ''|\#*) continue ;; esac
+  if [ ! -e "$FORK/$line" ]; then
+    echo "::error::.fox-removals expects $line in upstream — not found in pinned tag"
+    fail=1
+  fi
+done < "$REMOVALS"
+exit "$fail"
+```
+
+Update `.github/workflows/build-container.yml` to run `check-overlay-basis.sh` before the Docker build step.
+
+Delete from fork (already gone since Phase 4) — confirm:
+- `forks/hermes-webui/scripts/apply-local-patches.sh`
+- The `_ensure_active_branch()` function in `forks/hermes-webui/server.py`
+- Fox's `local-patches` branch in `fox-in-the-box-ai/hermes-webui` (or repurpose as `fitb-overlay-archive` tag for historical reference).
+
+**Validation gates.**
+- `check-overlay-basis.sh` exits 0.
+- All 11 patches in `series` apply with `git apply --check` cleanly.
+- Container builds. **Full smoke checklist sections A–L run end-to-end against the verification container, on both Apple Silicon and an x86_64 host.** Section A4 (architecture verification per #114 lesson) is non-skippable.
+- `docker exec fitb-test cat /app/version.txt` returns the FITB_VERSION (proves no `version.txt` regression).
+- `docker exec fitb-test ls /app/hermes-webui/api/` shows neither `ollama.py` nor `tailscale.py` etc. — they're in `/app/fox-overlay/...`.
+- `docker exec fitb-test pip show hermes-webui` shows the pinned upstream version (e.g. `Version: 0.51.22`).
+- 48-hour soak (anti-regression Rule 2) starts at tag time.
+
+**Rollback.** This is the most consequential phase. Rollback procedure:
+
+1. `git revert <merge-commit>` on monorepo `main` — restores .gitmodules to the fox fork URLs and the submodule pins to the previous SHAs.
+2. `git submodule sync && git submodule update --init --recursive` to re-fetch the fork-side content.
+3. Rebuild and redeploy `:stable` from the prior `:vX.Y.<n-1>` digest.
+4. File a post-mortem issue documenting which patch failed against which upstream tag.
+
+Critically: the prior Fox-fork branches (`master`/`main`) on `fox-in-the-box-ai/hermes-{webui,agent}` are **not deleted** until Phase 9. Until then, rollback is fully reversible.
+
+**Effort estimate.** 1.5 engineering days (1 day implementation, 0.5 day full smoke run on real hardware).
+
+**Suggested PR/issue split.**
+- "phase 7a: re-pin forks/hermes-webui to upstream nesquena v0.51.22"
+- "phase 7b: re-pin forks/hermes-agent to upstream NousResearch v0.13.0 (v2026.5.7)"
+- "phase 7c: multi-stage Dockerfile + check-overlay-basis CI gate"
+
+(These can be one merged PR if Dennis prefers atomic — the rollback story is identical either way since they all change the submodule pin.)
+
+**Risks.**
+- A patch fails `git apply --check` against the new upstream. **Mitigation:** dry-run before merging. If it fails, refresh the patch (or, if it's a 5-line edit, just inline it as a monkey-patch).
+- One of the 6 webui modules in `webui_modules/` imports a now-renamed upstream symbol. **Mitigation:** the Phase 5 import-time check (`getattr(module, "_thing", None)`) fires; CI catches it. Update the overlay module to handle the new symbol.
+- Upstream's pinned `pyproject.toml` requires Python >3.11 (it does — confirmed). **Mitigation:** Dockerfile already uses `python:3.11-slim`. But verify any sub-deps that bumped past 3.11.
+- A user mid-upgrade hits a state-format mismatch (e.g. `settings.json` schema). **Mitigation:** the `packages/integration/scripts/` migration scripts already run on entrypoint; add a one-time migration if needed (none expected, but flag in Phase 9 cleanup).
+
+---
+
+### Phase 9 — Wire `nightly upstream-watch.yml`
+
+**Goal.** A scheduled GitHub Actions workflow runs nightly. It checks for a newer upstream tag than `versions.toml` records. If found, it runs the full container build with the new tag and opens an issue if the build or smoke fails. Catches drift early, surfaces incompatibilities as CI signals, and enforces the security cadence implied by upstream's 8 P0 closures in v0.13.0 alone.
+
+**Prerequisites.** Phase 7 merged and deployed; 48-hour soak complete.
+
+**Concrete file operations.**
+
+Create `.github/workflows/upstream-watch.yml`:
+
+```yaml
+name: Upstream watch (nightly)
+
+on:
+  schedule:
+    - cron: "17 5 * * *"   # 05:17 UTC daily
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-and-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { submodules: recursive, fetch-depth: 0 }
+
+      - name: Read pinned versions
+        id: pinned
+        run: |
+          echo "agent=$(grep '^hermes_agent_tag' versions.toml | cut -d'\"' -f2)" >> "$GITHUB_OUTPUT"
+          echo "webui=$(grep '^hermes_webui_tag' versions.toml | cut -d'\"' -f2)" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve latest upstream tags
+        id: latest
+        run: |
+          agent_latest=$(curl -fsSL https://api.github.com/repos/NousResearch/hermes-agent/releases/latest | jq -r .tag_name)
+          webui_latest=$(curl -fsSL https://api.github.com/repos/nesquena/hermes-webui/releases/latest | jq -r .tag_name)
+          echo "agent=$agent_latest" >> "$GITHUB_OUTPUT"
+          echo "webui=$webui_latest" >> "$GITHUB_OUTPUT"
+
+      - name: Test build against latest upstream
+        if: ${{ steps.pinned.outputs.agent != steps.latest.outputs.agent || steps.pinned.outputs.webui != steps.latest.outputs.webui }}
+        env:
+          AGENT_TAG: ${{ steps.latest.outputs.agent }}
+          WEBUI_TAG: ${{ steps.latest.outputs.webui }}
+        run: |
+          git -C forks/hermes-agent fetch --tags origin
+          git -C forks/hermes-agent checkout "$AGENT_TAG"
+          git -C forks/hermes-webui fetch --tags origin
+          git -C forks/hermes-webui checkout "$WEBUI_TAG"
+          packages/fox-overlay/scripts/check-overlay-basis.sh
+          docker build -f packages/integration/Dockerfile \
+            -t fitb:upstream-watch \
+            --build-arg FITB_VERSION=upstream-watch .
+
+      - name: Open issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `upstream-watch: build failed for hermes-agent=${{ steps.latest.outputs.agent }}, hermes-webui=${{ steps.latest.outputs.webui }}`,
+              body: `Nightly upstream-watch run ${context.runId} failed. See workflow logs for details.\n\nMost likely cause: a patch in packages/fox-overlay/patches/ no longer applies, or a monkey-patch's signature self-test fired. Refresh the affected patch before bumping versions.toml.`,
+              labels: ["upstream-drift", "P2"],
+            });
+```
+
+**Validation gates.**
+- Manual `workflow_dispatch` trigger succeeds when current pin matches latest (no-op).
+- Manual run with a fake mismatch (temporarily edit versions.toml to an older tag) builds the container and either passes or opens an issue.
+- An issue actually opens when forced to fail (e.g. break a patch deliberately and rerun).
+
+**Rollback.** Disable the workflow (`workflow_dispatch` only) or delete the file.
+
+**Effort estimate.** 1 engineering day.
+
+**Suggested PR/issue split.**
+- "phase 9: nightly upstream-watch CI workflow"
+
+**Risks.**
+- GitHub API rate limits on `api.github.com/repos/.../releases/latest`. **Mitigation:** these endpoints don't need auth and are within the unauthenticated rate budget when run nightly.
+- An accepted upstream PR retroactively conflicts with a Fox monkey-patch and the issue piles up unnoticed. **Mitigation:** the issue is labeled `upstream-drift P2`; team triage cadence catches it.
+
+---
+
+### Phase 10 — Cleanup and decommission
+
+**Goal.** Remove all dead code and infrastructure that the migration obviated. The Fox forks of `hermes-webui` and `hermes-agent` are tagged for archival but no longer the source of truth. The `sync-submodules.yml` workflow is repurposed (or deleted) since it pointed at the Fox forks.
+
+**Prerequisites.** Phase 9 merged. At least 1 successful upstream-watch cycle observed (one nightly run with a real bump signal).
+
+**Concrete file operations.**
+
+In monorepo:
+- Delete `.github/workflows/sync-submodules.yml` (it pointed at the Fox forks; obsolete).
+- Delete any leftover dead code or comments in monorepo referring to the old fork-pinning model.
+- Update `CLAUDE.md` "Repository Structure" section to describe the new layout: forks point at upstream; Fox code lives in `packages/fox-overlay/`.
+- Update `AGENTS.md`, `CONTRIBUTING.md`, `README.md` accordingly (one PR each or one combined doc PR).
+
+In fork repos (`fox-in-the-box-ai/hermes-{webui,agent}`):
+- Tag current `master`/`main` as `fitb-overlay-archive-2026-MM-DD` so the historical Fox-fork content remains discoverable.
+- Update fork README to point to the monorepo (`packages/fox-overlay/`) for active development.
+- Optionally archive the fork repos via GitHub UI (read-only). **Do not delete** — they're referenced by historical commits/tags.
+
+In monorepo `docs/architecture/`:
+- Move `upstream-separation-plan.md` → `upstream-separation-plan.archive.md` (it's now historical).
+- Move `upstream-migration-execution-plan.md` → `upstream-migration-execution-plan.archive.md`.
+- Add a `docs/architecture/upstream-overlay.md` describing the steady-state architecture for newcomers (1-pager, no migration prose).
+
+**Validation gates.**
+- All linked docs render and reference correct paths.
+- `git submodule status` in monorepo shows clean upstream URLs.
+- A fresh clone + `git submodule update --init --recursive` produces a buildable tree.
+
+**Rollback.** Per-step. Everything in this phase is documentation + workflow config; no code change rollback needed.
+
+**Effort estimate.** 0.5 engineering day.
+
+**Suggested PR/issue split.**
+- "phase 10a: archive sync-submodules workflow; update docs to overlay model"
+- "phase 10b: tag fox forks as overlay-archive; archive fork repos read-only"
+
+**Risks.**
+- A future engineer reads `upstream-separation-plan.md` (now archive) without realizing it's historical. **Mitigation:** prominent banner at top + filename suffix.
+
+---
+
+## 5. Open questions Dennis must decide before Phase 1
+
+The original 827-line plan listed 3 open questions. Refreshed for current state (v0.5.4 in tree, drift now 1,526 + 1,238 commits, 2026-05-16):
+
+1. **Where in the roadmap does this slot? (Phase / version assignment.)**
+   The roadmap has Phase 1 = v0.5.5 (`fox-guardrails` + Presidio PII). Per anti-regression Rule 1, Phase 1 of the roadmap and the migration cannot share a release. Options:
+   - **(a) Migration is v0.5.5, push guardrails to v0.5.6.** Cleanest separation; 5-week migration window; guardrails resume after 48h soak post-Phase-7.
+   - **(b) Migration is v0.6.0 (after guardrails ship in v0.5.5).** Defers ~6 weeks; drift adds ~3,000 commits in that window; security-cadence risk grows materially.
+   - **(c) Interleave: Phase 0 (PR campaign) runs now; Phases 1–4 run in parallel with guardrail dev (different files); Phase 5+ blocks on guardrails ship.** Highest scheduling complexity; needs 2 engineers.
+   **Recommendation:** (a). The drift is a security cost; guardrails are a feature cost. Rule 2 ("48-hour soak") makes interleaving risky.
+
+2. **Phase 0 (Upstream-PR campaign) — go or skip?**
+   Sending the 5 bug-fix PRs upstream takes ~1.5 days; review latency adds 1–4 weeks of nothing-to-do calendar. Each accepted PR shrinks the patch series forever. The two top candidates (`runtime_provider.py` Bedrock fix, `models.py` #1558 metadata-save) are pure bug fixes any maintainer would accept.
+   **Recommendation:** GO. Run Phase 0 immediately, in parallel with Phase 1; do not block migration on it. If 0 PRs accept, Fox's patch series is unchanged. If 5 accept, Fox's permanent patch surface drops by another ~5 commits.
+
+3. **Choice of upstream tag pin for the initial cut.**
+   Two options:
+   - **(a) Latest stable tags as of migration start** (`hermes-agent v2026.5.7` / `hermes-webui v0.51.22` per the 2026-05-08 audit; check at Phase 7 time for newer). Maximizes immediate value capture (Kanban, `transform_llm_output` hook, security wave).
+   - **(b) Older tag known to compile against Fox's existing patches** (e.g. one tag prior to a known refactor). Lower risk; less value.
+   **Recommendation:** (a). The whole point of the migration is to enable upstream tracking; pinning to a stale tag immediately defeats it. If a patch fails against latest, the patch needs refresh anyway — that's a known cost, surface it in Phase 7 not Phase 8.
+
+---
+
+## 6. Glossary
+
+- **Overlay** — A separate package (`packages/fox-overlay/`) whose contents are layered on top of upstream files at build time, without modifying the upstream tree in place. Comparable to Nix overlays or rpm-ostree layered images.
+- **Monkey-patch** — Replacing a function or method on a Python module at runtime, after import. Used here when a Fox change must alter mid-file upstream behavior but cannot be expressed as a clean overlay (e.g. swapping `api.streaming._handle_provider_error`).
+- **Patch series** — A Debian-quilt-style ordered list of `.patch` files, with a `series` text file listing the order. Applied with `git apply` at Docker build time. Used here only for the unavoidable mid-file edits that cannot be monkey-patched (the 9 lines in webui's `server.py` and `api/routes.py`).
+- **Basis** — The upstream commit/tag the overlay was authored against. `check-overlay-basis.sh` verifies that every file Fox claims to modify or remove still exists in the pinned upstream — guards against silent feature loss when upstream renames or deletes a file.
+- **Dispatcher** — The `fox_overlay.dispatch` module's `handle_get`/`handle_post` callable. The 6-line patch in `api/routes.py` calls it before falling through to the upstream `if/elif` chain. Lets Fox claim route prefixes without modifying upstream's giant route table.
+- **Bootstrap** — The `fox_overlay.bootstrap.install()` entry point. Installs all monkey-patches at import time. The 3-line patch in `server.py` is just `import fox_overlay.bootstrap` — everything else fans out from there.
+- **`.fox-removals`** — A one-path-per-line manifest in the overlay listing upstream files Fox does NOT want in the shipped image. Applied via `xargs rm -f` after the upstream COPY in the Dockerfile. Cleaner than a patch that deletes 7 files.
+- **Anti-regression rules** — The 5 non-negotiable rules in `project_roadmap_v0_5_to_v0_9.md`: (1) one large change per release, (2) 48-hour soak after every tag, (3) growing regression suite, (4) feature flags everywhere, (5) stabilization pass before every minor bump.
+- **Smoke checklist** — `qa/SMOKE_CHECKLIST.md`. Sections A–L. Must pass against the released `:stable` (or candidate `:latest` for pre-tag), not against a local rebuild. Verification container always on port 8788, never disturbing the user's port-8787 production install.
+- **Verification container** — The convention from `reference_test_container.md`: `fitb-test` on port 8788 with `--cap-add=NET_ADMIN --device /dev/net/tun --sysctl net.ipv4.ip_forward=1` and a named volume. Required for Tailscale section of smoke to actually work.

--- a/docs/architecture/upstream-separation-plan.md
+++ b/docs/architecture/upstream-separation-plan.md
@@ -1,0 +1,827 @@
+# Upstream Separation Architecture — Research & Plan
+
+**Status:** RESEARCH COMPLETE / AWAITING DECISION
+**Date:** 2026-05-08
+**Author:** Architecture research dispatched by Dennis Vorobyov (@roadhero)
+**Scope:** Separate Fox in the Box customizations from upstream `NousResearch/hermes-agent` and `nesquena/hermes-webui`
+
+---
+
+## Why this document exists
+
+We forked `NousResearch/hermes-agent` and `nesquena/hermes-webui` and have been editing fork files directly for months. We're now ~612 commits behind on `hermes-agent` and ~294 commits behind on `hermes-webui`. Every upstream pull would conflict on dozens of files. Each upstream release adds real value (Kanban, security fixes, new plugin hooks) we can't easily absorb. This blocks Fox from benefiting from upstream improvements, and the gap widens by ~70 commits per day.
+
+This document captures four parallel deep-research lanes plus a synthesis that recommends a path forward. **No code has been changed. Implementation requires explicit approval.**
+
+---
+
+## TABLE OF CONTENTS
+
+1. [Synthesis & Recommended Approach](#1-synthesis--recommended-approach)
+2. [Agent 1: Git-Level Separation Research](#2-agent-1--git-level-fork-separation-architecture)
+3. [Agent 2: Plugin / Runtime Overlay Research](#3-agent-2--plugin--runtime-overlay-architecture)
+4. [Agent 3: Build-Time Assembly Research](#4-agent-3--build-time-assembly-architecture)
+5. [Agent 4: Upstream State as of 2026-05-08](#5-agent-4--upstream-state-report-2026-05-08)
+6. [Decision Points Still Open](#6-decision-points-still-open)
+
+---
+
+# 1. Synthesis & Recommended Approach
+
+## TL;DR
+
+**Hybrid: submodule-pinned-to-upstream-tag + sibling overlay tree + curated patch series + runtime plugin adoption.** Each lane handles a different class of Fox change; together they reduce Fox's upstream patch surface from "every modified upstream file conflicts forever" to **2 files / ~9 lines in `hermes-webui`** and **0 files in `hermes-agent`**.
+
+This is **not optional**. Upstream is shipping ~73 commits/day across both repos, with weekly minor tags and 8 P0 security closures in v0.13.0 alone (one was CVSS 8.1). Fox's current "edit forks directly" model means we're already 612 + 294 commits behind, and the gap widens by ~70 commits/day.
+
+## Why hybrid (not any single lane alone)
+
+| Change class | Right lane | Why |
+|---|---|---|
+| Pure-additive Python files (`api/ollama.py`, `api/tailscale.py`, `api/local_fallback.py`, etc. — 2,931 lines, 6 files) | **Build-time overlay** (Agent 3) | Drop into `packages/fox-overlay/webui-modules/`; zero conflict ever. |
+| Pure-additive static files (CSS, JS, fonts, fox avatar, setup wizard — 4,900 net lines) | **Build-time overlay** + existing `HERMES_WEBUI_EXTENSION_DIR` (Agent 2) | Already supported by upstream's `api/extensions.py`. Set 3 env vars; done. |
+| Mid-file Python edits Fox owns (`server.py`, `api/routes.py`, `api/streaming.py`, `api/models.py`, `api/config.py`, `api/onboarding.py`) | **Curated patch series** (Agent 1) + **runtime monkey-patches** (Agent 2) | Patches apply at Docker build; monkey-patches install at runtime via 9-line bootstrap shim. |
+| All hermes-agent changes (5 modified files + mem0 plugin) | **Runtime plugin** (Agent 2) | Upstream's plugin manager already exposes 17 hooks incl. brand-new `transform_llm_output`. Zero patches. |
+| Removed upstream files (7 deleted onboarding tests, `static/onboarding.js`) | **Build-time `.fox-removals` manifest** (Agent 3) | `xargs rm -f` step in Dockerfile after overlay copy. |
+| Branch-management workflow (`scripts/apply-local-patches.sh`, `_ensure_active_branch()`) | **Retire** | Becomes obsolete once submodule pins virgin upstream. |
+
+This isn't three competing proposals — it's one architecture with three implementation layers.
+
+## Final patch surface (target state)
+
+| Repo | Patches | Total lines |
+|---|---|---|
+| `hermes-agent` | **0 files** — everything via `pip install fox-overlay` + `hermes_agent.plugins` entry-point + 4 monkey-patches in bootstrap | 0 |
+| `hermes-webui` | **2 files: `server.py` (3 lines bootstrap import) + `api/routes.py` (3 lines per dispatcher × 2)** | ~9 |
+
+Compare to status quo: 5 modified files (agent) + 36 modified+deleted files (webui).
+
+## Concrete proposed layout
+
+```
+packages/fox-overlay/
+├── pyproject.toml                          # entry-point: hermes_agent.plugins → fox_overlay
+├── fox_overlay/
+│   ├── bootstrap.py                        # the 9-line import target; applies monkey-patches
+│   ├── agent_plugins/{mem0_oss,fox_guardrails}/  # uses upstream plugin manifest schema (kind: ...)
+│   ├── webui_modules/{ollama,tailscale,local_fallback,models_download,hostname,onboarding,session_recovery}.py
+│   ├── webui_routes.py                     # dispatch table called by routes.py patch
+│   └── webui_patches/{streaming,session_safety,config,providers}.py  # monkey-patches
+├── webui_static/                            # mounted via HERMES_WEBUI_EXTENSION_DIR
+│   ├── fox-in-the-box.css, fox-overlay.js
+│   ├── setup.{html,js,css}
+│   ├── fonts/, icons/, images/
+│   └── ...
+├── patches/
+│   ├── webui/series                        # Debian-style quilt
+│   │   ├── 001-server-py-bootstrap.patch    (3 lines)
+│   │   └── 002-routes-py-dispatch-hook.patch (6 lines)
+│   └── agent/series                        # empty — entry-points cover everything
+├── MANIFEST.toml                           # classifies every overlay file
+├── .fox-removals                           # files to rm from upstream tree at build
+└── scripts/check-overlay-basis.sh          # CI gate: detect upstream rename/delete
+```
+
+`forks/hermes-{webui,agent}` submodules **re-pointed at upstream** (`nesquena/hermes-webui` v0.51.22, `NousResearch/hermes-agent` v0.13.0), pinned to a tag in `versions.toml`.
+
+Dockerfile sketch:
+```dockerfile
+COPY forks/hermes-webui /app/hermes-webui          # virgin upstream
+COPY packages/fox-overlay/patches/webui /tmp/p
+RUN cd /app/hermes-webui && for p in $(ls /tmp/p/*.patch | sort); do git apply --check "$p" && git apply "$p"; done
+COPY packages/fox-overlay /app/fox-overlay         # the overlay package
+RUN cd /app/hermes-webui && xargs -r -a /app/fox-overlay/.fox-removals rm -f --
+RUN pip install -e /app/hermes-webui /app/fox-overlay
+ENV HERMES_WEBUI_EXTENSION_DIR=/app/fox-overlay/webui_static \
+    HERMES_WEBUI_EXTENSION_SCRIPT_URLS=/extensions/fox-overlay.js \
+    HERMES_WEBUI_EXTENSION_STYLESHEET_URLS=/extensions/fox-in-the-box.css
+```
+
+## Things to retire / drop during migration
+
+The upstream-state report flagged Fox features that already shipped upstream — these are **patches we delete entirely** during the rebase:
+
+- **#109 Custom Ollama URL** — partially obsolete. Upstream landed:
+  - `e38ea3807` `fix(credential_pool): resolve key mix-up when custom providers share base_url`
+  - `7338e5d9b` Ollama credential switch fix (#21703)
+  - `3ac89c2` Stage-306 named custom-provider routing (webui PR #1818)
+  - `:free`/`:beta`/`:thinking` suffix mis-resolution fix (PR #1783)
+
+  Drop the redundant parts of Fox's #109 implementation; keep only the UI tile (which is a clean overlay anyway).
+
+- **`mem0_oss` plugin manifest** — upstream now enforces `kind: standalone|backend|exclusive|platform|model-provider` in `plugin.yaml`. Fox's plugin omits this field. Update before next rebase.
+
+- **`scripts/apply-local-patches.sh` + `_ensure_active_branch()`** in webui's `server.py` — both become dead code in the new model. Delete in the migration.
+
+- **Fox's `local-patches` branch** in `fox-in-the-box-ai/hermes-webui` — stale (34 commits behind master). Not revivable; delete or repurpose as patch archive.
+
+## New upstream hooks Fox should adopt
+
+The upstream-state report identified concrete hook adoption opportunities — these collapse Fox monkey-patches into clean plugin registrations:
+
+- **`transform_llm_output`** (NEW in v0.13.0, PR #21235) — exactly the hook Fox guardrails Phase 1 (#4 + #5 Presidio PII) needs. Use this instead of any monkey-patch on streaming output.
+- **`pre_gateway_dispatch`** — for Fox admission control / message rewriting.
+- **`on_session_start` / `on_session_finalize`** — the right hooks for `mem0_oss` to register against.
+- **`pre_approval_request` / `post_approval_response`** — for the planned Llama Guard 3 work (Phase 4 / #6).
+- **`plugins/model-providers/` directory + `ProviderProfile` ABC** — the architecturally-clean way to ship Fox's local-fallback once Phase 0 stabilization absorbs it.
+
+## Migration plan (incremental, reversible at every step)
+
+| Phase | What | Days | Rollback |
+|---|---|---|---|
+| **1.** Scaffold `packages/fox-overlay/` skeleton + `MANIFEST.toml` | Empty package, current Dockerfile untouched | 1 | revert PR |
+| **2.** Move static files to overlay; set `HERMES_WEBUI_EXTENSION_DIR` | byte-identical runtime; smoke confirms | 1 | revert PR |
+| **3.** Migrate hermes-agent plugin + 4 monkey-patches; restore upstream `.py` files | `hermes plugins list` shows fox; smoke | 1 | revert PR |
+| **4.** Land 9-line webui patches (`server.py`, `api/routes.py`); harmless when overlay absent | bootstrap shim becomes loadable | 0.5 | revert PR |
+| **5.** Migrate additive webui Python modules (ollama, tailscale, local-fallback, etc.) into overlay | smoke each affected endpoint | 2 | per-module revert |
+| **6.** Migrate modified-upstream patches (streaming, models, config, providers) as monkey-patches; restore upstream files | feature-by-feature smoke | 3 | per-patch revert |
+| **7.** Migrate `api/onboarding.py` wholesale-replacement; deal with deleted `static/onboarding.js` fallout | setup flow smoke | 1 | revert PR |
+| **8.** Re-point submodules at upstream tags; switch Dockerfile to multi-stage; delete `_ensure_active_branch` + `apply-local-patches.sh` | Full smoke A–L | 1.5 | tag rollback + submodule revert |
+| **9.** Wire `nightly upstream-watch.yml` (auto-bump to latest tag, build, open issue on failure) | Catches drift early | 1 | disable workflow |
+
+**Total: ~12 days focused work, ~3 weeks calendar.** Each phase produces a working build.
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| **Upstream renames a function we monkey-patch** | `bootstrap.install()` self-test asserts every patched symbol exists (`inspect.signature` check); fail fast in CI. |
+| **Upstream adds a route at the same path as a Fox route** | Startup audit walks upstream `handle_get` for path literals; warn on overlap. |
+| **Order-of-import: bootstrap runs after `Session.save` is already cached** | Bootstrap patch is the **first** import in `server.py` before any `from api.* import`. |
+| **`api/routes.py` upstream growth (+3,153 lines, 80 commits/30 days) makes patches drift** | Patch is only 6 lines (dispatcher hook). Does not touch any upstream route handler. |
+| **`api/onboarding.py` upstream restructured (Codex OAuth onboarding shipped)** | Treat as full-replace, not patch. Fox dispatcher fires first; upstream becomes dead code. |
+| **Force-pushes to patch branches break in-flight contributor work** | Tag pre-rebase tip (`pre-pull-YYYY-MM-DD`); 24h announcement window for rebases. |
+| **Debug-ability — "where did this come from?"** | Every monkey-patch logs `[fox-overlay] patched api.streaming._handle_provider_error` at startup; `MANIFEST.toml` is canonical inventory. |
+| **Silent feature loss on upstream rename of overlaid file** | `check-overlay-basis.sh` runs as first build step; CI fails if a `full-replace` overlay file no longer exists upstream. |
+| **Security tag drops weekly, we're not tracking** | Nightly `upstream-watch.yml` opens an issue when a new tag fails to build; security cadence becomes a CI signal. |
+
+## Cost / ongoing maintenance
+
+| Scenario | Status quo | After migration |
+|---|---|---|
+| Typical weekly upstream pull | 6–10 hours (unworkable; we don't do it) | **15–60 min** |
+| Big-feature pull (e.g. Kanban v1) | Days | **1–2 hours** |
+| Worst case (upstream restructures patched dir) | Days | **Half a day**, detected by `git apply` failure not silent regression |
+| Cost of delaying further | Linear-in-commits, unbounded | Bounded by patch series size (~10 files, self-amortizing) |
+
+Migration cost: **~12 engineering days, recoupable in ~3 upstream pulls.**
+
+## Strategic call-out: Fox features to upstream first
+
+Several Fox commits are bug fixes upstream would likely accept. Sending them as PRs to NousResearch / nesquena before the migration **shrinks our patch series for free**:
+
+- `hermes_cli/runtime_provider.py` — one-line `target_model` fix (pure bug, no Fox semantics).
+- `agent/auxiliary_client.py` — `provider=auto` resolution + `auxiliary.default` fallback (general utility).
+- `cron/{jobs,scheduler}.py` + `tools/cronjob_tools.py` — failure diagnostics (operability improvement).
+- `api/models.py` (#1558) — `Session.save` metadata-only guard (P0 data-loss fix; **definitely** wanted upstream).
+- `api/providers.py` — gateway hot-reload after key change.
+
+Each one upstream accepts = one less commit in our patch series forever.
+
+---
+
+# 2. Agent 1 — Git-Level Fork Separation Architecture
+
+## Executive summary
+
+Recommended approach: **patch-series-on-top-of-upstream**, implemented as a long-lived `fitb` branch on each fork that we keep cleanly rebased onto `upstream/main` (agent) and `upstream/master` (webui). Submodule pointers in the monorepo move from `master`/`main` to `fitb`. The Dockerfile and CI keep working unchanged because they `COPY forks/hermes-*` — the branch name is opaque to the build.
+
+Why this and not subtree/submodule-of-upstream: the audit shows the actual patch surface is small enough to manage as a series. **hermes-agent has only 5 MODIFIED files / 0 DELETED**, and **hermes-webui has 29 MODIFIED / 7 DELETED**. Most of our work (22 of webui's 58 changed files, 4 of agent's 9) is already in NEW Fox-only files that conflict with nothing. A patch series turns "every pull is a merge nightmare" into "every pull is a 36-commit rebase, of which only ~12 commits touch upstream lines and might need touch-ups." Subtree adds a layer of indirection without solving the conflict on `static/index.html` or `api/routes.py`. A submodule-of-upstream + overlay copy-on-build would solve conflicts but bans us from ever touching upstream files at all, which the audit shows is unrealistic — onboarding, streaming, routes, server.py and config.py are co-modified by Fox features and upstream evolution.
+
+The codebase already has the bones of this approach: `scripts/apply-local-patches.sh` does `git rebase --onto origin/$DEFAULT_BRANCH origin/$DEFAULT_BRANCH local-patches`, and `server.py` has a `_ensure_active_branch()` startup hook that switches to `local-patches` before booting. The infrastructure exists; it's been bypassed by direct commits to `master`. Migration is largely "stop doing that, formalize what was already designed."
+
+## File-level diff audit
+
+Audit method: `git merge-base <fork-pin> upstream/<branch>`, then `git diff --name-status` and `git diff --numstat` from base to the submodule-pinned SHA. Pinned SHAs from `git submodule status` in `/Users/macpro/Desktop/Fox-In-the-Box/project`:
+
+- `forks/hermes-agent` → `44a6808f` (on `main`, merge-base `e5dad4ac` — only 6 commits ahead of upstream)
+- `forks/hermes-webui` → `62c0854` (on `master`, merge-base `9e31a2ac` — 56 linear commits ahead of upstream, **no merge commits**)
+
+**Note on actual Fox patch surface for webui:** the heavy "Fox-only" branches (e.g. `feat/wizard-option-b-flow`, `local-patches`, the fix/* and feat/* branches listed earlier) are not what's deployed. The deployed pin is `master`, and `master`'s 56 linear commits include all the Fox features. So the audit numbers below ARE the live patch surface.
+
+### hermes-agent (pin `44a6808f` vs `upstream/main`)
+
+| File | Class | LOC delta (+/−) | Intent |
+|---|---|---|---|
+| `.github/workflows/notify-monorepo.yml` | NEW | +18 / 0 | repository_dispatch to monorepo on push |
+| `plugins/memory/mem0_oss/__init__.py` | NEW | +1011 / 0 | mem0_oss memory provider plugin (drop-in dir, zero conflict) |
+| `plugins/memory/mem0_oss/README.md` | NEW | +201 / 0 | docs for plugin |
+| `plugins/memory/mem0_oss/plugin.yaml` | NEW | +6 / 0 | plugin manifest |
+| `agent/auxiliary_client.py` | MODIFIED | +20 / −2 | `_resolve_task_provider_model` provider=auto fallback + auxiliary.default config fallback |
+| `cron/jobs.py` | MODIFIED | +11 / 0 | cron failure diagnostics fields |
+| `cron/scheduler.py` | MODIFIED | +58 / −6 | rolling failure history on scheduler |
+| `tools/cronjob_tools.py` | MODIFIED | +8 / 0 | expose new diagnostics fields to tool API |
+| `hermes_cli/runtime_provider.py` | MODIFIED | +1 / −1 | use `target_model` for Bedrock api_mode routing |
+
+**Roll-up:** NEW=4, MODIFIED=5, DELETED=0. Minimum patch surface = **5 files**. Three of the MODIFIED files (`cron/*`) form one logical change set ("cron failure diagnostics") that touches related upstream code and lands as one commit.
+
+### hermes-webui (pin `62c0854` vs `upstream/master`)
+
+| File | Class | LOC delta (+/−) | Intent |
+|---|---|---|---|
+| `api/hostname.py` | NEW | +279 / 0 | post-wizard device-naming endpoint (#68) |
+| `api/local_fallback.py` | NEW | +616 / 0 | Local AI fallback orchestration (issue #9) |
+| `api/models_download.py` | NEW | +620 / 0 | Server-side GGUF download manager (#10) |
+| `api/ollama.py` | NEW | +508 / 0 | Pull/delete models from WebUI (#67) + custom URL (#109) |
+| `api/session_recovery.py` | NEW | +131 / 0 | Recover sessions on startup |
+| `api/tailscale.py` | NEW | +877 / 0 | Tailscale phase-1+2 endpoints (#96) |
+| `scripts/apply-local-patches.sh` | NEW | +63 / 0 | local-patches rebase tool (already a patch-series scaffold) |
+| `static/setup.css` `setup.html` `setup.js` | NEW | +939 / 0 | Onboarding wizard UI (Fox-specific) |
+| `static/fox-in-the-box.{css,js}` | NEW | +1011 / 0 | Fox visual shell + variable fonts |
+| `static/onboarding-preview.js` | NEW | +616 / 0 | Replacement preview for upstream onboarding |
+| `static/fallback-polish.js` | NEW | +527 / 0 | Failover modal UI (FITB#128/129c+d) |
+| `static/hostname-prompt.js` | NEW | +145 / 0 | Hostname prompt UI |
+| `static/fonts/*`, `static/fox_avatar_cropped.jpg`, `apple-touch-icon.png`, favicons (5) | NEW/MODIFIED (binary) | n/a | Fox branding assets |
+| `tests/test_local_patches_update_flow.py` | NEW | +77 / 0 | Test for #1 |
+| `tests/test_metadata_save_wipe_1558.py` | NEW | +217 / 0 | P0 #1558 regression test |
+| `tests/test_stale_stream_cleanup.py` | NEW | +149 / 0 | Stale-stream cleanup test |
+| `.github/workflows/notify-monorepo.yml` | NEW | +18 / 0 | repository_dispatch trigger |
+| `api/routes.py` | **MODIFIED** | **+1510 / −98** | **Hottest file.** Registers new endpoints + messaging session helpers. Conflicts every pull. |
+| `api/onboarding.py` | **MODIFIED** | +227 / −916 | Replaced upstream wizard with Fox 3-step flow; net DELETION of 689 lines |
+| `api/streaming.py` | MODIFIED | +207 / −28 | Silent failover to local model on remote error (#129b) |
+| `api/config.py` | MODIFIED | +118 / −6 | Tailscale + fallback + Ollama URL config keys |
+| `api/models.py` | MODIFIED | +58 / −1 | P0 #1558 metadata-save fix + project_id propagation |
+| `api/providers.py` | MODIFIED | +29 / 0 | Hot-reload gateway after key change |
+| `api/updates.py` | MODIFIED | +163 / −42 | Track fitb-ai fork remote; auto-reapply local patches |
+| `server.py` | MODIFIED | +95 / 0 | `_ensure_active_branch()` startup git checkout + onboarding redirect import |
+| `.env.example`, `.env.docker.example` | MODIFIED | +7 / 0 | Document Fox env vars |
+| `ARCHITECTURE.md` | MODIFIED | +1 / −2 | Note Fox fork |
+| `static/index.html` | MODIFIED | +174 / −31 | New side panels for Tailscale/fallback/models, Fox shell |
+| `static/panels.js` | **MODIFIED** | **+1181 / −7** | All side-panel JS for new features |
+| `static/messages.js` | MODIFIED | +142 / −1 | provider_switched badge + download-on-demand modal |
+| `static/style.css` | MODIFIED | +86 / −27 | Fox theme overrides |
+| `static/i18n.js` | MODIFIED | +40 / −36 | Fox translation keys |
+| `static/boot.js` | MODIFIED | +13 / −1 | Hardcoded agent name + WIP onboarding hooks |
+| `static/sw.js` | MODIFIED | +22 / −1 | Disable shell cache by default; avatar rename |
+| `static/sessions.js`, `static/ui.js` | MODIFIED (trivial) | +4 / −2 | Wiring |
+| `static/favicon-512.svg`, `favicon.svg` | MODIFIED | +19 / −37 | Fox branding |
+| `tests/test_pwa_manifest_sw.py`, `tests/test_service_worker_api_cache.py` | MODIFIED | +10 / −1 | Updated assertions |
+| `static/onboarding.js` | **DELETED** | 0 / −635 | Upstream onboarding script removed |
+| `tests/test_issue1499_keyless_onboarding.py` | DELETED | 0 / −381 | Upstream onboarding test |
+| `tests/test_issue1499_onboarding_probe.py` | DELETED | 0 / −409 | Upstream onboarding test |
+| `tests/test_onboarding_existing_config.py` | DELETED | 0 / −426 | Upstream onboarding test |
+| `tests/test_onboarding_mvp.py` | DELETED | 0 / −244 | Upstream onboarding test |
+| `tests/test_onboarding_network.py` | DELETED | 0 / −184 | Upstream onboarding test |
+| `tests/test_onboarding_static.py` | DELETED | 0 / −58 | Upstream onboarding test |
+
+**Roll-up:** NEW=22, MODIFIED=29, DELETED=7. Minimum patch surface = **36 files**. Of those 36, 6 are the "always conflict" set: `api/routes.py`, `api/onboarding.py`, `api/streaming.py`, `api/config.py`, `static/index.html`, `static/panels.js`. The 7 DELETED files are guaranteed conflicts every pull because upstream keeps touching them.
+
+## Industry precedents
+
+**LineageOS / AOSP** — monthly upstream merge cadence using their `aosp-merger` script. Tracks current vs. previous AOSP tag in `vendor/lineage/vars/common`; runs a coordinated merge across hundreds of repo-manifest projects. Crucially, *they merge, they don't rebase* — because the patch volume is too large to keep linear. Cost: a maintenance team, monthly merge windows. Outcome: tracks AOSP within ~30 days, indefinitely. ([source](https://github.com/LineageOS/android))
+
+**Chromium / ChromeOS** — uses `UPSTREAM`/`FROMGIT`/`FROMLIST` commit-message tags so every downstream patch advertises its provenance. Strict "upstream first" policy. ([source](https://www.chromium.org/chromium-os/chromiumos-design-docs/upstream-first/), [LWN coverage](https://lwn.net/Articles/798147/))
+
+**Bazzite / Bluefin / Universal Blue** — image-overlay model. They don't fork Fedora source. They take Fedora's OCI base image and layer rpm-ostree changes via `Containerfile`s. **Zero source-level merge cost** — they only ship overlay artifacts. ([source](https://docs.bazzite.gg/Installing_and_Managing_Software/rpm-ostree/))
+
+**Debian / Ubuntu (quilt patch series)** — every Debian source package using the "3.0 (quilt)" format keeps downstream changes as numbered patches in `debian/patches/` with a `series` file. `gbp pq` switches to a patch-queue git branch, `git rebase` against the new upstream, regenerates the series. ([Debian wiki: UsingQuilt](https://wiki.debian.org/UsingQuilt)) **This is the closest analogue to Fox's situation.**
+
+**Grafana (originally Kibana)** — Torkel Ödegaard forked Kibana 3 in 2013 to add Graphite/time-series support after upstream rejected the patches. They diverged immediately and **never tried to keep tracking** upstream Kibana — full hard fork. Cost: zero merge cost forever, but also zero free upstream features after the cut point. **This is the path Fox is implicitly drifting toward and should explicitly avoid.**
+
+## The three git-level approaches compared
+
+### Patch-series-on-top-of-upstream (RECOMMENDED)
+
+**Pros:** small operational surface (36 files for webui, 5 for agent); each Fox change keeps an authored commit you can `git log`; works with existing GitHub PR review; conflict resolution is per-commit not per-file; rejected commits drop out of the series naturally; the existing `scripts/apply-local-patches.sh` and `server.py` startup hook are already designed for this.
+
+**Cons:** linear history requires discipline (no merging into the patch branch, no force-pushes without notice); `git rebase` rewrites SHAs every pull. Mitigation: tag the pre-rebase tip as `pre-pull-2026-05-08` before each rebase.
+
+**Bootstrap (do once per fork):**
+```
+# In /Users/macpro/Desktop/Fox-In-the-Box/hermes-webui (standalone clone)
+git fetch origin upstream
+git checkout -b fitb origin/master            # 56 commits ahead of upstream
+git log --merges $(git merge-base fitb upstream/master)..fitb   # should print nothing
+git push -u origin fitb
+# In monorepo: re-pin submodule
+cd /Users/macpro/Desktop/Fox-In-the-Box/project
+git -C forks/hermes-webui fetch origin
+git -C forks/hermes-webui checkout fitb
+git add forks/hermes-webui && git commit -m "chore: pin webui submodule to fitb branch"
+# Update .gitmodules: branch = fitb
+```
+
+**Ongoing pull (per upstream release, ~weekly):**
+```
+git fetch upstream
+git tag pre-pull-$(date +%Y%m%d) fitb        # rollback anchor
+git rebase upstream/master                   # replay 56 commits onto new base
+# resolve conflicts (typically 0–4 files)
+git push --force-with-lease origin fitb
+```
+
+**Conflict surface per pull:** the 6 always-conflict files in webui plus the 7 DELETED files. Empirically: 5–15 minutes of conflict resolution per upstream release.
+
+### `git subtree` (skip)
+
+Does not solve any conflicts on shared files (`api/routes.py` still has to be modified). Splitting our changes into "overlay" vs "patch" duplicates classification work. **Verdict:** subtree is great when the patch surface is 0 modified files. We have 36. Skip.
+
+### Submodule pointing at upstream + Fox overlay directory (analyzed in Agent 3's lane)
+
+Shifts the conflict from `git pull` time to `git apply` time — same 36-file conflict surface, same expertise required, just in a different file format (.patch vs git rebase).
+
+## Recommended migration plan (git-level only)
+
+The existing `local-patches` branch on webui is stale. We should not revive it; we should formalize `master` itself as the patch series, rename it `fitb`, and fix the workflow so it stays clean.
+
+**Step 1: Audit & tag.** In `hermes-webui` standalone clone: `git tag fitb-snapshot-2026-05-08 origin/master` and push the tag. Same for `hermes-agent`.
+
+**Step 2: Create the `fitb` branch.** `git checkout -b fitb origin/master` in each fork; `git push -u origin fitb`.
+
+**Step 3: Repoint submodules.** Edit `.gitmodules` so `branch = fitb` for both fork submodules.
+
+**Step 4: Branch protect both forks' `fitb` and `master`/`main`.**
+
+**Step 5: First pull-from-upstream dry run** (1–2 hours, webui only).
+
+**Step 6: Document the workflow.**
+
+**Hard cases — files we MUST patch (cannot move to overlay):**
+- `api/routes.py` — keep all Fox endpoint registration in a single contiguous block at the bottom of the file, marked with `# === FITB ===` fences.
+- `api/onboarding.py` — explicitly mark this commit "REPLACE upstream onboarding" and use `-Xtheirs` for that one commit during rebase.
+- `static/index.html`, `static/panels.js` — frontend equivalent of `routes.py`. Same fence-comment mitigation.
+
+## Risks (Agent 1's view)
+
+**R1: Submodule pointer mismatch breaks the Docker build.** Mitigation: Step 3 includes a CI build verification before merging the PR.
+
+**R2: First rebase produces a silently-wrong merge.** Mitigation: Step 5 includes manual smoke tests; pin a "canary" deploy slot before promoting `fitb` rebases to the main monorepo.
+
+**R3: Force-push to `fitb` clobbers in-flight feature branches.** Mitigation: announce rebase windows.
+
+**R4: 7 DELETED files come back every pull.** Mitigation: a tiny `.git/hooks/post-rewrite` (or a CI check) that runs `git rm` on a hardcoded list.
+
+**R5: A Fox commit is duplicated when nesquena merges our PR upstream.** Mitigation: when we send a PR to nesquena, mark our local commit with `Upstream-Status: Submitted <PR-URL>`.
+
+**R6: The existing `_ensure_active_branch()` startup hook hardcodes `local-patches`.** Mitigation: change the env var default in the same commit that renames the branch.
+
+## Effort and ongoing maintenance estimates
+
+**Migration:** ~6–8 hours, single-engineer.
+
+**Per-upstream-pull cost, before vs after:**
+- *Before* (status quo): ~6–10 hours, unworkable.
+- *After*: ~30–60 minutes for a typical weekly upstream release.
+
+**Ongoing maintenance:** the patch series should *shrink* over time as we upstream changes.
+
+---
+
+# 3. Agent 2 — Plugin / Runtime Overlay Architecture
+
+## Executive Summary
+
+The plugin/overlay story is **highly asymmetric** between the two forks.
+
+**hermes-agent** is in great shape. Upstream ships a real, mature plugin framework at `forks/hermes-agent/hermes_cli/plugins.py` with 14 lifecycle hooks, four discovery sources (bundled / user / project / pip entry-points), tool registration, slash- and CLI-command registration, platform adapters, image-gen providers, context engines, and skill registration. Our actual fork delta against `NousResearch/hermes-agent` upstream is tiny: **4 modified `.py` files** plus **one fully-additive `plugins/memory/mem0_oss/` directory**. **Realistic patch surface for hermes-agent: 0 files** — the four modifications can either be upstreamed as PRs (they fix real bugs) or expressed as targeted monkey-patches in a Fox bootstrap.
+
+**hermes-webui** is the hard problem. Upstream's only built-in overlay surface is `api/extensions.py`: a directory of static files (CSS/JS/HTML/fonts) injected via two env vars (`HERMES_WEBUI_EXTENSION_DIR`, `HERMES_WEBUI_EXTENSION_SCRIPT_URLS`, `HERMES_WEBUI_EXTENSION_STYLESHEET_URLS`) into `static/index.html`. There is **no Python route registry**, no Flask-style blueprints, no entry_points hook — `api/routes.py` is a 5,400-line `if/elif` chain dispatched from `server.py`.
+
+**Minimum unavoidable patch surface (target state):**
+- hermes-agent: **0 patches** (entry-points + monkey-patches in a bootstrap module).
+- hermes-webui: **2 minimal patches** — one in `server.py` to call `fox_overlay.bootstrap()` at startup, one in `api/routes.py` to call `fox_overlay.dispatch(handler, parsed)` before returning False from `handle_get`/`handle_post`.
+
+## Plugin System Inventory
+
+### hermes-agent plugin framework
+
+**Loader entry point:** `forks/hermes-agent/hermes_cli/plugins.py` lines 614–747 (`PluginManager.discover_and_load`).
+
+**Discovery sources (priority low→high; later wins on key collision):**
+1. **Bundled** — `<repo>/plugins/<name>/`
+2. **User** — `~/.hermes/plugins/<name>/`
+3. **Project** — `./.hermes/plugins/<name>/`
+4. **pip entry_points** — `hermes_agent.plugins` group via `importlib.metadata`.
+
+**Plugin contract:** Each plugin is a directory with `plugin.yaml` (manifest) + `__init__.py` exposing `def register(ctx: PluginContext) -> None`.
+
+**Lifecycle hooks (full set):** `pre_tool_call`, `post_tool_call`, `transform_terminal_output`, `transform_tool_result`, `pre_llm_call`, `post_llm_call`, `pre_api_request`, `post_api_request`, `on_session_start`, `on_session_end`, `on_session_finalize`, `on_session_reset`, `subagent_stop`, `pre_gateway_dispatch`, `pre_approval_request`, `post_approval_response`. **(Note: Agent 4 confirmed `transform_llm_output` was added in v0.13.0 — bringing the total to 17.)**
+
+**`PluginContext` capabilities:**
+- `register_tool(name, toolset, schema, handler, …)` — adds new model-callable tools.
+- `register_hook(name, callback)` — register lifecycle hook.
+- `register_cli_command(name, help, setup_fn, handler_fn)` — adds `hermes <subcommand>` shell commands.
+- `register_command(name, handler, …)` — adds `/slash` commands.
+- `register_platform(name, label, adapter_factory, check_fn, …)` — registers a new gateway messaging adapter.
+- `register_image_gen_provider(provider)`, `register_context_engine(engine)`, `register_skill(name, path, description)`.
+- `inject_message(content, role)` — push messages into an active CLI conversation.
+
+### hermes-webui overlay system
+
+**Static-file overlay:** `forks/hermes-webui/api/extensions.py` (246 lines, fully implemented in upstream).
+- Env vars: `HERMES_WEBUI_EXTENSION_DIR`, `HERMES_WEBUI_EXTENSION_SCRIPT_URLS`, `HERMES_WEBUI_EXTENSION_STYLESHEET_URLS`.
+- `serve_extension_static()` at `extensions.py:209–246` serves files from the configured dir under `/extensions/` URL prefix.
+- `inject_extension_tags(html)` at `extensions.py:158–197` injects `<link>` tags before `</head>` and `<script defer>` before `</body>`.
+- Wire-in points in upstream `api/routes.py`: line 1125 (HTML injection) and lines 1269–1272 (`/extensions/*` static dispatch).
+- Cap: 32 URLs per env var.
+- Security: same-origin only.
+
+**Python backend overlay:** **Does not exist upstream.** `server.py`'s `do_GET`/`do_POST` calls `handle_get`/`handle_post` from `api/routes.py`, which is a single giant `if parsed.path == "/foo"` chain. There is no decorator, no Blueprint, no registration list.
+
+## Per-Modified-File Audit (Agent 2's view)
+
+### hermes-agent
+
+| File | What we changed | Strategy | Feasibility |
+|---|---|---|---|
+| `agent/auxiliary_client.py` | provider=auto fallback + auxiliary.default | Upstreamable bug fix; fallback = monkey-patch | Easy |
+| `cron/jobs.py` | failure_history rolling-5 list | Upstreamable; fallback = `post_tool_call` hook | Easy |
+| `cron/scheduler.py` | diagnostics + traceback | Upstreamable; fallback = monkey-patch run_job | Easy |
+| `hermes_cli/runtime_provider.py` | one-line target_model fix | Pure bug fix; fallback = monkey-patch | Easy |
+| `tools/cronjob_tools.py` | surface failure fields | Upstreamable; fallback = `transform_tool_result` hook | Easy |
+| `plugins/memory/mem0_oss/*` | new exclusive memory provider plugin | Already a plugin | Easy |
+
+**hermes-agent unavoidable patches: none.**
+
+### hermes-webui
+
+#### Additive Python files — drop-in candidates
+
+`api/ollama.py`, `api/tailscale.py`, `api/local_fallback.py`, `api/models_download.py`, `api/hostname.py`, `api/session_recovery.py` — all move into `packages/fox-overlay/webui_modules/`; loaded by Fox bootstrap; routes registered via Fox dispatcher. **Easy.**
+
+#### New static files — pure overlay candidates
+
+All move to `packages/fox-overlay/static/` and serve via `HERMES_WEBUI_EXTENSION_DIR`. Already supported by upstream. **Easy.**
+
+#### Modified upstream Python files
+
+| File | Strategy | Feasibility |
+|---|---|---|
+| `server.py` (+95) | **Minimum patch:** 1 line, `import packages.fox_overlay.bootstrap` at the top of `server.py`. | Hard (without 1-line patch); Easy with it |
+| `api/routes.py` (+1608) | Wrap the dispatcher: monkey-patch `handle_get` and `handle_post` to first call `fox_overlay.dispatch_get(handler, parsed)`. **OR** ask Agent 1 to land a 2-line patch upstream. | Hard (without patch); Medium with monkey-patch; Easy with 2-line patch |
+| `api/onboarding.py` (-689 net) | Move our version to `packages/fox-overlay/webui-modules/onboarding.py`. Upstream becomes dead code. | Medium |
+| `api/streaming.py` | Monkey-patch the exception handler, OR expose as `pre_llm_call` / `post_api_request` hook | Medium |
+| `api/models.py` | Monkey-patch `Session.save` and `Session.load_metadata_only`. | Medium |
+| `api/config.py` | Monkey-patch settings defaults at import time. | Medium |
+| `api/updates.py` | Tightly coupled to patch-series branch workflow (Agent 1's lane). | Hard |
+| `api/providers.py` | Likely small wrap; monkey-patch | Easy |
+
+#### Modified static files (HTML/JS/CSS)
+
+| File | Strategy | Feasibility |
+|---|---|---|
+| `static/index.html` | Most rebrandable from overlay JS at DOMContentLoaded. SW disable needs care. | Medium |
+| `static/panels.js` (+1188) | Overlay JS as DOM-mutation code. | Medium |
+| `static/messages.js` | Add to overlay JS; subscribe to existing SSE event stream. | Easy |
+| Other JS/CSS | Overlay-able as appended scripts/styles | Easy |
+| `static/onboarding.js` (DELETED) | Can't delete via overlay. Solution: our setup.js loads first; upstream becomes dead code. | Medium |
+
+**Webui unavoidable patches summary:** With the recommended **2-line patch in `server.py`** and the recommended **1-line patch at the top of `handle_get`/`handle_post`**, every other change moves out of `forks/hermes-webui/`. Total patch surface: **2 files, 9 lines**.
+
+## Industry Precedents (Agent 2's view)
+
+### Open WebUI — Functions + Pipelines
+
+Closest peer product. Two extension layers:
+- **Functions** (in-process, admin-only): **Pipe** (virtual model), **Filter** (inlet/outlet middleware — same hook pair Fox needs), **Action** (button on each message).
+- **Pipelines** (separate process, OpenAI-compatible API).
+
+Sources: [docs.openwebui.com/features/extensibility/plugin/](https://docs.openwebui.com/features/extensibility/plugin/), [docs.openwebui.com/features/extensibility/pipelines/](https://docs.openwebui.com/features/extensibility/pipelines/).
+
+### Other patterns
+
+- **Jupyter server extensions** — `jupyter_server_extensions` entry-point group.
+- **MkDocs plugins** — `mkdocs.plugins` entry-points; `on_config`, `on_pre_build` hooks.
+- **Flask Blueprints / Starlette routers** — the dominant Python pattern for route extension.
+- **VS Code extensions** — activation events + contribution points.
+
+## Recommended Overlay Architecture (Agent 2's proposal)
+
+[See section 1 synthesis for the consolidated layout — Agent 2's proposal is incorporated there.]
+
+## Migration Plan (Agent 2's view)
+
+[See section 1 synthesis for the consolidated migration plan.]
+
+## Risks (Agent 2's view)
+
+**Upstream rename / signature change of a hook or function we monkey-patch.** Mitigation: a self-test in `bootstrap.install()` that asserts every hook we register is in `VALID_HOOKS`; fail fast in CI on hermes-agent updates.
+
+**Order-of-import sensitivity.** Mitigation: install bootstrap **before any `from api.* import …`** in `server.py`.
+
+**Performance overhead.** Negligible.
+
+**Debug-ability — "where did this behavior come from?"** Mitigations: every monkey-patch sets a sentinel attribute and prints a startup line; ship a `hermes-webui doctor` command that lists every patched function.
+
+**Static-file collision with hard-coded asset paths.** Accept either Docker-stage COPY (Agent 3) or `_serve_static` monkey-patch.
+
+**Upstream adds a new route at the same path as a Fox route.** Startup audit walks upstream `handle_get` for path literals and warns on overlap.
+
+## Effort Estimate (Agent 2's view)
+
+| Phase | Days |
+|---|---|
+| 1. Skeleton package + entry-points | 1 |
+| 2. Static-file overlay | 1 |
+| 3. hermes-agent plugin migration | 1 |
+| 4. Two-line webui patches + bootstrap shim | 0.5 |
+| 5. Additive webui Python modules | 2 |
+| 6. Modified-upstream patches | 3 |
+| 7. Onboarding migration + dead-code cleanup | 1 |
+| 8. api/updates.py + final coordination | 1.5 |
+| 9. CI / monkey-patch sentinels / docs | 1 |
+| **Total** | **~12 days** |
+
+---
+
+# 4. Agent 3 — Build-Time Assembly Architecture
+
+## Executive Summary
+
+The current container build (`packages/integration/Dockerfile`) bakes the Fox fork directly into the image via `COPY forks/hermes-agent /app/hermes-agent` and `COPY forks/hermes-webui /app/hermes-webui`. Because both submodules point at the Fox fork's default branch (with edits applied directly to upstream files), each upstream pull triggers the conflict storm.
+
+**Recommended architecture: Submodule-pinned-to-upstream-tag + sibling `packages/fox-overlay/{webui,agent}` + multi-stage Docker COPY.** The Dockerfile clones the virgin upstream into `/app/hermes-webui`, then a second `COPY` lays the Fox overlay on top. Files we own outright live in the overlay and shadow upstream cleanly. The remaining ~6 mid-file patches in `hermes-webui` and ~5 in `hermes-agent` become a **patch series** maintained by Agent 1 and applied via `git apply` in a build stage between the upstream copy and the overlay copy.
+
+The single load-bearing tradeoff: this approach pushes complexity to upstream **bumps** (re-resolve patches against new upstream tag) instead of paying it on every developer rebase. The bet is that bumps are intentional, scheduled events while rebases happen continuously. A **pre-build "overlay basis check"** detects upstream renames/deletions before they silently swallow Fox features.
+
+## Current Dockerfile Read-Out
+
+`packages/integration/Dockerfile` today (lines 127–139) does:
+
+```
+COPY forks/hermes-agent /app/hermes-agent
+COPY forks/hermes-webui /app/hermes-webui
+RUN pip install -e /app/hermes-agent && \
+    (pip install -e /app/hermes-webui || pip install -r /app/hermes-webui/requirements.txt)
+```
+
+The `forks/` paths are submodules pointing at the Fox fork. CI uses `actions/checkout@v4` with `submodules: recursive`. Everything below line 139 — entrypoint, supervisord, qdrant/llama-cpp tarballs, ENV/VOLUME/EXPOSE — is independent of this change and stays as-is. The `release.yml` / signing / notarization flow is **completely insulated** from this restructure.
+
+## The Three Build-Time Approaches
+
+### Multi-stage Docker COPY overlay (no patches)
+
+```dockerfile
+FROM alpine/git:latest AS upstream-webui
+ARG UPSTREAM_WEBUI_TAG=v0.51.22
+RUN git clone --depth 1 --branch ${UPSTREAM_WEBUI_TAG} \
+    https://github.com/nesquena/hermes-webui /upstream-webui \
+ && rm -rf /upstream-webui/.git
+
+FROM python:3.11-slim
+COPY --from=upstream-webui /upstream-webui /app/hermes-webui
+COPY packages/fox-overlay/webui/ /app/hermes-webui/
+RUN pip install -r /app/hermes-webui/requirements.txt
+```
+
+**Pros.** Pure file-system semantics; auditable. Cache-friendly.
+
+**Cons.**
+1. **Mid-file edits are unsolvable.** `api/routes.py` upstream is 1,180 lines; Fox added 1,608 lines into the middle. Replacing the whole file means re-doing the merge every upstream bump.
+2. **Silent feature loss on upstream rename.** No build error.
+3. **No precedent for "remove upstream file."** `COPY` cannot delete.
+
+### Runtime patching alternative
+
+```dockerfile
+COPY --from=upstream-webui /upstream-webui /app/hermes-webui
+COPY packages/fox-overlay/webui/ /app/fox-overlay/
+COPY packages/fox-overlay/patches/webui/*.patch /app/fox-patches/
+COPY packages/integration/apply-overlay.sh /app/
+ENTRYPOINT ["/app/apply-overlay.sh", "/app/entrypoint.sh"]
+```
+
+**Pros.** Same image works as upstream (with `FITB_OVERLAY=0` skip). A/B testing trivial.
+
+**Cons.** Cold-start latency. Patch failures surface at boot not build. Disqualifying issue: Fox overlay introduces new top-level Python files that need `setup.py`/`pyproject.toml` to know about them.
+
+### Submodule-pinned-to-upstream + sibling overlay + curated patch series (RECOMMENDED)
+
+```dockerfile
+# forks/hermes-webui submodule now points at github.com/nesquena/hermes-webui
+# pinned to a tag (e.g. v0.51.22). NOT the Fox fork.
+COPY forks/hermes-webui /app/hermes-webui
+
+# Apply curated mid-file patches.
+COPY packages/fox-overlay/patches/webui /tmp/patches
+RUN cd /app/hermes-webui \
+ && for p in $(ls /tmp/patches/*.patch 2>/dev/null | sort); do \
+        echo "Applying $(basename $p)"; \
+        git apply --check "$p" && git apply "$p" || \
+            { echo "::error::patch $(basename $p) failed against pinned upstream"; exit 1; }; \
+    done \
+ && rm -rf /tmp/patches
+
+# Drop in fully-Fox-owned files.
+COPY packages/fox-overlay/webui /app/hermes-webui
+
+# Remove upstream files Fox does NOT want shipped.
+RUN xargs -r -a /app/hermes-webui/.fox-removals rm -f --
+
+RUN pip install -e /app/hermes-webui
+```
+
+**Pros.** Submodule pointer always names a precise upstream tag. Patches are short, named, reviewable. Overlay tree is pure adds + replaces. `.fox-removals` makes deletions explicit. CI's existing submodule-checkout flow keeps working unchanged.
+
+**Cons.** Patch maintenance is real work (~10 files). Forces discipline. No GitHub Dependabot on the pinned tag. Mitigation: a separate workflow polls upstream tags weekly and opens an issue.
+
+## Per-Modified-File Overlay-Feasibility Audit (Agent 3)
+
+[Tables consolidated into Agent 1's audit; Agent 3's classification per file: full-replace / layered-add / patch-required / `.fox-removals`. Aggregate count: ~10 patch files for hermes-webui + 5 for hermes-agent = **~15 small, named patches**, of which 3–4 carry the bulk of the line count.]
+
+## Industry Precedents (Agent 3's view)
+
+1. **Nix overlays** — pure functions taking `(self, super)` and returning a record of overrides. https://nixos.wiki/wiki/Overlays
+2. **Bazzite / Bluefin / Silverblue (rpm-ostree)** — base immutable image + layered customizations. https://docs.projectbluefin.io/, https://universal-blue.org/
+3. **Bitnami container images** — never patch upstream PHP files; mounted config files and entrypoint helpers compose around the unmodified payload. https://github.com/bitnami/containers
+4. **Apache Tomcat WAR drop-in** — stock Tomcat container with `webapps/` volume mount. **Strategic recommendation:** every patch we land upstream for a clean extension point pays dividends forever.
+5. **Kustomize** — `bases/` + `overlays/` directories, strategic-merge-patch model. https://kustomize.io/
+6. **Debian source packages with quilt** — closest precedent. `debian/patches/series` file applied by `quilt`. **Borrow Debian's directory layout** — `packages/fox-overlay/patches/{webui,agent}/series` listing the patch order, individual `.patch` files alongside.
+
+## Edge-Case Handling
+
+**Upstream renames a file we patched.** A `git apply` patch contains the source filename in its header. `git apply` fails loudly. **Good.**
+
+**Upstream deletes a file Fox depends on.** Two failure shapes:
+- (a) We had a patch against the deleted file: `git apply` fails loudly. **Good.**
+- (b) Our overlay overwrote the now-deleted file: `COPY` succeeds. **Silent.** Detection: `packages/fox-overlay/scripts/check-overlay-basis.sh` walks the overlay tree and asserts each *non-overlay-only* file exists in upstream.
+
+**Upstream restructures the directory.** Both detections fire. Workflow: pin submodule back to last-known-good upstream tag, file an issue, ship from the working pin, schedule the bump for after triage.
+
+**Upstream changes function signatures inside a hunk we patched.** `git apply` with default fuzz tolerates 3 lines of context drift; beyond that it fails. Run `git apply --check` first AND a sanity test (`pip install -e .` succeeds, `pytest` smoke runs) inside the build stage.
+
+## CI Changes Required
+
+**`.github/workflows/build-container.yml`** changes:
+1. `actions/checkout@v4` `submodules: recursive` keeps working — submodules will fetch upstream content directly. **Zero edits to checkout step.**
+2. Add a new step before the build: "Validate overlay basis" runs `packages/fox-overlay/scripts/check-overlay-basis.sh`.
+3. Add a build-arg passthrough for `UPSTREAM_WEBUI_TAG` and `UPSTREAM_AGENT_TAG` (read from `versions.toml`).
+4. The `Determine FITB_VERSION` step is unchanged.
+
+**`.github/workflows/sync-submodules.yml`** changes: repurpose to poll upstream for new tags, open a PR bumping `versions.toml` + the submodule pointer.
+
+**Caching.** Multi-stage `COPY --from=upstream-webui` caches at the layer boundary. **Net cache hit rate improves**.
+
+**Image size delta.** Negligible. The `git clone --depth 1` of upstream is the same content the submodule already provides. `rm -rf .git` actually **shrinks** the image.
+
+## Migration Plan (Agent 3's view)
+
+[Phases consolidated into the synthesis section above.]
+
+## Risks (Agent 3's view)
+
+**During migration.** Phase 4 patch extraction misses a hunk. Mitigation: byte-equivalence CI gate. Submodule re-pointing breaks dev environments. Patch fails to apply against upstream HEAD that previously applied against fork master.
+
+**Ongoing.** Patch rot on upstream bumps. Drift between overlay tree and upstream API. Overlay tree drifts from MANIFEST.
+
+## Effort Estimate (Agent 3's view)
+
+**Migration: 8–12 engineering days.**
+
+**Ongoing per-upstream-bump cost:**
+- Best case: **15 minutes**.
+- Typical case: **1–2 hours**.
+- Worst case: **half a day**.
+
+---
+
+# 5. Agent 4 — Upstream State Report (2026-05-08)
+
+## Executive summary
+
+Both upstreams are in an extreme growth-and-iteration phase that bears almost no resemblance to what Fox forked. **`NousResearch/hermes-agent`** has shipped **1,236 commits in the last 30 days alone** (737 since Fox's fork-base on 2026-04-30) and tags a minor release every Thursday — `v0.7.0` through `v0.13.0` all landed in the 35 days between 2026-04-03 and 2026-05-07. **`nesquena/hermes-webui`** has shipped **953 commits in the last 30 days** (479 since Fox's fork-base on 2026-05-03) and tags a patch release essentially daily — `v0.50.278` to `v0.51.22` in five days, including a major version bump for the Kanban v1 feature on 2026-05-05.
+
+Headline features Fox doesn't have include durable multi-agent Kanban, the `/goal` Ralph loop, Checkpoints v2, Google Chat as the 20th platform, a `ProviderProfile` plugin ABC, seven new i18n locales, the `transform_llm_output` plugin hook, and SSE-driven Kanban dashboards.
+
+Stability signals are strongly positive on both repos: 295 contributors on the agent's last release, daily merges from a top-5 contributor pool, no rewrite/abandonment language in commit history, 138K stars on hermes-agent and growing.
+
+Breakage risk on rebase is severe — `api/routes.py` alone grew by 3,153 lines upstream while Fox modified ~1,412 lines of it; five new API modules (`kanban_bridge.py`, `agent_health.py`, `dashboard_probe.py`, `system_health.py`, `session_recovery.py`) appeared upstream that Fox would have to reconcile.
+
+Both upstreams are unambiguously **worth tracking** — the velocity is too high to ignore — but Fox's current fork-and-patch model is no longer viable; a true plugin/overlay architecture is required or Fox will be a year out of date within months.
+
+## NousResearch/hermes-agent — current state
+
+- **Latest tag**: `v2026.5.7` = Hermes Agent **v0.13.0** "Tenacity Release", **2026-05-07** (one day ago).
+- **Cadence (last 6 mo)**: ~weekly minor versions. 12 minor releases in 56 days, accelerating.
+- **Top ~10 themes/features shipped since Fox's fork-base** (737 commits behind):
+  1. **Durable multi-agent Kanban** — heartbeat, reclaim, zombie detection, hallucination gate, per-task `max_retries`, cross-profile shared boards (PRs #17805, #19653, #20232, #20332, #21330, #21183, #21214). Single biggest feature in v0.13.0.
+  2. **`/goal` Ralph loop** — agent stays locked on a target across turns (#18262, #18275, #21287).
+  3. **Pluggable platforms via `ProviderProfile` ABC** — `plugins/model-providers/` directory; third-party providers drop in without core changes (#20324). IRC and Teams already migrated.
+  4. **Google Chat as the 20th messaging platform** plus generic platform-plugin hooks (#21306, #21331).
+  5. **Sessions auto-resume after gateway restart** (#21192) and Checkpoints v2 with real pruning (#20709).
+  6. **Curator subcommands**: `archive`, `prune`, `list-archived`, synchronous `run` (#20200, #21236, #21216).
+  7. **MCP improvements** — SSE transport with OAuth forwarding, stale-pipe retries, image results as MEDIA tags, keepalive (#21227, #21323, #21289, #21328, #20209).
+  8. **`no_agent` cron mode** — script-only watchdog; empty stdout silent (#19709).
+  9. **Post-write delta lint** — agent lints its own `write_file` / `patch` outputs for Python/JSON/YAML/TOML syntax errors before they propagate (#20191).
+  10. **Security wave — 8 P0 closures** in v0.13.0 alone: redaction ON by default, Discord role-allowlists guild-scoped (CVSS 8.1 cross-guild DM bypass), WhatsApp rejects strangers, TOCTOU windows on `auth.json` and MCP OAuth, browser SSRF cloud-metadata floor, cron prompt-injection scans skill content, `hermes debug share` redacts at upload (#21193, #21241, #21291, #21176, #21194, #21228, #21350, #19318).
+  11. **`transform_llm_output` plugin hook** — new lifecycle hook for context-window reducers and content filters (#21235, commit `c3be6ec18`). **This is the key opportunity for Fox.**
+  12. **i18n** — 7 locales (zh, ja, de, es, fr, uk, tr) for static gateway+CLI strings.
+  13. **Six new optional skills** — Shopify, here.now, shop-app, Anthropic financial-services, kanban-video-orchestrator, searxng-search.
+  14. **`X-Hermes-Session-Key` API server header** for long-term memory scoping (#20199).
+- **Open issues / open PRs**: **3,211 open issues**, **5,737 open PRs**.
+- **Top 5 contributors last 6 mo**: Teknium (368), Brooklyn Nicholson (59), teknium1 (53), Austin Pickett (42), brooklyn! (36).
+- **Breaking changes / dependency bumps**:
+  - **Python**: `requires-python = ">=3.11"` at HEAD.
+  - **Pinned upper bounds added** to `openai>=2.21.0,<3`, `anthropic>=0.39.0,<1`, `pydantic>=2.12.5,<3`, `requests>=2.33.0,<3` (CVE-2026-25645), `PyJWT[crypto]>=2.12.0,<3` (CVE-2026-32597).
+  - **Plugin manifest schema** added `kind: standalone|backend|exclusive|platform|model-provider`. Fox's `mem0_oss/plugin.yaml` does not declare `kind` — needs review.
+  - **`gateway/hooks.py`** — new event-driven hook system at `~/.hermes/hooks/` with YAML+Python pairs (separate from `hermes_cli/plugins.py`). **Two parallel hook systems now exist.**
+  - Optional-skill ports touched `cron/scheduler.py`, `cron/jobs.py`, `tools/cronjob_tools.py`, `agent/auxiliary_client.py`, `hermes_cli/runtime_provider.py` — every file Fox modified.
+- **Plugin-system evolution**:
+  - **At HEAD, the Python plugin manager registers ~17 hook events** (added `transform_llm_output`).
+  - **Plugin kinds gained `model-provider`** — third parties can register a `ProviderProfile` via `plugins/model-providers/<name>/`. **Fox's #109 Custom Ollama URL is exactly the shape of a `model-provider` plugin.**
+- **Last 30 days, files in Fox's modified-file set**:
+  - `cron/scheduler.py`: 5 commits.
+  - `cron/jobs.py`: 1 commit.
+  - `tools/cronjob_tools.py`: 2 commits.
+  - `hermes_cli/runtime_provider.py`: 2 commits including `fix(credential_pool): resolve key mix-up when custom providers share base_url` (`e38ea3807`) — directly relevant to Fox's custom-Ollama work, **already implements much of #109**.
+  - `agent/auxiliary_client.py`: 5 commits.
+
+## nesquena/hermes-webui — current state
+
+- **Latest tag**: `v0.51.22` on **2026-05-07**.
+- **Cadence (last 6 mo)**: extremely high — typical day ships **3–10 patch tags**. 953 commits in 16 days (~60/day average).
+- **Top ~10 themes/features shipped since Fox's fork-base** (479 commits behind):
+  1. **Kanban v1 launch** (v0.51.0, PRs #1645, #1646, #1647, #1649, #1654, #1655, #1660, #1675) — first-party-compatible board, multi-board CRUD, real-time SSE event stream, dispatcher contract enforcement, +68 tests.
+  2. **Kanban hardening** (#1828, #1843).
+  3. **VPS resource health panel** + **agent heartbeat alert** + active provider quota status (PR #1676).
+  4. **Workspace polish** (#1816, #1818, #1689, #1702).
+  5. **Custom provider routing** — named custom providers (PR #1818), `:free`/`:beta`/`:thinking` suffix mis-resolution fix (#1783), `custom:*` provider model list (#1619), provider duplicate-group collapse (#1568) — **directly overlaps Fox's #109 custom-Ollama-URL work**.
+  6. **Codex spark models** (#1685), **Codex OAuth onboarding flow** (commit `259c5c4`), **Anthropic OAuth env fallback serialization** (commit `91f99d8`).
+  7. **Streaming markdown** via `smd.min.js` (P0 hotfix in v0.51.22 PR #1851) and **LaTeX `\(...\)` / `\[...\]` delimiter rendering** (PR #1848).
+  8. **No-agent cron edits** support, **shell-route HTML 503 fallback** (PR #1844 v0.51.21).
+  9. **CSP source-map allowance for jsDelivr** (PR #1852).
+  10. **Subpath frontend route hardening**.
+  11. **Auto-compression running indicator**, **adaptive title refresh deadlock fix** (#1693).
+- **Open issues / open PRs**: **65 open issues**, **30 open PRs**.
+- **Top 5 contributors last 6 mo**: nesquena-hermes (343), Hermes Bot (95), Michael Lam (83), test (78), bergeouss (55).
+- **Breaking changes**:
+  - **`api/routes.py` shape**: 5,425 lines at fork-base → 8,578 lines at upstream HEAD (+3,153 lines, +58%). Fox's version has 6,837 lines.
+  - **Five new `api/` modules**: `agent_health.py`, `dashboard_probe.py`, `kanban_bridge.py`, `system_health.py`, `session_recovery.py`. **None overlap Fox's added modules — clean coexistence is possible.**
+  - **Service worker (`static/sw.js`)** version-pin scheme tightened.
+  - **CSP headers** in `api/helpers.py` updated for jsDelivr.
+  - **`localStorage.setItem('hermes-webui-model')` now guarded against `QuotaExceededError`** (commit `9a0a621`).
+- **Plugin / extensibility surface**: webui has **no plugin system** in the agent's sense.
+- **Last 30 days touch on Fox-modified files**: `api/routes.py` 80 commits, `api/streaming.py` 18, `api/models.py` 21, `api/providers.py` 8, `static/index.html` 35, `static/style.css` 66, `static/boot.js` 12, `static/onboarding.js` 5, `static/sw.js` 5, `server.py` 8. **Nearly every Fox-modified file is upstream-active**.
+- **Kanban impact on Fox files**: Kanban v1's 12-commit stack landed on 2026-05-05 and touched `api/routes.py`, `static/index.html`, and `static/style.css`. Specifically: `397d851 feat(kanban): multi-board management + SSE live event stream`, `dc3418c feat: add Kanban dashboard parity core`, `5093e01 feat: add Kanban write semantics MVP`. Fox's `routes.py` and `index.html` patches will require manual three-way reconciliation here.
+
+## Other NousResearch projects worth knowing
+
+- **`hermes-agent-self-evolution`** (2,915 stars) — DSPy + GEPA evolutionary skill optimizer.
+- **`hermes-paperclip-adapter`** (1,126 stars) — Hermes as a managed employee in Paperclip.
+- **`atropos`** (1,178 stars) — RL environments framework.
+- **`autonovel`** (882 stars), **`pokemon-agent`** (85 stars) — applications built on Hermes Agent.
+- **`NemoClaw`**, **`OpenShell-Community`** — sandbox runtime for autonomous agents.
+- **No repos suggest hermes-agent is being rewritten or absorbed**. The org's posture is to invest in `hermes-agent` as the flagship and add adapters/applications around it.
+
+## Implications for the Fox separation architecture
+
+- **Cadence reality check**: 1,236 agent commits + 953 webui commits in the **last 30 days** = ~73 upstream commits per day across both. Even a weekly Fox rebase would face ~500 commits worth of conflict surface. A patch-series-on-tag-only strategy (only re-baselining when upstream tags a release) is the only sustainable model.
+- **Drop-in opportunities (Fox commits to retire)**:
+  - **#109 Custom Ollama URL** is partially obsolete. Drop redundant parts.
+  - **Fox's `mem0_oss` plugin** uses an outdated `plugin.yaml` schema.
+- **Plugin hooks Fox should adopt to retire monkey-patches**:
+  - **`transform_llm_output`** for Fox guardrails Phase 1.
+  - **`pre_gateway_dispatch`** for Fox admission control.
+  - **`on_session_start` / `on_session_finalize`** for `mem0_oss`.
+  - **`pre_approval_request` / `post_approval_response`** for Llama Guard 3 (Phase 4 / #6).
+  - **`plugins/model-providers/` directory + `ProviderProfile` ABC**.
+- **Patches at structural risk**:
+  - **`api/routes.py`** — single largest conflict surface. Recommendation: shard Fox's routes into `api/fox_*.py` modules.
+  - **`static/style.css`** — 66 upstream commits in 30 days.
+  - **`static/index.html`** — 35 upstream commits/30 days.
+  - **`cron/scheduler.py`** — `af9336d57 feat(gateway): generic plugin hooks for env enablement + cron delivery` directly contests this file.
+- **Kanban as forcing function**: webui's Kanban v1 added a parallel UI layer that Fox doesn't need but users will expect. Either Fox enables it pass-through (zero work) or hides it (CSS/route gating).
+- **Security cadence**: 8 P0 security closures in v0.13.0 alone, including a CVSS 8.1 cross-guild Discord DM bypass. Fox tracking upstream tags weekly, not monthly, is now a **security requirement**, not just a freshness preference.
+
+## Sources
+
+**Repos & releases**
+- https://github.com/NousResearch/hermes-agent (138,586 stars)
+- https://github.com/NousResearch/hermes-agent/releases (latest `v2026.5.7` = v0.13.0)
+- https://github.com/nesquena/hermes-webui
+- https://github.com/nesquena/hermes-webui/releases (latest `v0.51.22`)
+- https://github.com/orgs/NousResearch/repositories?type=public
+
+**Local clones with `upstream` remote**
+- `/Users/macpro/Desktop/Fox-In-the-Box/hermes-agent` — upstream HEAD `a3131862b` (2026-05-08), merge-base `e5dad4ac` (2026-04-30), 737 commits behind.
+- `/Users/macpro/Desktop/Fox-In-the-Box/hermes-webui` — upstream HEAD `5005f1c8` (2026-05-07), merge-base `9e31a2ac` (2026-05-03), 479 commits behind.
+
+**Issue counts (via `gh api search/issues`)**
+- NousResearch/hermes-agent: 3,211 open issues + 5,737 open PRs
+- nesquena/hermes-webui: 65 open issues + 30 open PRs
+
+**Top contributors (via `git shortlog -sn upstream/{main,master} --since='2025-11-08'`)**
+- Agent: Teknium 368, Brooklyn Nicholson 59, teknium1 53, Austin Pickett 42, brooklyn! 36
+- Webui: nesquena-hermes 343, Hermes Bot 95, Michael Lam 83, test 78, bergeouss 55
+
+---
+
+# 6. Decision Points Still Open
+
+Three things need explicit sign-off before any implementation starts:
+
+1. **Approach: hybrid as described in section 1?** (Submodule-pinned-upstream + sibling overlay + 9-line patch + runtime plugin adoption.) Or a single lane?
+
+2. **Migration cadence: ship as v0.5.5 (3 weeks of dedicated work), or interleave with Phase 1 guardrails (#4 + #5)?** The roadmap currently has Phase 1 in v0.5.5; this work would either delay it or share the slot.
+
+3. **Upstream-PR campaign first?** Send the 5 bug-fix-class commits (~7 files) upstream before migration, so the patch series starts smaller. Adds ~3–5 days but materially reduces ongoing maintenance.
+
+---
+
+**Document control**
+
+- Generated: 2026-05-08
+- Research dispatch: 4 parallel agents (Plan + general-purpose subagents)
+- Synthesis author: Claude Code (Opus 4.7)
+- Status: NOT COMMITTED — local document only, awaiting decision per @roadhero instruction
+- Location: `docs/architecture/upstream-separation-plan.md` in working tree

--- a/docs/architecture/v0.6.0-github-breakdown-v2.md
+++ b/docs/architecture/v0.6.0-github-breakdown-v2.md
@@ -1,0 +1,301 @@
+# v0.6.0 — Upstream Separation Migration: GitHub Epic + Tickets Breakdown (v2)
+
+**Status:** FINAL DRAFT — awaiting Dennis sign-off before issue creation
+**Date:** 2026-05-16
+**Supersedes:** `v0.6.0-github-breakdown.md` (v1)
+**Drives:** `upstream-migration-execution-plan.md` (Architect 1's authoritative plan)
+
+This is v2 after independent review by two unbiased architects (Reviewer A: gap-finder; Reviewer B: dependency/risk-skeptic). 21 confirmed findings applied. 5 judgment calls resolved per Dennis 2026-05-16.
+
+## 0. Decisions locked in this revision
+
+| # | Decision | Resolution |
+|---|---|---|
+| Q1 | Phase numbering (Architect 1 = "10-phase" but doc has §Phase 0–10) | Keep as drafted; phase NAME numbering is informational; what matters is the work, not the label |
+| Q2 | Initial webui tag pin | **`v0.51.74`** (latest stable at v2 writing); re-evaluate at Phase 8 merge time and pin to whatever's latest then; dry-run before merge |
+| Q3 | Phase 5 — 12 PRs (6 fork + 6 monorepo)? | **Keep 12 PRs.** Fork-side are one-line `git rm`s, batch-reviewable in minutes; preserves cross-repo cohesion |
+| Q4 | Memory updates beyond `project_state_v0_6_0.md` | **Update `reference_repo_paths.md` + `reference_upstream_origins.md` in Phase 10b** (#52) |
+| Q5 | Phase 10b archive vs Phase 8 rollback dependency | **Add prereq to #52**: "48h soak complete + zero rollback issues filed during soak window" |
+
+## 1. Changes vs v1 — all 21 reviewer findings applied
+
+| # | Finding (source: Reviewer A=GapFinder, B=RiskSkeptic) | v2 fix |
+|---|---|---|
+| 1 | B: Phase 2 vs Phase 3 Dockerfile merge conflict | §4 Phase 2 — explicit serialization: monorepo PR #14 before #17; §4 Phase 3 — rebase note in body |
+| 2 | A+B: Phase 6 prereq over-tightened (was "4+5 merged") | Phase 6 (#35) prereq softened to "Phase 4 merged; Phase 5 strongly recommended"; allows P5/P6 parallelism if 2 engineers |
+| 3 | A: Validation/Rollback content not verbatim in tickets | Issue-creation script (§8) splices verbatim Validation + Rollback per phase from `upstream-migration-execution-plan.md` at create time |
+| 4 | A+B: Phase 8 — pick atomic, drop 8a/8b/8c hedge | **Phase 8 is one atomic PR (#45)**. No 8a/8b/8c split. Single revert if rollback. |
+| 5 | A: Rule 3 violated — regression suite must grow per-phase | Every phase ticket body now includes a "tests/checklist additions" line that names the specific smoke row added |
+| 6 | A: Rule 2 second soak (Phase 10 if user-visible changes) | Phase 10b (#52) body has conditional soak clause; clause is "no soak needed unless cleanup touches user-facing wording/asset/route" |
+| 7 | A: Phase 5 dispatch-no-overlap test filed as conditional | Test is now a **hard prereq of module #1** (`ollama.py` PR pair #22/#23); breakdown updated to reflect |
+| 8 | A: Phase 6 PR count (was 5, plan says 6) | Phase 6 now has 6 monorepo PRs: #36 streaming, #37 models, #38 config, #39 providers, #40a patch `updates.py`, #40b decision-only "delete vs patch updates.py" |
+| 9 | A: Phase 5 smoke gates — `models_download.py` was duplicated | Phase 5 table clarifies: `local_fallback` + `models_download` share a combined F+G+H gate run once at the later-merging PR; each module's PR body specifies which scenarios validate it |
+| 10 | B: Mid-migration tripwire escalation policy missing | `#53` (Tripwires) body adds: "any tripwire firing before Phase 8 ships pauses migration; 24h escalation to Dennis" |
+| 11 | B: P0-during-soak policy | Phase 8 (#45) body: "if a P0 fix lands during 48h soak, soak clock resets to zero on the new tag" |
+| 12 | B: Phase 10 nightly-watch precondition too loose | Phase 10a (#51) prereq tightened from "1 successful nightly run" to "1 force-mismatch `workflow_dispatch` run verified" |
+| 13 | B: Decision Tracker #2 closure condition wrong | Tracker #2 closes at **Phase 8 PR #45 open**, not Phase 1 start (Q3 tag decision is deferred to Phase 8) |
+| 14 | A: Module ordering in Phase 5 | `session_recovery.py` lands last (longest smoke + #129 failover-engine coupling); other 5 modules can land in any order |
+| 15 | A: Doc updates needed earlier than Phase 10 | CLAUDE.md "Repository Structure" updated in Phase 1 PR (#11) body; `versions.toml` doc lives in Phase 8 PR (#45); other docs still in Phase 10a |
+| 16 | B: Phase 8 dry-run timing | Phase 8 (#45) acceptance criteria: "dry-run executed and logged at least 24h before merge window opens" |
+| 17 | B: In-flight onboarding sessions during Phase 7 | Phase 7 (#43) Section L smoke row added: "User with stale onboarding cookie on pre-Phase-7 image is gracefully redirected to fresh wizard" |
+| 18 | B: Phase 8 rollback notification gap | Phase 8 (#45) rollback procedure step 5 added: notify Electron auto-update channel, post status to release-notes channel, pin rollback notice to GitHub release |
+| 19 | B: Engineer-sick checkpoint | Epic (#1) body adds: "end-of-phase 1-paragraph state-of-migration comment posted, so substitute engineer can resume from any phase boundary" |
+| 20 | B: Weekend accounting in 48h soak | Pre-flight (#3) and Phase 8 (#45) bodies state: "48h soak = calendar time including weekends; engineer is on call but not actively working" |
+| 21 | A: CVE feed (#59) sequencing — move to pre-Phase-8 | Tripwires (#53) body — #59 moved to "before Phase 8" bucket alongside #54, #55, #57 |
+
+Plus 4 minor v1 corrections:
+- v1 had Phase 0 tracker numbered #4, colliding with roadmap issue #4 (Guardrails). v2 disambiguates: roadmap Guardrails referenced by name, not number.
+- v1 had Phase 9 label as single `upstream-drift P2`; corrected to two labels `upstream-drift` + `P2`.
+- v1 had Pre-flight #3 missing the "will be invalidated by submodule re-point" rationale; restored.
+- v1 had Phase 4 #19 dropping "Phase 2 strongly recommended" softening; restored.
+
+## 2. Epic structure (corrected)
+
+```
+EPIC #1 (v0.6.0): Upstream-Separation Migration
+│
+├── Decision Tracker #2: Three Open Questions (closes at #45 open, not Phase 1)
+├── Pre-flight #3: Stabilization pass + Go/No-Go checklist
+│
+├── Phase 0  (#4):  Upstream-PR campaign           ──► 5 upstream PR trackers (#5–#9)  [async, parallel-safe]
+├── Phase 1  (#10): Scaffold packages/fox-overlay/ ──► 1 PR (#11)                       [blocking]
+├── Phase 2  (#12): Static-file overlay            ──► PRs #13, #14                     [merge BEFORE Phase 3]
+├── Phase 3  (#15): Agent plugin + monkey-patches  ──► PRs #16, #17                     [merge AFTER Phase 2 monorepo PR]
+├── Phase 4  (#18): 9-line webui patches           ──► PRs #19, #20                     [REVIEW CHECKPOINT 1]
+├── Phase 5  (#21): Additive webui modules         ──► 12 PRs (#22–#33), 6 pairs        [ollama first; session_recovery last]
+├── Phase 6  (#34): Mid-file webui monkey-patches  ──► PRs #35, #36–#40b (6 monorepo)  [Phase 4 hard prereq; Phase 5 recommended]
+├── Phase 7  (#41): Onboarding wholesale-replace   ──► PRs #42, #43
+├── Phase 8  (#44): Submodule re-point             ──► 1 atomic PR (#45)                [REVIEW CHECKPOINT 2 + 48h soak]
+├── Phase 9  (#48): Nightly upstream-watch CI      ──► 1 PR (#49)                       [after Phase 8 soak]
+├── Phase 10 (#50): Cleanup + docs + archive       ──► PRs #51, #52                     [after 1 force-mismatch verified]
+│
+└── Tripwires (#53): 10 monitoring tripwires       ──► 10 sub-issues (#54–#63)          [parallel-safe; some PRE-Phase-8]
+```
+
+**Total ticket count:** 1 epic + 1 decision + 1 pre-flight + 5 upstream-PR trackers + 1 Phase-0 parent + 1 PR per Phase 1 + 2 per Phase 2-4 + 12 per Phase 5 + 7 per Phase 6 (1 fork + 6 monorepo) + 2 per Phase 7 + 1 atomic per Phase 8 + 1 per Phase 9 + 2 per Phase 10 + 1 Tripwires parent + 10 tripwire sub-issues + 10 phase trackers = **~62 issues**.
+
+## 3. Dependency graph (v2 — corrected serialization)
+
+```
+                Phase 0 (PR campaign, async, never blocks)
+                    │
+                    ▼
+Pre-flight #3 ─► Decision #2 ─► Phase 1
+                                  │
+                  ┌───────────────┘
+                  ▼
+              Phase 2 (#14 monorepo PR merges first)
+                  │
+                  ▼
+              Phase 3 (#17 rebases onto #14; or land sequential)
+                  │
+                  ▼
+              Phase 4 (REVIEW CHECKPOINT 1)
+              │
+       ┌──────┼──────┐
+       ▼      ▼      ▼
+   Phase 5  Phase 6  (parallel-safe if 2 engineers; serialize if 1)
+       │      │
+       └──┬───┘
+          ▼
+      Phase 7
+          │
+          ▼
+      Phase 8 atomic PR (REVIEW CHECKPOINT 2)
+          │
+          ▼  ◄── 48h soak (calendar time inc. weekends; engineer on-call)
+          │
+          ▼
+      Phase 9 (after soak; need 1 force-mismatch dispatch verified)
+          │
+          ▼
+      Phase 10a (#51 docs cleanup)
+          │
+          ▼  ◄── conditional second soak if user-visible cleanup
+          │
+          ▼
+      Phase 10b (#52 fork archive — only after zero rollback issues)
+          │
+          ▼
+       EPIC CLOSES
+
+Tripwires (parallel-safe, runs alongside):
+  Pre-Phase-8 deploy:  #54 (digest), #55 (license), #57 (NousResearch UI watch), #59 (CVE feed)
+  Concurrent w/ Phase 8/9:  #58 (maintainer canary)
+  Post-Phase-8:  #56, #60, #61, #62, #63
+```
+
+**Key correctness fixes vs v1:**
+- Phase 2 monorepo PR (#14) MUST merge before Phase 3 monorepo PR (#17). They edit the same Dockerfile region (lines 128–130). Annotation in v1 said "parallel-safe" — corrected.
+- Phase 6 hard prereq is Phase 4 only. Phase 5 is "strongly recommended" but allows 2-engineer parallelism.
+- Phase 8 is atomic; no sub-PR split.
+- Phase 9 hard prereq is "48h soak complete AND 1 force-mismatch workflow_dispatch verified."
+- Phase 10b hard prereq is "48h soak complete + zero rollback issues filed during soak window."
+
+## 4. Labels strategy (unchanged from v1)
+
+`v0.6.0`, `migration`, `phase-0..10`, `upstream-pr`, `tripwire`, `fork-side`, `monorepo`, `blocking`, `parallel-safe`, `smoke-required`, `48h-soak`, `P2` (when relevant).
+
+## 5. Milestone
+
+Single milestone: **`v0.6.0`**. Target close: ~5 calendar weeks after Phase 1 start (12.5 eng-days critical path + 48h soak + 1 review checkpoint + Phase 0 async latency).
+
+## 6. Per-issue body template (the script will splice these per phase)
+
+Every ticket follows this body shape. **For each phase, the script splices in verbatim Validation and Rollback content from `upstream-migration-execution-plan.md`** at issue-creation time, eliminating drift between the plan and the tickets:
+
+```markdown
+## Scope
+<one-line summary>
+
+## Parent
+<link to phase tracker or epic>
+
+## Prerequisites
+<- list other tickets that must close first>
+
+## Deliverable
+<- exact files/dirs/commands; cross-reference plan §<phase>, lines <Y-Z>>
+
+## Validation gates
+<- VERBATIM from plan §<phase>; spliced in at creation time>
+
+## Rollback
+<- VERBATIM from plan §<phase>; spliced in at creation time>
+
+## Tests / checklist additions  (NEW in v2 — Rule 3 compliance)
+<- specific qa/SMOKE_CHECKLIST.md Section L row added by this PR>
+
+## Estimated effort
+<- hours/days from plan>
+
+## References
+- upstream-migration-execution-plan.md §<phase>
+- relevant memory files
+```
+
+## 7. Per-phase notes (deltas from v1; structure & prereqs)
+
+### Epic #1
+- Body adds "engineer-sick checkpoint" requirement: every phase close posts a 1-paragraph state-of-migration update as an epic comment so a substitute engineer can resume.
+
+### Decision Tracker #2
+- **Closes at Phase 8 #45 open**, not Phase 1.
+- Q3 (tag pin) re-confirmed at Phase 8 start; currently `v0.51.74` for webui + latest stable `v2026.5.7` (=v0.13.0) for agent; Phase 8 PR will lock final selection.
+
+### Pre-flight #3
+- Restores rationale: "no open PR on forks **— they will be invalidated by the submodule re-point**."
+- Adds: "48h soak = calendar time including weekends."
+
+### Phase 0 (#4)
+- 5 sub-trackers unchanged; #5 (`runtime_provider.py`) prioritized as the cleanest one-line bug fix.
+
+### Phase 1 (#10)
+- Sub-PR #11 body now includes: update CLAUDE.md "Repository Structure" section to mention `packages/fox-overlay/`.
+- Tests/checklist addition: smoke A1–A4 verified.
+
+### Phase 2 (#12)
+- **Monorepo PR #14 must merge BEFORE Phase 3 monorepo PR #17** (Dockerfile region collision).
+- Tests/checklist addition: `sw.js` cache disable verified (Section A2); font MIME types verified.
+
+### Phase 3 (#15)
+- Sub-PR #17 body explicitly notes: rebase onto #14 before merge.
+- Validation requires **four** `[fox-overlay] patched ...` log lines (not three as v1 said).
+- Tests/checklist addition: smoke D for mem0; cron failure diagnostics regression.
+
+### Phase 4 (#18)
+- REVIEW CHECKPOINT 1 with Dennis before Phase 5 begins.
+- Sub-PR #19 prereq restored: "Phase 2 strongly recommended."
+- Sub-PR #20 validation adds: `curl -X POST /api/setup/skip` returns 200.
+- Tests/checklist addition: dispatcher skeleton smoke + log-line check.
+
+### Phase 5 (#21) — module ordering
+- **Module #1 (`ollama.py`)** must include `tests/test_dispatch_no_overlap.py` — hard prereq.
+- **Module #6 (`session_recovery.py`)** lands last.
+- Modules #2–#5 (`tailscale`, `local_fallback`, `models_download`, `hostname`) land in any order.
+- `local_fallback` and `models_download` share a combined F+G+H smoke run executed when the second of the pair lands (avoids running F+G+H twice).
+- Tests/checklist addition: per-module Section L row capturing the module's smoke section.
+
+### Phase 6 (#34) — 6 monorepo PRs
+- Hard prereq: Phase 4 (was "4 + 5" in v1).
+- 6 monorepo PRs:
+  - #36 streaming.py (silent failover #129b)
+  - #37 models.py (Session.save #1558)
+  - #38 config.py — **must merge first** (others read its settings)
+  - #39 providers.py (gateway hot-reload)
+  - #40a updates.py — patch path
+  - #40b updates.py — delete path (decision-only ticket; pick #40a OR #40b)
+- After #38 merges, #36/#37/#39/#40a/#40b are parallel-safe.
+- Tests/checklist addition: per-patch Section L row + existing `test_metadata_save_wipe_1558.py`.
+
+### Phase 7 (#41)
+- Sub-PR #43 adds Section L smoke row: "User with stale onboarding cookie on pre-Phase-7 image is gracefully redirected to fresh wizard."
+- Tests/checklist addition: full wizard walk-through Section B + new stale-cookie row.
+
+### Phase 8 (#44) — ONE atomic PR
+- **#45 is the entire phase.** Re-pin webui + re-pin agent + Dockerfile + `versions.toml` + `check-overlay-basis.sh` + `.github/workflows/build-container.yml` update + delete `_ensure_active_branch()` + delete `scripts/apply-local-patches.sh` from fork (verify, not re-delete) — all in one PR with one revert path.
+- REVIEW CHECKPOINT 2 with Dennis before merge.
+- Acceptance criteria adds: "Dry-run executed and logged at least 24h before merge window opens."
+- Body includes "if P0 fix lands during soak, soak clock resets to zero on new tag."
+- Rollback procedure step 5: notify Electron auto-update channel, post status to release-notes, pin rollback notice to GitHub release.
+- `48h-soak` label triggers post-merge.
+- Tests/checklist addition: full A–L smoke pass on Apple Silicon AND x86_64.
+
+### Phase 9 (#48)
+- Hard prereq: Phase 8 (#45) merged AND 48h soak complete.
+- Validation: 1 force-mismatch `workflow_dispatch` run verified (NOT just "1 successful run").
+- Labels: `upstream-drift`, `P2` (two separate labels).
+
+### Phase 10 (#50)
+- Sub-PR #51 (docs cleanup) — prereq: "1 force-mismatch workflow_dispatch verified on Phase 9 workflow."
+- Sub-PR #52 (fork archive) — prereq: "48h soak complete + zero rollback issues filed during soak."
+- Sub-PR #52 body adds: refresh `reference_repo_paths.md` and `reference_upstream_origins.md` in memory.
+- Sub-PR #52 conditional second soak clause: "if any docs cleanup touches user-facing wording/asset/route, additional 48h soak required."
+
+### Tripwires (#53)
+- Pre-Phase-8 deploy: #54 (digest with always-conflict file alerting), #55 (license watch), #57 (NousResearch UI watch), **#59 (CVE feed — moved from post-Phase-8 in v1)**.
+- Concurrent with Phase 8/9: #58 (maintainer canary; debounce note for vacation window).
+- Post-Phase-8 deploy: #56, #60, #61, #62, #63.
+- Body adds: "any tripwire firing before Phase 8 ships pauses migration; 24h escalation to Dennis."
+
+## 8. Issue-creation script (executed after Dennis sign-off)
+
+A single shell script (`scripts/create-v0.6.0-issues.sh`, generated at GitHub-creation time, not checked in long-term) will:
+1. Read `upstream-migration-execution-plan.md` and extract Validation + Rollback blocks per phase.
+2. Read this v2 doc for prereq/effort/label/body-template info.
+3. Create the epic first; capture its number.
+4. Create the decision tracker, pre-flight, and Phase-0 parent; capture numbers.
+5. Create the 5 upstream-PR trackers under Phase 0.
+6. For each phase 1–10, create the phase tracker then the PR sub-issues.
+7. Create the Tripwires parent and 10 sub-issues.
+8. Set parent/child relations via `gh issue edit ... --add-sub-issue` (or via Linear-style references in bodies if GitHub's sub-issue API is unavailable).
+9. Apply labels and milestone.
+10. Output a final summary table of `(number, title, parent, labels)` for sanity check.
+
+Pre-flight check: count of issues created must equal expected count (~62). If mismatched, the script halts and reports diff.
+
+## 9. Acceptance gate for this v2 doc
+
+Before issue creation begins:
+- [ ] Dennis confirms v2 is final.
+- [ ] All 21 reviewer findings present (audit § 1 table).
+- [ ] All 5 Dennis Q&A answers present (audit § 0 table).
+- [ ] Dependency graph reflects all serialization corrections.
+- [ ] Module ordering in Phase 5 explicit (ollama first; session_recovery last).
+- [ ] Phase 6 internal ordering explicit (config first).
+- [ ] Phase 8 atomic (no sub-split).
+- [ ] Phase 9 force-mismatch precondition wording present.
+- [ ] Phase 10b 48h-soak-clean precondition wording present.
+
+Once approved, `scripts/create-v0.6.0-issues.sh` runs in one batch via `gh` CLI and creates all ~62 issues with consistent labels, milestone, and parent/child relations.
+
+## 10. What does NOT change vs v1
+
+- The 10-phase structure itself.
+- Total effort estimate (~14 eng-days, 5 calendar weeks).
+- Labels strategy.
+- Milestone.
+- The 21-item reviewer-finding integration approach.
+- The 5 upstream PRs in Phase 0.
+- The 10 tripwires.
+- The four out-of-scope items (React rewrite, #64 visual overhaul, Phase 1 Guardrails, other roadmap work).

--- a/docs/architecture/v0.6.0-github-breakdown.md
+++ b/docs/architecture/v0.6.0-github-breakdown.md
@@ -1,0 +1,625 @@
+# v0.6.0 — Upstream Separation Migration: GitHub Epic + Tickets Breakdown
+
+**Status:** DRAFT — awaiting unbiased architect review before issues are created on GitHub
+**Date:** 2026-05-16
+**Author:** Claude (drafting); reviewed by Architects A and B (gap + dependency lanes)
+**Drives:** `docs/architecture/upstream-migration-execution-plan.md` (Architect 1's 10-phase plan)
+**Approved by Dennis:** YES — v0.6.0 = this migration; everything else pushed behind; daily tag-check + weekly UI bump cadence
+
+---
+
+## 0. Scope confirmation
+
+**In scope for v0.6.0:**
+
+1. Architect 1's 10-phase migration (Phases 0–10) — every phase, no gaps
+2. Tripwires from Architect 3's risk assessment (10 items)
+3. Open Questions resolved up front (3 decisions captured as comments on the epic)
+4. Documentation updates (CLAUDE.md, AGENTS.md, CONTRIBUTING.md, README.md, qa/SMOKE_CHECKLIST.md)
+5. The pre-migration v0.5.5 stabilization pass per anti-regression Rule 5
+
+**Out of scope for v0.6.0** (per Dennis's decisions today):
+
+- React/shadcn/Tailwind rewrite (Architect 2 Path A) — deferred indefinitely; revisit only on a trigger
+- Phase 3 visual UI overhaul (#64) — postponed to v0.6.1 after migration soaks
+- Phase 1 Guardrails (`fox-guardrails` #4 + Presidio PII #5) — pushed to v0.6.2 or later
+- Any other Phase 2–5 roadmap work (#7, #6, #12)
+
+---
+
+## 1. Epic structure (top-down)
+
+```
+EPIC #1 (v0.6.0): Upstream-Separation Migration
+│
+├── Decision Tracker #2: Three Open Questions (slot, Phase-0, tag-pin)
+├── Pre-flight #3: Stabilization pass (Rule 5)
+│
+├── Phase 0  (#4):  Upstream-PR campaign (async)         ──► 5 upstream PR trackers (#5–#9)
+├── Phase 1  (#10): Scaffold packages/fox-overlay/       ──► 1 PR (#11)
+├── Phase 2  (#12): Static-file overlay                  ──► 2 PRs: fork-side (#13), monorepo (#14)
+├── Phase 3  (#15): Agent plugin + monkey-patches        ──► 2 PRs: fork-side (#16), monorepo (#17)
+├── Phase 4  (#18): 9-line webui patches                 ──► 2 PRs: fork-side (#19), monorepo (#20)
+├── Phase 5  (#21): Additive webui modules               ──► 6 PR pairs (#22–#33), one per module
+├── Phase 6  (#34): Mid-file webui monkey-patches        ──► 6 PRs: 1 fork-side (#35) + 5 monorepo (#36–#40)
+├── Phase 7  (#41): Onboarding wholesale-replace         ──► 2 PRs: fork-side (#42), monorepo (#43)
+├── Phase 8  (#44): Submodule re-point + multi-stage Dockerfile ──► 3 PRs: #45, #46, #47
+├── Phase 9  (#48): Nightly upstream-watch CI            ──► 1 PR (#49)
+├── Phase 10 (#50): Cleanup + docs                       ──► 2 PRs (#51, #52)
+│
+└── Tripwires (#53): 10 monitoring/alert mechanisms     ──► 10 sub-issues (#54–#63)
+```
+
+**Total ticket count: 63** — 1 epic + 1 decision tracker + 1 pre-flight + 11 phase trackers + 33 PR-level issues + 10 tripwire issues + 5 upstream PR trackers + 1 documentation tracker. Numbers above are placeholders; GitHub will assign real numbers when created.
+
+---
+
+## 2. Labels strategy
+
+| Label | Applied to | Color |
+|---|---|---|
+| `v0.6.0` | All issues in this epic | red (priority) |
+| `migration` | All migration phase tickets (excludes tripwires + decision tracker) | blue |
+| `phase-0` ... `phase-10` | Per-phase scoping | yellow |
+| `upstream-pr` | The 5 Phase-0 upstream PR trackers | green |
+| `tripwire` | The 10 monitoring tickets | purple |
+| `fork-side` | PRs that land in fox-in-the-box-ai/hermes-{agent,webui} | orange |
+| `monorepo` | PRs that land in fox-in-the-box-ai/fox-in-the-box | orange (light) |
+| `blocking` | Anything in the critical path | red (light) |
+| `parallel-safe` | Phases that can run in parallel with another phase | green (light) |
+| `smoke-required` | Phase tickets that require full SMOKE_CHECKLIST run before close | red (dark) |
+| `48h-soak` | Phases triggering anti-regression Rule 2 soak window | yellow (dark) |
+
+---
+
+## 3. Milestone
+
+Single milestone: **`v0.6.0`** (target close: 5 calendar weeks from Phase 1 start; 14 engineering-days actual work + 48h soaks + 1 review checkpoint + 1 PR-campaign latency window).
+
+---
+
+## 4. Issue-by-issue breakdown
+
+Every ticket below uses this consistent body template:
+
+```
+## Scope
+<one-line summary>
+
+## Parent
+<link to phase tracker or epic>
+
+## Prerequisites
+<- list other tickets that must close first; or "none">
+
+## Deliverable
+<- exact files/dirs/commands; reference upstream-migration-execution-plan.md section>
+
+## Validation gates
+<- copy-paste from Architect 1's plan; smoke sections required>
+
+## Rollback
+<- copy-paste from Architect 1's plan>
+
+## Estimated effort
+<- hours or days>
+
+## References
+- upstream-migration-execution-plan.md §<phase>
+- (any prior-art issues / memory files)
+```
+
+---
+
+### EPIC #1 — `[v0.6.0] Upstream-Separation Migration`
+
+**Body:**
+
+```markdown
+This epic tracks the full migration of Fox in the Box's dependency on
+NousResearch/hermes-agent and nesquena/hermes-webui from "edit-fork-files-directly"
+to "pin-virgin-upstream + sibling fox-overlay package". When this epic closes,
+Fox can absorb upstream weekly with ≤ 1 hour of effort per release, vs. today's
+"never pull, gap grows forever" model.
+
+## Approved decisions (2026-05-16)
+
+- **Slotting:** This migration IS v0.6.0 — full stop, every other roadmap item
+  pushed behind it.
+- **WebUI strategy:** No React rewrite. Visual quality lift comes later via the
+  existing overlay's `HERMES_WEBUI_EXTENSION_DIR` (#64 deferred to v0.6.1).
+- **Cadence:** Daily upstream tag-check (CI), weekly UI bump cadence (manual).
+
+## Sub-trackers
+
+- Pre-flight stabilization: #3
+- Phase 0 (upstream PR campaign): #4
+- Phases 1–10: #10, #12, #15, #18, #21, #34, #41, #44, #48, #50
+- Tripwires: #53
+
+## Acceptance criteria
+
+- [ ] All 11 phase trackers (#4, #10–#50) closed
+- [ ] All 5 Phase-0 upstream PR trackers closed (accepted, rejected, or stale)
+- [ ] All 10 tripwires (#54–#63) deployed and verified
+- [ ] Full SMOKE_CHECKLIST.md A–L green on both Apple Silicon and x86_64 hosts
+- [ ] 48-hour soak post-Phase-8 passes with no user reports
+- [ ] CHANGELOG.md `## [0.6.0]` entry written
+- [ ] CLAUDE.md, AGENTS.md, CONTRIBUTING.md, README.md updated to reflect overlay model
+- [ ] `:stable` tag moves to v0.6.0 release
+- [ ] Memory updated: new `project_state_v0_6_0.md` entry
+
+## Out of scope (deferred)
+
+- React/shadcn rewrite — never, until trigger
+- Phase 3 vanilla-CSS UI overhaul (#64) — v0.6.1
+- Phase 1 Guardrails (#4 + #5) — v0.6.2 or later
+```
+
+**Labels:** `v0.6.0`, `migration`, `blocking`
+**Milestone:** v0.6.0
+**Assignee:** Dennis (epic owner; engineering owner reassigned per phase)
+
+---
+
+### DECISION TRACKER #2 — `[v0.6.0] Three Open Questions (confirm before Phase 1)`
+
+Three answers from today's conversation; this ticket records them in-repo so they're not lost if memory rolls.
+
+**Body:**
+
+```markdown
+Per upstream-migration-execution-plan.md §5, three decisions must be locked
+before Phase 1 starts. All three are answered by Dennis 2026-05-16:
+
+## Q1: Where in the roadmap does this slot?
+**A: Option (a) — Migration IS v0.5.5/v0.6.0 (slot TBD: see note).** Push Phase 1
+Guardrails behind it.
+**Note for engineering:** Per anti-regression Rule 1 ("one big change per release"),
+Architect 1's plan recommends shipping this as v0.6.0 (not v0.5.5) because the
+scope is substantially larger than a typical minor bump. We'll release as **v0.6.0**
+to match scope; v0.5.5 will be a skipped version number.
+
+## Q2: Phase 0 (Upstream-PR campaign) — go or skip?
+**A: GO.** Run in parallel with Phase 1. Time-boxed; do not block migration.
+
+## Q3: Choice of upstream tag pin for the initial cut.
+**A: Latest stable tags at Phase 8 time.** Re-evaluate at Phase 8 start; the
+recommendation right now (2026-05-16) is `hermes-agent v2026.5.7` (=v0.13.0)
+and `hermes-webui v0.51.74`. Tag selection is the FIRST step of Phase 8 PR #45.
+
+## Rule violations flagged
+
+None. All three answers align with the five anti-regression rules.
+```
+
+**Labels:** `v0.6.0`, `migration`, `blocking`
+**Closes:** automatically when Phase 1 (#10) is started.
+
+---
+
+### PRE-FLIGHT #3 — `[v0.6.0] Pre-flight: Stabilization pass + Go/No-Go checklist`
+
+**Body:**
+
+```markdown
+Anti-regression Rule 5 mandates a stabilization pass before every minor bump.
+Combined with Architect 1's Go/No-Go preconditions, this ticket gates Phase 1.
+
+## Code preconditions
+- [ ] `main` is at v0.5.4 stable, no in-flight feature branches blocking on
+      the always-conflict file set (api/routes.py, static/index.html,
+      static/panels.js, api/streaming.py, api/onboarding.py, api/config.py).
+- [ ] v0.5.4 follow-on issues #138/#139/#140 all closed.
+- [ ] Smoke checklist Section L row for v0.5.4 passes against `:stable`.
+- [ ] No open PR on fox-in-the-box-ai/hermes-{webui,agent} forks.
+- [ ] `.github/workflows/sync-submodules.yml` paused (workflow_dispatch only).
+
+## Roadmap preconditions
+- [ ] Phase 1 Guardrails (#4 + #5) explicitly pushed (note posted to roadmap).
+- [ ] Decision tracker #2 confirmed.
+
+## Team capacity preconditions
+- [ ] One engineer with 14 days focused capacity over 5-week window. Owner: ?
+- [ ] Dennis available for 2 review checkpoints: end of Phase 4 (patch series
+      locked) and end of Phase 8 (submodule re-point passed smoke).
+- [ ] Real-hardware tester available for Phase 8 (full SMOKE_CHECKLIST.md A–L,
+      ~30 min if green).
+
+## Infrastructure preconditions
+- [ ] Verification container pattern (reference_test_container.md) works on
+      Apple Silicon AND x86_64 host.
+- [ ] Standalone clones at ~/Documents/Fox-In-the-Box/hermes-{agent,webui}
+      have `upstream` remote configured with push=DISABLED. (Verified — they do.)
+- [ ] Branch protection on fox-in-the-box-ai/hermes-{webui,agent} does NOT block
+      the `fitb-overlay-archive-YYYY-MM-DD` tag push (Phase 10).
+
+## v0.5.5 stabilization smoke
+
+Run the full SMOKE_CHECKLIST.md A–L against `:stable` (v0.5.4) on:
+- Apple Silicon (Mac)
+- x86_64 host (CI runner or a Linux VM)
+
+Required because Phase 8 will re-pin the submodule and we need a known-good
+baseline to compare against. Any regression caught here delays Phase 1.
+```
+
+**Labels:** `v0.6.0`, `migration`, `blocking`, `smoke-required`
+**Closes when:** all checkboxes checked + smoke green on both architectures.
+
+---
+
+### PHASE 0 (#4) — `[v0.6.0 P0] Upstream-PR campaign — track 5 candidate fixes`
+
+**Body:**
+
+```markdown
+Send 5 bug-fix-class FITB commits as upstream PRs. Each accepted PR shrinks
+Fox's permanent patch series. Async — does not block any other phase.
+
+## Sub-trackers (one issue per upstream PR)
+
+- #5 — `hermes_cli/runtime_provider.py` Bedrock target_model fix → NousResearch
+- #6 — `api/models.py` #1558 metadata-save guard → nesquena
+- #7 — `agent/auxiliary_client.py` provider=auto fallback → NousResearch
+- #8 — `cron/{jobs,scheduler}.py` + tools/cronjob_tools.py diagnostics → NousResearch
+- #9 — `api/providers.py` gateway hot-reload → nesquena
+
+## Acceptance criteria
+- [ ] All 5 sub-trackers reach a terminal state (accepted / rejected / stale).
+- [ ] Accepted PRs cause the corresponding Phase 3 / 6 monkey-patch to be
+      retired in Phase 10 cleanup.
+
+## Closing condition
+Either: all 5 reach terminal state, OR Phase 10 starts and remaining open
+PR trackers are left open with a `pending-upstream-review` label.
+```
+
+**Labels:** `v0.6.0`, `migration`, `phase-0`, `parallel-safe`, `upstream-pr`
+**Estimated effort:** 1.5 eng-days author work; 1–4 weeks upstream review latency.
+
+#### Sub-issues (#5 – #9) — one per upstream PR
+
+Each has body:
+
+```markdown
+## Upstream
+<upstream repo + branch>
+
+## Source file in Fox
+<relative path in standalone clone>
+
+## Fox commit
+<SHA of the Fox commit being upstreamed>
+
+## Steps
+1. Cherry-pick or recreate as a clean commit against `upstream/<branch>` in the
+   standalone clone (not the Fox fork).
+2. Open PR with reproducer + test.
+3. Edit the corresponding Fox commit message to add `Upstream-Status: Submitted <PR-URL>`.
+4. Set `pending-upstream-review` label here.
+5. On accept: link the merged commit; flag the corresponding monkey-patch
+   (Phase 3 or Phase 6) for retirement in Phase 10.
+6. On reject: close with reason; the Fox monkey-patch lives on permanently.
+
+## Acceptance criteria
+- [ ] PR opened upstream
+- [ ] Fox-side commit message annotated
+- [ ] Closure reason recorded
+```
+
+**Labels:** `v0.6.0`, `phase-0`, `upstream-pr`
+
+---
+
+### PHASE 1 (#10) — `[v0.6.0 P1] Scaffold packages/fox-overlay/`
+
+**Body:** see template; one PR (#11) per upstream-migration-execution-plan.md §4 Phase 1.
+
+**Sub-issue #11 — `phase 1: scaffold packages/fox-overlay/ (no behavior change)`**
+- **Prereq:** Pre-flight (#3) closed, Decision tracker (#2) closed
+- **Deliverable:** Full directory tree per §Phase 1 (pyproject.toml, MANIFEST.toml, fox_overlay/ package, webui_static/, patches/{webui,agent}/series files, scripts/check-overlay-basis.sh stub)
+- **Validation:** `pip install -e packages/fox-overlay` from fresh venv succeeds; `python -c "import fox_overlay.bootstrap"` prints log line; container builds; smoke A1–A4 green
+- **Effort:** 4h
+- **Labels:** `v0.6.0`, `migration`, `phase-1`, `monorepo`
+
+---
+
+### PHASE 2 (#12) — `[v0.6.0 P2] Move Fox-only static assets into overlay`
+
+**Phase tracker body:** see template; **2 PRs** (one fork-side, one monorepo) per cross-repo cohesion rule (`feedback_cross_repo_cohesion.md`).
+
+**Sub-issue #13 — `phase 2a (webui): move Fox-only static assets out of static/`**
+- **Repo:** fox-in-the-box-ai/hermes-webui (fork)
+- **Branch:** `fitb/phase2-move-static`
+- **Prereq:** Phase 1 (#11) merged
+- **Deliverable:** `git mv` 11 files+dirs from `static/` per §Phase 2 list; remove explicit `<link>`/`<script>` tags for moved files from `static/index.html`
+- **Validation:** Fork-side CI green; commits preserve history (`git log --follow`)
+- **Effort:** 4h
+- **Labels:** `v0.6.0`, `migration`, `phase-2`, `fork-side`
+
+**Sub-issue #14 — `phase 2b (monorepo): serve Fox static via overlay extension dir`**
+- **Repo:** fox-in-the-box-ai/fox-in-the-box
+- **Prereq:** PR #13 merged in fork
+- **Deliverable:** Files placed under `packages/fox-overlay/webui_static/`; Dockerfile edit per §Phase 2 (3 ENV vars + COPY); MANIFEST.toml updated; .fox-removals populated with 7 upstream onboarding test files; submodule pointer bump
+- **Validation:** view-source comparison shows the two injection diffs and otherwise byte-identical markup; sha256 of moved assets unchanged; HTTP 200 on all `/extensions/*` URLs; smoke B (wizard) green
+- **Effort:** 4h
+- **Labels:** `v0.6.0`, `migration`, `phase-2`, `monorepo`, `smoke-required`
+
+---
+
+### PHASE 3 (#15) — `[v0.6.0 P3] Migrate hermes-agent plugin + bootstrap monkey-patches`
+
+**Phase tracker body:** see template. **PARALLEL-SAFE with Phase 2** (different repos, no shared files).
+
+**Sub-issue #16 — `phase 3a (agent): restore upstream content for 5 files; remove mem0_oss`**
+- **Repo:** fox-in-the-box-ai/hermes-agent (fork)
+- **Branch:** `fitb/phase3-restore-upstream`
+- **Prereq:** Phase 1 (#11) merged
+- **Deliverable:** Revert Fox edits to 5 files (`hermes_cli/runtime_provider.py`, `agent/auxiliary_client.py`, `cron/jobs.py`, `cron/scheduler.py`, `tools/cronjob_tools.py`); `git rm -r plugins/memory/mem0_oss/` (relocated); keep `.github/workflows/notify-monorepo.yml`
+- **Effort:** 4h
+- **Labels:** `v0.6.0`, `migration`, `phase-3`, `fork-side`
+
+**Sub-issue #17 — `phase 3b (monorepo): implement fox-overlay agent plugin + monkey-patches`**
+- **Repo:** monorepo
+- **Prereq:** PR #16 merged
+- **Deliverable:** `packages/fox-overlay/fox_overlay/agent_plugins/` populated per §Phase 3 (4 monkey-patches: runtime_provider, auxiliary_client, cron_diagnostics, models — note: `models` is webui not agent, so 3 here + 1 in Phase 6); mem0_oss relocated with `kind: backend` added to plugin.yaml; pyproject.toml entry-points wired; Dockerfile updated to install fox-overlay; submodule bump
+- **Validation:** `hermes plugins list` shows fox_overlay + mem0_oss; startup logs include 3 `[fox-overlay] patched ...` lines; mem0 ops green (smoke D); cron failure diagnostics still surface
+- **Effort:** 1 eng-day
+- **Labels:** `v0.6.0`, `migration`, `phase-3`, `monorepo`, `smoke-required`
+
+---
+
+### PHASE 4 (#18) — `[v0.6.0 P4] Land 9-line webui patches (dispatcher hook)`
+
+**REVIEW CHECKPOINT:** end of Phase 4 — Dennis reviews patch series before Phase 5 work begins (per Architect 1's plan).
+
+**Sub-issue #19 — `phase 4a (webui): restore upstream server.py + api/routes.py`**
+- **Repo:** fork
+- **Branch:** `fitb/phase4-restore-upstream-server-routes`
+- **Prereq:** Phase 1 (#11) merged; Phase 3 (#17) merged (proves bootstrap import works)
+- **Deliverable:** revert Fox edits to `server.py` and `api/routes.py`; **also delete `_ensure_active_branch()` function** in `server.py` (it's misaligned with the new model; harmless to delete now)
+- **Effort:** 2h
+- **Labels:** `v0.6.0`, `migration`, `phase-4`, `fork-side`
+
+**Sub-issue #20 — `phase 4b (monorepo): introduce fox-overlay patch series + dispatcher skeleton`**
+- **Repo:** monorepo
+- **Prereq:** PR #19 merged
+- **Deliverable:** `packages/fox-overlay/patches/webui/{series,001-server-py-bootstrap.patch,002-routes-py-dispatch-hook.patch}` per §Phase 4; `fox_overlay/dispatch.py` skeleton; Dockerfile edit to apply patches between upstream COPY and overlay; submodule bump
+- **Validation:** `git apply --check` succeeds; container starts; `[fox-overlay] bootstrap installed` log line; smoke A-B-C green; behavior byte-identical to pre-Phase-4 for non-Fox paths (dispatch table is still empty)
+- **Effort:** 4h
+- **Labels:** `v0.6.0`, `migration`, `phase-4`, `monorepo`, `smoke-required`
+
+---
+
+### PHASE 5 (#21) — `[v0.6.0 P5] Migrate 6 additive webui Python modules into overlay`
+
+**Phase tracker body:** see template. **One PR pair per module** — 6 fork PRs + 6 monorepo PRs = 12 sub-issues. Strict sequencing not required between modules; each pair can land independently.
+
+| # | Module | Smoke section | Fork PR | Monorepo PR |
+|---|---|---|---|---|
+| 1 | `ollama.py` | D5–D7 | #22 | #23 |
+| 2 | `tailscale.py` | E (full) | #24 | #25 |
+| 3 | `local_fallback.py` | F (full) + G + H | #26 | #27 |
+| 4 | `models_download.py` | F (full) + G + H | #28 | #29 |
+| 5 | `hostname.py` | I | #30 | #31 |
+| 6 | `session_recovery.py` | L (#127–#129 carry-forward) | #32 | #33 |
+
+**Each fork PR (#22, #24, ...):**
+- Body template: "Remove `api/<module>.py` — migrated to overlay. See monorepo PR <N+1>."
+- Branch: `fitb/phase5-remove-<module>`
+- Deliverable: `git rm api/<module>.py` (single-file PR)
+- Effort: 30 min each
+
+**Each monorepo PR (#23, #25, ...):**
+- Body template: "Host `<module>` via fox-overlay; register routes; bump hermes-webui submodule."
+- Deliverable: file at `packages/fox-overlay/fox_overlay/webui_modules/<module>.py`; route registration at bottom; MANIFEST.toml row added; eager import in `fox_overlay/__init__.py`; submodule bump
+- Validation: smoke section per the table above
+- Effort: 2–3 hours each (the local-fallback / tailscale / session-recovery triad takes longer due to longer smoke runs)
+
+**Phase 5 also delivers:** new test `packages/fox-overlay/tests/test_dispatch_no_overlap.py` to prevent overlapping `startswith()` registrations. Filed as a tracker sub-issue under #21 if it doesn't fit in one of the module PRs.
+
+**Effort:** 2 eng-days total
+**Labels:** all sub-issues get `v0.6.0`, `migration`, `phase-5`, plus `fork-side` or `monorepo`, plus `parallel-safe` (within phase)
+
+---
+
+### PHASE 6 (#34) — `[v0.6.0 P6] Mid-file webui monkey-patches`
+
+**Phase tracker body:** see template. **One fork-PR + 5 monorepo PRs.** Per anti-regression Rule 1, this is one logical change — sub-PRs are for review hygiene, not separate releases.
+
+**Sub-issue #35 — `phase 6 (webui-fork): restore upstream content for 5 modified files`**
+- **Repo:** fork
+- **Branch:** `fitb/phase6-restore-mid-file-edits`
+- **Prereq:** Phases 4 + 5 merged (proves overlay-import lifecycle works end-to-end)
+- **Deliverable:** revert Fox edits to `api/streaming.py`, `api/models.py`, `api/config.py`, `api/providers.py`, `api/updates.py`
+- **Effort:** 4h
+- **Labels:** `v0.6.0`, `migration`, `phase-6`, `fork-side`
+
+**Sub-issues #36–#40 — one monorepo PR per monkey-patch:**
+
+| # | Patch | Validates against smoke section | Effort |
+|---|---|---|---|
+| 36 | `webui_patches/streaming.py` (silent failover #129b) | G + H | 6h |
+| 37 | `webui_patches/models.py` (Session.save #1558) | D + custom test_metadata_save_wipe_1558 | 5h |
+| 38 | `webui_patches/config.py` (Fox env vars) | C | 4h |
+| 39 | `webui_patches/providers.py` (gateway hot-reload) | D | 4h |
+| 40 | `webui_patches/updates.py` (delete or patch) | (incidental) | 3h |
+
+Each PR body includes the inspect-based signature self-check pattern from §Phase 6, the `_INSTALLED` guard, and a log line.
+
+**Order constraint** documented in PR bodies and in `bootstrap.install()`: `config` must apply first (others read its settings).
+
+**Effort:** 3 eng-days total
+**Labels:** `v0.6.0`, `migration`, `phase-6`, `monorepo`, `smoke-required`
+
+---
+
+### PHASE 7 (#41) — `[v0.6.0 P7] Wholesale-replace api/onboarding.py + delete static/onboarding.js`
+
+**Sub-issue #42 — `phase 7a (webui): remove api/onboarding.py — Fox dispatcher takes over`**
+- **Repo:** fork
+- **Branch:** `fitb/phase7-remove-onboarding`
+- **Prereq:** Phases 4 + 5 merged
+- **Deliverable:** `git rm api/onboarding.py`; restore the 7 upstream onboarding tests (`test_issue1499_*`, `test_onboarding_*`); mark them `pytest.mark.skipif(os.environ.get("FOX_OVERLAY"))` so they don't fail when Fox's dispatcher claims the route prefix
+- **Effort:** 4h
+- **Labels:** `v0.6.0`, `migration`, `phase-7`, `fork-side`
+
+**Sub-issue #43 — `phase 7b (monorepo): host Fox onboarding via overlay; remove upstream onboarding.js`**
+- **Repo:** monorepo
+- **Prereq:** PR #42 merged
+- **Deliverable:** `packages/fox-overlay/fox_overlay/webui_modules/onboarding.py` (moved from fork); dispatcher claims `/api/onboarding/`, `/setup`, `/api/setup/`; `.fox-removals` adds `static/onboarding.js` line (verify no dup from Phase 2); Dockerfile applies `.fox-removals` after `pip install -e fox-overlay`; submodule bump
+- **Validation:** smoke B1–B9 (full wizard); Section L #122 row; `curl /api/onboarding/status` returns Fox shape; `curl /static/onboarding.js` returns 404
+- **Effort:** 4h
+- **Labels:** `v0.6.0`, `migration`, `phase-7`, `monorepo`, `smoke-required`
+
+---
+
+### PHASE 8 (#44) — `[v0.6.0 P8] Re-point submodules at upstream tags; multi-stage Dockerfile`
+
+**THE BIG ONE.** Architect 1 calls this "the point of structural change." 48-hour soak (Rule 2) starts when the tag ships. Second review checkpoint with Dennis before merge.
+
+**Sub-issue #45 — `phase 8a: re-pin forks/hermes-webui to upstream nesquena <tag>`**
+- **Prereq:** Phases 1–7 merged; all smoke green against existing Fox-fork pins; patch series confirmed to apply against chosen upstream tag (dry-run)
+- **Deliverable:** select upstream tag (recommendation: latest stable as of merge day, currently `v0.51.74` for webui); update `.gitmodules` URL to `https://github.com/nesquena/hermes-webui.git`; `git submodule sync` + checkout; `git add forks/hermes-webui`
+- **Validation:** `git apply --check` succeeds for all webui patches against new pin; `check-overlay-basis.sh` exits 0
+- **Effort:** 2h
+- **Labels:** `v0.6.0`, `migration`, `phase-8`, `monorepo`, `blocking`
+
+**Sub-issue #46 — `phase 8b: re-pin forks/hermes-agent to upstream NousResearch <tag>`**
+- **Prereq:** Phase 8a (#45) merged (or atomic with it)
+- **Deliverable:** same as 8a but for hermes-agent; tag recommendation: `v2026.5.7` (=v0.13.0) or latest at merge time
+- **Validation:** `git apply --check` succeeds for all agent patches; `check-overlay-basis.sh` exits 0
+- **Effort:** 1h
+- **Labels:** `v0.6.0`, `migration`, `phase-8`, `monorepo`, `blocking`
+
+**Sub-issue #47 — `phase 8c: multi-stage Dockerfile + check-overlay-basis CI gate + versions.toml`**
+- **Prereq:** Phase 8a (#45) and 8b (#46) merged (or all three are one atomic PR; Dennis's call)
+- **Deliverable:** Create `versions.toml` at repo root; restructure Dockerfile per §Phase 8 (replace lines 127–139 with the multi-stage layout: COPY virgin upstream → apply patches → install upstream → install overlay → apply .fox-removals → set ENV); make `check-overlay-basis.sh` real (not stub); update `.github/workflows/build-container.yml` to run `check-overlay-basis.sh` before Docker build; confirm `_ensure_active_branch()` and `scripts/apply-local-patches.sh` deleted from fork (or do it here if missed in Phase 4)
+- **Validation:** Container builds. **Full SMOKE_CHECKLIST.md A–L runs end-to-end on Apple Silicon AND x86_64**, both required (Section A4 architecture verification is non-skippable per #114 lesson); `docker exec fitb-test ls /app/hermes-webui/api/` shows neither `ollama.py` nor `tailscale.py` (they're in `/app/fox-overlay/`); `pip show hermes-webui` shows the pinned upstream version
+- **Effort:** 1 eng-day (1 day implementation, 0.5 day full smoke run)
+- **Labels:** `v0.6.0`, `migration`, `phase-8`, `monorepo`, `blocking`, `smoke-required`, `48h-soak`
+
+**Rollback procedure** documented in PR body (verbatim from §Phase 8 plan): `git revert` on monorepo main + `git submodule sync && git submodule update --init --recursive` + rebuild `:stable` from prior `:vX.Y.<n-1>` digest. Fox-fork branches NOT deleted until Phase 10 — rollback fully reversible until then.
+
+---
+
+### PHASE 9 (#48) — `[v0.6.0 P9] Nightly upstream-watch CI workflow`
+
+**Sub-issue #49 — `phase 9: nightly upstream-watch.yml`**
+- **Prereq:** Phase 8 (#47) merged; 48-hour soak complete
+- **Deliverable:** `.github/workflows/upstream-watch.yml` per §Phase 9 — runs `17 5 * * *` daily; reads `versions.toml`; resolves latest upstream tags via `api.github.com/repos/<>/releases/latest`; on mismatch, attempts `docker build` against latest; opens issue labeled `upstream-drift P2` on failure
+- **Validation:** manual `workflow_dispatch` succeeds when pins match latest; force-mismatch scenario builds and either passes or opens issue; deliberate-fail scenario opens issue correctly
+- **Effort:** 1 eng-day
+- **Labels:** `v0.6.0`, `migration`, `phase-9`, `monorepo`
+
+---
+
+### PHASE 10 (#50) — `[v0.6.0 P10] Cleanup, archive, docs`
+
+**Sub-issue #51 — `phase 10a: archive sync-submodules workflow; update docs to overlay model`**
+- **Prereq:** Phase 9 (#49) merged; at least 1 successful upstream-watch nightly run observed
+- **Deliverable:**
+  - Delete `.github/workflows/sync-submodules.yml` (obsolete)
+  - Update `CLAUDE.md` "Repository Structure" section
+  - Update `AGENTS.md`, `CONTRIBUTING.md`, `README.md`
+  - Move `docs/architecture/upstream-separation-plan.md` → `.archive.md`
+  - Move `docs/architecture/upstream-migration-execution-plan.md` → `.archive.md`
+  - Create `docs/architecture/upstream-overlay.md` (1-pager steady-state overview)
+  - Add `## [0.6.0]` entry to `CHANGELOG.md` per Keep a Changelog format
+  - Update `qa/SMOKE_CHECKLIST.md` Section L: add "v0.6.0 migration carry-forward" row (validations from Phases 2, 3, 5, 6, 7)
+- **Effort:** 0.5 eng-day
+- **Labels:** `v0.6.0`, `migration`, `phase-10`, `monorepo`
+
+**Sub-issue #52 — `phase 10b: tag fox forks as overlay-archive; archive fork repos read-only`**
+- **Prereq:** PR #51 merged
+- **Deliverable:**
+  - Tag current `master`/`main` heads on `fox-in-the-box-ai/hermes-{webui,agent}` as `fitb-overlay-archive-YYYY-MM-DD`
+  - Push tags
+  - Update fork READMEs to redirect readers to monorepo
+  - Optionally archive fork repos via GitHub UI (read-only); **do NOT delete** (historical commits/tags must remain reachable)
+  - Update memory: write `project_state_v0_6_0.md` and `reference_upstream_overlay_architecture.md`
+- **Effort:** 2h
+- **Labels:** `v0.6.0`, `migration`, `phase-10`, `fork-side`
+
+---
+
+### TRIPWIRES (#53) — `[v0.6.0] Install 10 upstream-monitoring tripwires`
+
+Per Architect 3's risk assessment (§10). These run independently of the migration phases and can be installed before, during, or after — but at least the daily-digest, license-watch, and NousResearch-official-UI-watch should land BEFORE Phase 8 to catch any upstream surprise during the migration.
+
+**Sub-issues #54–#63:**
+
+| # | Tripwire | Implementation | Effort |
+|---|---|---|---|
+| 54 | Daily upstream-commit digest | `.github/workflows/upstream-digest.yml` — daily, posts Slack/email summary; greps for `breaking\|deprecat\|migration\|rewrite\|schema\|password\|auth\|csrf\|xss\|injection` keywords; flags always-conflict files | 4h |
+| 55 | License watch | GitHub Action diffing `LICENSE` on both upstreams daily; pages Dennis on change | 2h |
+| 56 | Branch-creation watch | Action lists upstream branches daily; alerts on new branch matching `react\|vue\|svelte\|preact\|rewrite\|v1\|next\|major` | 2h |
+| 57 | NousResearch official-UI watch | Daily check of `NousResearch/hermes-agent` tree for `webui/`, `frontend/`, `static/` directory appearance | 3h |
+| 58 | Maintainer absence canary (nesquena) | Alert if `nesquena` has zero commits to `upstream/master` for 5 consecutive days (baseline: 0 such gaps in 48d) | 2h |
+| 59 | CVE feed subscription | GitHub Security Advisories for `nesquena/hermes-webui` + `NousResearch/hermes-agent` + Python advisory DB for pinned deps | 2h |
+| 60 | Stage-batch monitoring | Alert if `Hermes Agent stage-NNN: stamp CHANGELOG vX.Y.Z` stamp pattern breaks for >48h (signals nesquena's release pipeline is down) | 2h |
+| 61 | End-to-end pair test in Fox CI | Every Fox build runs hermes-webui + hermes-agent pinned pair end-to-end; pair-mismatch failure triggers a pin freeze instead of auto-bump | 6h |
+| 62 | Patch-series rebase clock | CI metric: time-to-rebase per upstream pull; alert if average >4h for 3 consecutive pulls | 4h |
+| 63 | Open-issue-age sentry | Track age of oldest unresolved upstream issue; alert if >90d while upstream <12mo old | 2h |
+
+**Phase tracker body for #53:**
+
+```markdown
+Install 10 monitoring tripwires per upstream-migration-execution-plan.md §3
+(Architect 3's risk assessment). Each is a small, independent action.
+
+## Sequencing within Phase 0–10
+
+- **Before Phase 8:** #54 (daily digest), #55 (license watch), #57 (NousResearch UI watch) — these catch surprises during migration
+- **Concurrent with Phase 8/9:** #58 (maintainer canary), #59 (CVE feed)
+- **After Phase 8 (post-soak):** #56, #60, #61, #62, #63
+
+## Closing condition
+All 10 sub-issues deployed and verified with at least one successful run.
+```
+
+**Effort:** ~30 hours total across 10 small issues; can be parallelized aggressively if a second engineer is available.
+**Labels:** `v0.6.0`, `migration`, `tripwire`, `parallel-safe`
+
+---
+
+## 5. Effort + calendar summary
+
+| Lane | Eng-days | Calendar weeks | Critical path? |
+|---|---|---|---|
+| Phase 0 (PR campaign) | 1.5 author-days + 1–4w latency | ~4w max | NO — async |
+| Phases 1–4 (scaffold + dispatcher) | ~3 days | ~1.5w | YES |
+| Phases 5–7 (module migration) | ~6 days | ~2w | YES (after Phase 4) |
+| Phase 8 (re-point) | 1.5 days + 48h soak | ~1w | YES |
+| Phase 9 + 10 (CI + cleanup) | 1.5 days | ~0.5w | YES (after Phase 8) |
+| Tripwires | 4 days (or 2 if parallelized) | ~1w | NO — parallel-safe |
+| **Total critical path** | **~12.5 eng-days** | **~5 weeks** | |
+| **Total work including tripwires + PR campaign authoring** | **~14 eng-days** | **~5 weeks** | |
+
+Matches Architect 1's estimate of 14 eng-days, 5-week calendar window.
+
+---
+
+## 6. Open items the breakdown does NOT yet resolve
+
+These are flagged for the reviewer architects:
+
+1. **Engineer assignment.** The breakdown assumes one engineer for the critical path. Confirm with Dennis: who, and what's their actual capacity?
+2. **Phase-5 module ordering.** I've assumed modules can land in any order. Reviewer B should sanity-check whether `session_recovery.py` should land last (it depends on the gateway-watcher pattern that other modules may set).
+3. **Tripwires sequencing.** I've recommended which tripwires precede Phase 8. Reviewer A should challenge: are there any I should move earlier?
+4. **Documentation tracker.** Should I add an explicit issue for "update all docs" (CLAUDE.md, AGENTS.md, etc.) or roll into Phase 10? Current draft rolls into Phase 10 (#51) for sequencing simplicity.
+5. **Versioning.** I've assumed `v0.5.5` is skipped and we go straight to `v0.6.0`. Alternative: ship migration as `v0.5.5` to match Architect 1's plan literally. Reviewer should challenge.
+6. **CHANGELOG strategy.** When is the `## [0.6.0]` CHANGELOG entry written? Current draft: written in Phase 10 (#51). Alternative: write incrementally per phase. Reviewer should pick.
+7. **Smoke checklist updates.** When are new Section L rows added (one per phase that introduces user-visible state)? Current draft: rolled into the per-phase PR. Alternative: a dedicated final-pass issue. Reviewer should challenge.
+
+---
+
+## 7. Reviewer guidance
+
+Two unbiased reviewers (not Architect 1) will scrub this draft separately:
+
+- **Reviewer A — Completeness/Gap-finder.** Read the Architect 1 plan + this breakdown side by side. Find: missing phases, missing sub-issues, missing acceptance criteria, missing rollback procedures, missing validation gates, missing prerequisites. Anything Architect 1 specified that isn't reflected here.
+- **Reviewer B — Dependency/Risk-skeptic.** Challenge the dependency graph: are any prereqs wrong? Any phases that could parallelize and aren't? Any phases that can't actually parallelize? Risk scenarios not covered. PR-split decisions that will cause review fatigue or merge conflicts.
+
+After both reviewers report, I'll integrate feedback into a final version, then create the actual GitHub issues.

--- a/docs/architecture/webui-build-vs-fork-analysis.md
+++ b/docs/architecture/webui-build-vs-fork-analysis.md
@@ -1,0 +1,558 @@
+# Fox WebUI: Build-vs-Fork Analysis
+
+**Status:** RESEARCH COMPLETE / AWAITING DECISION
+**Date:** 2026-05-16
+**Author:** Architect 2 (build-our-own-WebUI feasibility)
+**Audience:** Dennis Vorobyov (owner). Read alongside `upstream-separation-plan.md` (foundational research) and `upstream-migration-execution-plan.md` (Architect 1 lane).
+
+---
+
+## 0. TL;DR (read this first)
+
+**Recommendation: do NOT replace hermes-webui with a Fox-owned React UI right now. Execute the 12-day Architect-1 overlay/patch-series migration; defer the React rewrite until after v0.6.0 ships and Phase 1 (Guardrails) is in production.** When you do build a Fox UI, build **Path A** (React frontend on top of the existing Python backend) — not Path B (full backend rewrite).
+
+The cadence question — "based on hermes-webui's shipping schedule, how solid is them as a UI choice?" — has a sharper answer than the framing suggests: **upstream is shipping aggressively, but the surface Fox actually consumes is small, well-bounded, and stable enough**. The real risks are (a) `nesquena` is the bus-factor and (b) hermes-webui is tightly coupled to hermes-agent's in-process Python contracts. Those risks both *grow*, not shrink, if Fox writes its own UI without first owning the agent contract.
+
+The 12-day Architect-1 plan reduces Fox's ongoing patch surface from "every file conflicts" to **2 patched files / 9 lines** in webui and **0 patched files** in agent, with ≤ 1 hour/week to track upstream. A full Fox-owned React rewrite is **35–55 engineering-days for Path A** and **65–110 engineering-days for Path B**, with permanent ownership cost of every endpoint contract and every feature upstream ships (e.g., Kanban v1) thereafter.
+
+The most important fact to surface: **Fox's webui code calls into hermes-agent's Python directly via 18 distinct module imports across 49 import sites** (`agent.*`, `hermes_cli.*`, `cron.*`, `tools.*`). A new Fox-owned backend has to reproduce that surface or stay in-process Python — which is why Path B is so much more expensive than the React framing implies.
+
+---
+
+## 1. Surface-area audit
+
+This section catalogs what a replacement must provide. Numbers in this section come from grepping the live deployed pin (`hermes-webui` at commit `62c0854`).
+
+### 1.1 HTTP endpoints Fox's frontend depends on
+
+**Total:** 158 distinct endpoint conditions in `api/routes.py` (`grep -cE 'parsed.path == ' api/routes.py`). Of those, ~140 are `==` exact matches and ~18 are `startswith` prefixes. Grouped:
+
+| Group | Endpoints (sample) | Owner | Stability |
+|---|---|---|---|
+| **Auth** | `/api/auth/login`, `/api/auth/logout`, `/api/auth/status`, `/login` | Upstream | High |
+| **Health/static** | `/health`, `/static/*`, `/extensions/*`, `/favicon.ico`, `/manifest.json`, `/sw.js` | Upstream | High |
+| **Sessions (CRUD)** | `/api/session`, `/api/sessions`, `/api/session/{new,delete,rename,duplicate,branch,move,pin,update,clear,truncate,undo,retry,archive,compress,export,import,import_cli,handoff-summary,conversation-rounds}`, `/api/sessions/search`, `/api/sessions/cleanup{,_zero_message}` | Upstream | **Hot**: `api/routes.py` grew +1,510/-98 lines under Fox; upstream adds endpoints monthly |
+| **Chat / streaming** | `/api/chat`, `/api/chat/{start,cancel,steer,stream,stream/status}` | Upstream | **Hot**: this is where SSE protocol lives |
+| **Approvals (interactive tool calls)** | `/api/approval/{pending,respond,stream,inject_test}` | Upstream | Stable |
+| **Clarify (mid-stream Q&A)** | `/api/clarify/{pending,respond,stream,inject_test}` | Upstream | Stable |
+| **Models** | `/api/models`, `/api/models/live`, `/api/default-model`, `/api/reasoning`, `/api/personalities`, `/api/personality/set` | Upstream | Medium |
+| **Providers** | `/api/providers`, `/api/providers/delete` | Upstream + Fox (custom OpenAI-compatible additions in flight, #144) | **Hot for Fox** |
+| **Settings** | `/api/settings`, `/api/settings/hostname`, `/api/settings/hostname/dismiss-prompt` | Upstream + Fox (hostname is Fox) | Mixed |
+| **Profiles** | `/api/profiles`, `/api/profile/{active,create,delete,switch}` | Upstream | Stable |
+| **Workspaces** | `/api/workspaces`, `/api/workspaces/{add,remove,rename,reorder,suggest}` | Upstream | Stable |
+| **Projects** | `/api/projects`, `/api/projects/{create,delete,rename}` | Upstream | Stable |
+| **Files (filesystem ops)** | `/api/file`, `/api/file/{create,create-dir,delete,raw,rename,reveal,save}`, `/api/list` | Upstream | Stable |
+| **Skills** | `/api/skills`, `/api/skills/{content,delete,save}` | Upstream | Stable |
+| **Cron / routines** | `/api/crons`, `/api/crons/{create,delete,history,output,pause,recent,resume,run,status,update}` | Upstream | Stable (will grow when Fox does Phase 5 routines) |
+| **MCP servers** | `/api/mcp/servers` | Upstream | Stable |
+| **Memory (mem0)** | `/api/memory`, `/api/memory/write` | Upstream + Fox (mem0_oss plugin) | Stable |
+| **OAuth (Codex)** | `/api/oauth/codex/{start,poll}` | Upstream | New |
+| **Updates** | `/api/updates/{check,apply,force}` | Upstream + Fox patches | **Fox-modified** |
+| **Rollback** | `/api/rollback/{list,diff,restore}` | Upstream | Stable |
+| **Background tasks** | `/api/background`, `/api/background/status` | Upstream | Stable |
+| **Insights / git-info / btw** | `/api/insights`, `/api/git-info`, `/api/btw` | Upstream | Stable |
+| **Terminal** | `/api/terminal/{start,close,input,output,resize}` | Upstream | Stable |
+| **Upload / transcribe / media** | `/api/upload`, `/api/upload/extract`, `/api/transcribe`, `/api/media` | Upstream | Stable |
+| **Commands / gateway / admin** | `/api/commands`, `/api/gateway/status`, `/api/admin/reload` | Upstream | Stable |
+| **Setup / onboarding (Fox-replaced)** | `/setup`, `/api/setup/{welcome,openrouter,complete,skip,restart}` | **Fox-owned** (replaces upstream) | **Frozen by Fox** |
+| **Ollama (Fox)** | `/api/ollama/{status,models,pull,delete,refresh,use-model}` | **Fox-owned** | Stable |
+| **Tailscale (Fox)** | `/api/tailscale/{status,up,up/poll,logout,serve}` | **Fox-owned** | Stable |
+| **Local fallback (Fox)** | `/api/local-fallback/{status,enable,disable,activate,remote-health}`, `/api/local-models`, `/api/local-models/{id}/progress` | **Fox-owned** | Stable |
+
+**Reality check:** There are >100 upstream endpoints Fox's frontend depends on **transitively** (i.e., the existing UI calls them, but Fox itself doesn't customize them). A from-scratch React UI must implement client integration for every one of those if we want feature parity (skills CRUD, file browser, terminal, cron, OAuth, MCP servers, etc.).
+
+A Fox UI that targets only "chat + onboarding + settings + Tailscale" — i.e., the Fox-distinctive surface — is a non-starter; it would be a regression from what hermes-webui already provides.
+
+### 1.2 SSE streams
+
+Five SSE endpoints, all consumed by the frontend via `EventSource`:
+
+| Stream | Consumer (file:line) | Purpose | Owner |
+|---|---|---|---|
+| `/api/chat/stream?stream_id=…` | `messages.js:1176, 1331, 1988` | The main streaming chat token feed | Upstream (Fox patches `api/streaming.py` for failover) |
+| `/api/sessions/gateway/stream` | `sessions.js:1112` (with HEAD probe at `:1082`) | Real-time gateway session updates (CLI mirroring) | Upstream |
+| `/api/approval/stream?session_id=…` | `messages.js:1508` | Tool-call approval prompts | Upstream |
+| `/api/clarify/stream?session_id=…` | `messages.js:1870` | Mid-stream clarify Q&A | Upstream |
+| `/api/local-models/{id}/progress` | `panels.js:4056` | Local model download progress | **Fox** |
+| `/api/terminal/output` | `terminal.js:378` | Terminal session output (PTY tail) | Upstream |
+
+The chat-stream protocol is **not** a documented contract. It is a JSON-encoded SSE event stream with at least these events: `delta`, `tool_call`, `tool_result`, `error`, `provider_switched` (Fox-added), `title_status`, `usage`, plus typed events on the approval/clarify channels (`initial`, `clarify`, `pending`, etc.). A Fox-owned frontend has to either mirror the upstream event taxonomy bug-for-bug, or adapt to its evolution every release.
+
+### 1.3 Static assets served
+
+| Asset | Owner |
+|---|---|
+| `static/index.html` (1,212 lines, 174+ Fox-modified) | Upstream + Fox shell wrapper |
+| `static/style.css` (3,052 lines) | Upstream + Fox theme overrides (86 lines) |
+| `static/{boot,sessions,messages,panels,ui,commands,workspace,terminal,login}.js` (~13k lines) | Upstream |
+| `static/i18n.js` (7,814 lines, **7,339 keys across multiple locales**) | Upstream + Fox keys |
+| `static/sw.js` (PWA service worker) | Upstream + Fox patches |
+| `static/manifest.json` (PWA) | Upstream + Fox |
+| `static/fonts/{Manrope,Sora}[wght].woff2` | **Fox** |
+| `static/vendor/smd.min.js` (markdown renderer) | Upstream |
+| `static/icons.js` (90 lines, inline SVG sprite) | Upstream |
+| `static/{fox-in-the-box,setup,fallback-polish,hostname-prompt,onboarding-preview}.{css,js,html}` | **Fox** (additive — already isolated) |
+| `static/fox_avatar_cropped.jpg`, `apple-touch-icon.png`, favicon variants | **Fox branding** |
+
+The hermes-webui frontend is **NOT a SPA**. It's an HTML page that loads ~17 vanilla-JS files in order; each registers globals on `window`. Theming is done via CSS custom properties cascading from `:root` overrides defined in `fox-in-the-box.css`. The 7,339 i18n keys are a real surface.
+
+### 1.4 Server-side state
+
+Held in the Python process and on disk under `~/.hermes/webui/` (or `HERMES_WEBUI_STATE_DIR`):
+
+| State | Location | Purpose |
+|---|---|---|
+| `STATE_DIR/sessions/*.json` + `_index.json` + `.bak` files | Disk | Session messages, atomic-write pattern, `.bak` is the #1558 data-loss fix |
+| `STATE_DIR/settings.json` | Disk | All settings the UI persists |
+| `STATE_DIR/workspaces.json`, `last_workspace.txt` | Disk | Workspace list |
+| `STATE_DIR/projects.json` | Disk | Projects |
+| `STATE_DIR/models_cache.json` | Disk | Cached provider model lists |
+| `~/.hermes/.env` | Disk (in `$HERMES_HOME`, NOT state dir) | Provider API keys (Fox-relevant: written by both setup wizard and Settings panel) |
+| `_RUNNING_CRON_JOBS: dict[str, float]` | In-process | Cron job tracking |
+| `_approval_sse_subscribers: dict[str, list[Queue]]` | In-process | Approval SSE fan-out |
+| `_models_cache_path` + `_active_profile_for_live_models_cache` | In-process | Live model cache |
+| `_MESSAGING_SESSION_METADATA_CACHE` | In-process | Mirrors `~/.hermes/sessions/sessions.json` from agent |
+| Active session pointer | URL/cookie (`/session/<id>`) + `STATE_DIR` | UI state |
+| In-flight stream registry | In-process keyed by `stream_id` | Lets reload reattach |
+| Session-recovery on startup (Fox) | In-process | Reads `.bak` files; restores on partial-write |
+| Per-request profile context | Cookie + thread-local | Multi-profile support |
+| Gateway watcher thread | Background thread | Mirrors agent session JSON |
+
+A Fox-owned backend would need to reimplement (or share) all of these. Sessions on disk *must* stay JSON-compatible because the agent CLI also reads them.
+
+### 1.5 Direct-to-disk operations
+
+Listed above. The atomic-write pattern + `.bak` recovery is non-trivial. The settings file format is a free-form JSON shape that the UI assumes by key. Any new backend that "just owns settings" inherits all these schemas.
+
+### 1.6 Direct calls into hermes-agent's Python (in-process imports)
+
+**This is the single most important finding of the audit.** Fox's webui imports from hermes-agent across 49 import sites referencing 18 distinct modules:
+
+```
+agent.anthropic_adapter         tools.approval
+agent.auxiliary_client          tools.mcp_tool
+agent.credential_pool           tools.skills_tool
+agent.manual_compression_feedback tools.transcription_tools
+agent.model_metadata            cron.jobs
+agent.redact                    cron.scheduler
+hermes_cli.auth                 hermes_cli.profiles
+hermes_cli.commands             hermes_cli.runtime_provider
+hermes_cli.models               hermes_cli.tools_config
+```
+
+These are **in-process Python imports**, not HTTP calls. They reach into the agent's internals (e.g., `agent.credential_pool.load_pool`, `agent.anthropic_adapter.build_anthropic_kwargs`, `agent.model_metadata.get_model_context_length`, `cron.scheduler.run_job`). They are **undocumented**, change with upstream, and are the reason the webui is co-installed with the agent in the same Python venv (Dockerfile installs both with `pip install -e`).
+
+Implication for Path B (full backend replacement):
+- Either keep the new backend as Python in the same venv → you've replaced one Python wrapper with another, and you still have the `from agent.*` import surface to keep up with.
+- Or write the backend in Node → you have to either spawn the agent CLI per request (cold-start cost) or reimplement those 18 modules' surfaces in Node (months of work, plus continuous re-sync).
+- Or go HTTP-only → hermes-agent does not currently expose all of `agent.*` over HTTP. You'd be defining and maintaining a new agent-side HTTP API, which is out of scope per the brief.
+
+**This finding alone should kill Path B for the foreseeable future.**
+
+### 1.7 Browser-side features
+
+| Feature | Implementation | Owner |
+|---|---|---|
+| PWA service worker (`sw.js`) | Vanilla JS service worker, opt-in app-shell cache | Upstream + Fox patches |
+| PWA manifest | `manifest.json` | Upstream + Fox |
+| Theme system | CSS custom properties on `:root`, dark/light auto + override | Upstream + Fox tokens in `fox-in-the-box.css` |
+| i18n | `static/i18n.js`, `t(key, params)` global, **7,339 keys** | Upstream + Fox keys |
+| Markdown rendering | `vendor/smd.min.js` (Streaming MD) | Upstream |
+| Model picker | `panels.js`, populated from `/api/models` + `/api/models/live` | Upstream + Fox modifications |
+| File uploads / drag-drop / paste | `messages.js`, `upload.py`/`upload/extract` endpoints | Upstream |
+| Voice input | `static/messages.js`, `/api/transcribe` endpoint | Upstream |
+| Speech locale | Per-locale `_speech` field in i18n bundle | Upstream |
+| Onboarding wizard | `setup.{html,css,js}` + `api/setup/*` + redirect interstitial in `do_GET` | **Fox** |
+| Failover modal | `fallback-polish.js` | **Fox** |
+| Hostname prompt | `hostname-prompt.js` | **Fox** |
+| Setup welcome / Ollama / Tailscale UI | `panels.js` + Fox additions | **Fox** |
+| Login page | `login.{html,js}` | Upstream |
+
+---
+
+## 2. Two replacement paths (compared side-by-side)
+
+### Path A — React/Next + shadcn/ui + Tailwind frontend; keep the Python webui server
+
+Replace **only** the `static/` tree (and the index.html shell). The existing `server.py` + `api/routes.py` + every Python module (including the 18 agent imports) stays. From the browser's perspective, `index.html` becomes a thin React entry point; the React app speaks the existing REST + SSE protocol. The Python server keeps serving SSE, sessions, settings, models, providers, etc.
+
+#### What we keep / drop / rebuild
+
+| Layer | Status |
+|---|---|
+| `server.py` + `api/*.py` | **Keep, lightly fork** (still need ~2 patches as in Architect 1's plan) |
+| All HTTP endpoints | **Keep upstream-owned** |
+| All SSE protocols | **Keep upstream-owned** |
+| Session storage on disk | **Keep upstream-owned** |
+| `static/*.{css,html,js}` (everything) | **Drop and rewrite** |
+| `static/i18n.js` (7,339 keys) | Rebuild as `react-i18next` JSON bundle (machine-portable, can keep keys) |
+| `static/sw.js` (PWA worker) | Rewrite using `vite-plugin-pwa` or Workbox |
+| `static/messages.js` SSE handling | Rewrite as a custom hook `useChatStream(streamId)` |
+| `static/vendor/smd.min.js` | Replace with `react-markdown` + `remark-gfm` |
+
+#### Engineering-day estimate
+
+Assumes one full-time engineer; range, not point. Anchored to comparable rewrites (Open WebUI v0 → v0.4 = ~8 weeks for one core engineer; LibreChat's Vite migration = ~4 weeks).
+
+| Workstream | Days (low–high) |
+|---|---|
+| Project setup (Vite + React + Tailwind + shadcn + i18n + PWA + SSE polyfill audit) | 2–3 |
+| Design tokens migration (Fox CSS variables → Tailwind theme + shadcn theme) | 2–3 |
+| Layout shell (sidebar, top bar, panel system) | 3–5 |
+| Chat surface (message list, virtualized scroll, streaming markdown, attachments, voice button) | 5–8 |
+| Sessions list + CRUD UI (rename, branch, delete, archive, pin, etc.) | 3–5 |
+| Settings panels (8 settings areas: providers, models, hostname, Tailscale, fallback, profiles, workspace, theme) | 5–7 |
+| Onboarding wizard rebuild (Fox-distinctive) | 2–3 |
+| Approval/Clarify modals + SSE wiring | 2–3 |
+| Cron / routines UI (will be fleshed out in Phase 5; build the shell) | 1–2 |
+| File browser + terminal panel | 3–5 |
+| Skills / MCP / OAuth screens | 2–3 |
+| i18n re-keying (port 7,339 keys; or scope to en + 1–2) | 2–4 (scoped) / 8–12 (full) |
+| PWA + SW + offline shell + manifest | 1–2 |
+| Migration of Fox-distinctive UIs (Tailscale, Ollama panel, fallback modal, hostname prompt) | 2–3 |
+| Build pipeline integration with Dockerfile + Electron | 1–2 |
+| QA, accessibility pass, non-technical-user smoke (audience 45+) | 3–5 |
+| Buffer (10%) | 4–7 |
+| **Total Path A** | **42–80 eng-days, mid-point ≈ 55** |
+
+If we scope i18n to English-only at launch (acceptable for Fox's US-first SMB target, with locale roadmap later): **35–55 eng-days, mid-point ≈ 45**.
+
+#### Hermes-agent contracts we'd take on
+
+Same as today: the in-process Python contract surface stays in `api/*.py`. **Path A does not change the agent-coupling situation.**
+
+#### New dependency list (Path A)
+
+- React 18+, Vite, TypeScript
+- Tailwind CSS + `tailwindcss-animate`
+- shadcn/ui (radix-based, copy-into-repo, no runtime dep on shadcn org)
+- react-i18next + i18next
+- TanStack Query (REST data) + a hand-rolled `useEventStream` hook for SSE
+- react-hook-form + zod (settings forms)
+- react-markdown + remark-gfm + rehype-sanitize + smd-style streaming wrapper (or keep `smd.min.js` from upstream)
+- vite-plugin-pwa (Workbox under the hood)
+- Vitest + @testing-library/react (unit), Playwright (e2e)
+- Lucide React (icon set; replaces inline `icons.js` SVG sprite)
+
+Ongoing maintenance cost: **2–4 hours/month** for routine dep bumps + 1 day/quarter for major bumps. Roughly the cost of any maintained React app.
+
+#### Non-technical-user UX comparison
+
+- **Hermes-webui today:** functional, dated, dense. Looks like a developer tool. Phase 3 (#64) was budgeted at 3–4 weeks of vanilla-CSS overhaul to fix this.
+- **Path A new build:** native-app feel. shadcn defaults are restrained, accessible, keyboard-friendly. Better animation on transitions. Larger initial JS payload (Electron-wrapped → not a real concern).
+- **Caveat:** "looks like a real app" is mostly typography + spacing + component polish, not framework choice. A 3-week vanilla-CSS overhaul *could* reach 80% of the visual gain. The framework win is in *consistency over time* — every new feature inherits the design system rather than re-implementing patterns ad-hoc, which is what `panels.js`'s 5,097 lines has become.
+
+#### Migration sequencing
+
+**Gradual page-by-page is not feasible** because hermes-webui is not a SPA — it's a full-page render with global JS. Two options:
+- **Option A1 — Big bang at Phase 3.** Replace `static/` wholesale at v0.6.0. Ship Phase 3 as the React rewrite instead of as a CSS overhaul. **Recommended if Path A is chosen.**
+- **Option A2 — Two URLs.** Keep `/` upstream, mount `/v2/` React app. Move users gradually. Doubles QA cost and confuses users 45+. **Not recommended.**
+
+#### Risk register (Path A)
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| SSE protocol drift between upstream and our React client | Med | Encapsulate event taxonomy in one TS module; pin upstream tag during dev. |
+| `api/routes.py` adds an endpoint we now need a UI for (e.g., Kanban v1) | High | Track upstream weekly; budget continuous "absorb upstream" time. |
+| Phase 3 ships late if React rewrite balloons | High | Set hard 60-day cap; if exceeded, fall back to vanilla-CSS overhaul. |
+| Audience 45+ regressions: change-aversion, cognitive load on power users | Med | Beta with named friendly testers (already in Fox's QA practice per `feedback_qa_methodology.md`). |
+| Service worker behavior diverges from upstream's careful cache opt-out (#114, etc.) | Med | Reuse upstream's `HERMES_WEBUI_PWA_SHELL_CACHE` opt-in semantics in our SW. |
+| Lose i18n investment | Med | Port the en bundle 1:1, schedule other locales as Phase 4 work. |
+| Electron CSP / file:// quirks | Low | shadcn/Tailwind have no exotic runtime requirements; vetted on Electron in many shipped products. |
+
+---
+
+### Path B — Full Fox-owned UI: React frontend + new Fox-owned thin Python (or Node) server
+
+Drop hermes-webui entirely. New backend talks directly to hermes-agent. New frontend talks to new backend.
+
+#### What we keep / drop / rebuild
+
+| Layer | Status |
+|---|---|
+| All of `hermes-webui/` | **Drop entirely** |
+| 158 endpoints | **Re-implement every one we need** |
+| 5 SSE streams | **Re-implement** |
+| Session storage | **Reimplement, must stay on-disk-compatible with agent CLI** |
+| 18 `from agent.* / hermes_cli.* / cron.* / tools.*` imports | **Reimplement or maintain forever** |
+| Session.save atomic-write + .bak recovery | **Reimplement** (P0 data-loss fix already lives here) |
+| Auth, profiles, workspaces, projects, files, terminal, cron, skills, MCP, OAuth | **Reimplement** |
+
+#### Engineering-day estimate
+
+| Workstream | Days |
+|---|---|
+| Everything from Path A | 35–55 |
+| New backend scaffold (Python aiohttp/FastAPI, or Node/Hono) | 5–8 |
+| Re-implement 158 endpoints (avg 0.25 day each, weighted by complexity — chat/streaming/sessions are 3-5 days each) | 30–50 |
+| In-process Python integration with hermes-agent (if Python backend) | 5–8 |
+| Or build a new agent-HTTP API (if Node backend) | 30+ (out of scope per brief; would require coordinating with hermes-agent fork) |
+| Session storage compatibility tests (must coexist with agent CLI on same files) | 3–5 |
+| Auth, CSRF, profile cookies, security parity with upstream | 3–5 |
+| Reproduce upstream's #1558 P0 data-loss fix and other quietly-shipped patches | 2–4 |
+| Migration testing (must not lose anyone's existing sessions) | 3–5 |
+| **Total Path B** | **86–140 eng-days, mid-point ≈ 110** |
+
+If we stay in-process Python (i.e., new Python backend in same venv as agent): the lower end. If we go Node and reimplement agent surfaces: easily double.
+
+#### Hermes-agent contracts taken on
+
+**All of them.** Same 18 modules. Plus we now own the bug-for-bug compatibility surface for session JSON, gateway-session JSON (`~/.hermes/sessions/sessions.json`), credential pool semantics, model metadata lookups, profile config, etc. **This is the cost the React framing hides.**
+
+#### New dependency list (Path B)
+
+Path A list, plus:
+- aiohttp or FastAPI (Python backend) — and we lose the BaseHTTPServer simplicity of upstream
+- A new test matrix for the backend
+- A CI pipeline for the backend
+- A versioning + release story for it (currently the webui is just submoduled-and-installed)
+
+#### Non-technical-user UX comparison
+
+Same as Path A. The user can't see the backend.
+
+#### Migration sequencing
+
+Big bang. There is no gradual path that doesn't double-maintain two backends.
+
+#### Risk register (Path B)
+
+All of Path A's, plus:
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Reimplemented session storage drops messages on a corner case upstream caught (#1558 took weeks of debugging) | **Critical** | Mass-test against existing user session files; Fox's CHANGELOG already documents `:bak` recovery; need real test coverage |
+| Auth / CSRF / cookie-handling gap creates a security regression | **High** | Mirror upstream's `api/auth.py` exactly; security review before launch |
+| Cron / routines feature freeze: upstream Kanban-style features land but Fox can't absorb them | **High** | Permanent — this is the trade we're making |
+| Lose mid-stream protocol enhancements upstream ships (e.g., new streaming event types) | High | Permanent ownership burden |
+| Electron app refuses to install / certify because new server's startup signature changed | Low | Test on signed builds before merge |
+| Upstream lands a feature that's load-bearing for Fox (e.g., new approval semantics for Llama Guard 3 in Phase 4) | High | Permanent ownership burden |
+
+**Bottom line on Path B: plausible, but it costs 2–3× Path A and yields zero additional UX value over Path A. The only thing it buys is independence from the `nesquena/hermes-webui` Python dependency. It does not buy independence from hermes-agent — that coupling is unavoidable and Architect 1's plan already addresses it cleanly.**
+
+---
+
+## 3. Comparison matrix
+
+| Dimension | Status quo (edit forks) | Plan A from existing doc (overlay + 12-day patch series) | Path A (React + keep Python backend) | Path B (Full Fox UI + new backend) |
+|---|---|---|---|---|
+| **Migration cost (eng-days)** | 0 | **12** | **35–55 + 12 (overlay)** = ~50–70 total | **86–140 + 12** = ~100–155 total |
+| **Ongoing maintenance (hours/month)** | 30+ (and growing — currently *not done*) | **1–4** | 4–8 (deps + occasional upstream backend churn that affects frontend) | 15–30 (own everything) |
+| **Upstream-track cost (per release)** | Unworkable; we don't track | **15–60 min** | 30–90 min (upstream may add endpoints we want to surface) | None for upstream-webui (gone), but we lose upstream features unless re-built |
+| **Risk profile** | High & growing (security, drift) | **Low** | Medium (Phase 3 schedule risk; SSE protocol drift) | High (data-loss reimplementation risk; ownership of 158 endpoints) |
+| **Time to Phase-3-UI-polish** | 3–4 weeks (per #64) | 3–4 weeks Phase-3 + 12 days migration; can run partly in parallel | **Phase 3 IS the rewrite** — 7–11 weeks instead of 3–4; but visual win is bigger | 14–22 weeks before Phase-3 polish ships |
+| **Time to non-technical-user quality bar** | 3–4 weeks (CSS overhaul only) | Same as status quo + Architect-1 work invisible to user | 7–11 weeks (Phase 3 and rewrite combined) | 14–22 weeks |
+| **Security cadence inheritance** | Falls behind every week | **Inherited automatically** (12 backend patches drift, but security is at agent + upstream-webui level) | Inherited (same backend) | **Lost** — Fox owns the entire surface |
+| **Ability to absorb upstream features (Kanban, OAuth, etc.)** | Possible but currently blocked | Free for backend features; UI-side features need Fox to re-implement in React | Backend features free; UI features need re-implementation | **None** — every upstream UI feature is permanently lost unless re-implemented |
+| **Lock-in / reversibility** | Already locked in | Reversible: we can still rewrite later | Reversible: backend is shared with upstream | **Hardest to reverse**: schema and endpoint divergence accumulates |
+| **Developer experience (new feature work)** | Worst (vanilla JS, 5k-line files) | Same as status quo | Best (TS, components, hot reload) | Best on frontend, worst on backend (own everything) |
+
+**Reading the matrix:** Architect-1's overlay plan dominates the status quo on every axis. Path A is the natural follow-on **if and when** the visual/Phase-3 cost is justified. Path B is dominated by Path A on every axis except "no longer dependent on nesquena."
+
+---
+
+## 4. Honest tech-stack opinion
+
+### shadcn/ui
+
+**Recommendation: use shadcn/ui for Path A.**
+
+**Why:**
+- Audience 45+ benefits from restrained, high-contrast, accessible defaults — shadcn nails this out of the box. Radix primitives underneath are the gold standard for keyboard nav and screen readers.
+- Copy-into-repo model means **zero runtime dependency on the shadcn org**. We own the components after install. There is no shadcn version to track. This is the single best argument for it in an "install-and-forget" product.
+- Big ecosystem; example code for every screen we'd build is one search away.
+
+**Lock-ins:**
+- Tailwind required (see below).
+- Radix UI runtime is the actual dependency (well-maintained, ~stable).
+- React-only.
+
+**Compared to alternatives:**
+- **Mantine**: more components out of the box, more polished defaults for forms — but heavier runtime (CSS-in-JS), larger bundle, less Tailwind-friendly. Picks more opinions for you. Reasonable second choice if we *don't* want Tailwind.
+- **Radix-direct + Tailwind**: lower-level, more work; what shadcn already wraps. No reason to bypass.
+- **Headless UI (Tailwind Labs) + Tailwind**: smaller library, fewer components, less momentum. Skip.
+- **MUI**: looks like Google products, harder to feel "native." Default font size, color, density screams "Material" — bad fit for a non-technical SMB tool that should feel like Outlook/Slack/Quicken, not Google Workspace. Skip.
+
+**Verdict:** shadcn/ui is the right choice if and only if Tailwind is also chosen. They are a paired bet.
+
+### Tailwind
+
+**Recommendation: use Tailwind for Path A.**
+
+**Why for Fox specifically:**
+- Fox today already uses CSS custom properties for theming (`fox-in-the-box.css`). Tailwind plays nicely with this — define design tokens as CSS vars, reference them in `tailwind.config.ts`. Theme switching keeps working.
+- Co-located styling reduces drift between markup and styles, which has plagued `style.css` (3,052 lines) + 17 JS files.
+- Tooling — JIT, PurgeCSS — means production CSS bundle is tiny (typically < 30 KB).
+
+**Concerns the brief flags:**
+- "Utility CSS in a product that aims to be themed for non-technical users" — themability for end-users is **not impacted** by Tailwind. Tailwind is a developer abstraction; the user still gets a `:root { --bg: …; --fg: …; }` runtime they can override. This is exactly how shadcn themes work.
+
+**Compared to alternatives:**
+- **CSS Modules**: fine but loses the design-system feel; we re-discover tokens per file.
+- **Vanilla CSS variables (today's Fox approach)**: works, has been working. Loses the per-component encapsulation. Continues to grow `style.css` linearly. Accumulates dead code.
+- **Linaria / styled-components / Emotion**: CSS-in-JS adds runtime cost or complex build, no payoff over Tailwind for our use case.
+
+**Verdict:** Tailwind. The "utility CSS for non-technical users" framing conflates two different things — we use Tailwind to *build* the UI; users still see CSS variables.
+
+### React framework
+
+**Recommendation: Vite + React Router (NOT Next.js, NOT Remix).**
+
+Reasoning:
+- The app runs in **Electron-wrapped browser served from a local Docker container**. There is no SEO, no edge rendering, no cold-start tradeoff — the whole "Next.js/Remix make sense for SSR" argument doesn't apply.
+- Next.js's App Router pulls in opinions we don't need (server actions, RSC, middleware). The complexity tax is real.
+- Vite is the cleanest possible toolchain: pnpm install, vite dev, vite build, done. Output is a static folder we can drop into `static/` or serve from a sidecar.
+- React Router 6+ handles every routing need we have (sessions, settings, projects).
+- Lighter dependency surface = easier upgrades, smaller maintenance burden.
+
+**SvelteKit (the foil)**: smaller bundles, lovely DX, but (a) shadcn has no first-class Svelte port (shadcn-svelte exists but lags), (b) team-mobility cost — fewer engineers know Svelte than React, (c) we'd be re-deciding everything around it. Real argument against SvelteKit: ecosystem and hireability for a small team. Skip.
+
+**Verdict:** **Vite + React + React Router** as the foundation; keep options to migrate to Next or Remix later if SSR or data-loading patterns warrant it (they won't).
+
+### State / data
+
+**Recommendation:**
+- **TanStack Query** for REST data fetching (caching, retries, invalidation, mutations). Battle-tested, Electron-friendly, plays nicely with SSE invalidation patterns.
+- **Hand-rolled `useEventStream(url)` hook** for SSE — TanStack Query has subscription support but our streams are too custom (chat tokens, approvals, clarify) to map cleanly. Wrap `EventSource` in ~80 lines of typed hook code.
+- **Zustand** for tiny client-only state (active session id, sidebar open/closed, theme). Avoid Redux Toolkit unless complexity actually appears.
+- **No SWR** — TanStack Query has more features and similar ergonomics; pick one.
+- **No RTK Query** — we don't need Redux for this app.
+
+**Streaming SSE pattern sketch:**
+```ts
+function useChatStream(streamId: string | null) {
+  const [events, append] = useReducer(chatEventsReducer, []);
+  useEffect(() => {
+    if (!streamId) return;
+    const es = new EventSource(`/api/chat/stream?stream_id=${streamId}`);
+    es.addEventListener('delta', (e) => append({ type: 'delta', data: JSON.parse(e.data) }));
+    es.addEventListener('tool_call', /* … */);
+    es.addEventListener('error', () => es.close());
+    return () => es.close();
+  }, [streamId]);
+  return events;
+}
+```
+
+### Forms
+
+**Recommendation: react-hook-form + zod + `@hookform/resolvers/zod`.**
+
+Reasoning: small, fast, no rerender storms, schema-first validation that doubles as TypeScript types. The settings panels (8 areas, lots of conditional fields, server-validated) benefit enormously from this combo. Alternatives (formik, vanilla `useState`) lose on either DX or correctness.
+
+### Testing
+
+**Recommendation: Vitest + React Testing Library for unit, Playwright for e2e and onboarding-flow regressions.**
+
+Reasoning:
+- Vitest co-runs with Vite, zero extra config.
+- Playwright is the industry standard for Electron-app e2e (Microsoft uses it for VS Code) and gives us screenshot diffing for the visual-regression bar Phase-3 needs.
+- Skip Cypress (heavier, slower, less Electron-friendly).
+- Don't skip e2e: Fox's `qa/SMOKE_CHECKLIST.md` discipline maps to Playwright runs naturally.
+
+### Build / packaging into Docker + Electron
+
+**Recommendation:**
+- Build React with `vite build --outDir=dist` in CI.
+- In the Dockerfile, after `COPY forks/hermes-webui /app/hermes-webui`, **also `COPY packages/fox-react/dist /app/hermes-webui/static`** (or to `HERMES_WEBUI_EXTENSION_DIR`).
+- The existing Python server keeps serving from `static/`. **No new sidecar needed.** This is the single cleanest packaging path.
+- For Electron: nothing changes — the renderer points at `http://127.0.0.1:8787/` as today. The React app is just what `index.html` loads.
+- For dev: `vite dev` proxies `/api/*` and `/extensions/*` to `localhost:8787`. Hot-reload works.
+
+This packaging story is the **biggest pragmatic argument for Path A over Path B**: Path A slots into the existing Docker build with one extra `COPY` line. Path B requires a new supervisord program, a new port story, a new install-script update, a new auth flow review, and probably new GitHub Action steps.
+
+---
+
+## 5. The hermes-webui-cadence question
+
+> "Based on hermes-webui shipping schedule, how solid is them as a web ui choice?"
+
+### What the data says
+
+From `git log upstream/master` in the standalone clone:
+
+- **661 commits in last 7 days** (~94/day)
+- **1,329 commits in last 14 days** (~95/day)
+- **1,724 commits in last 30 days** (~57/day, includes a slower week)
+- **Tag cadence:** 50 most-recent tags span only a few weeks; current tag at time of writing is `v0.51.74`. Tags are released multiple times per day.
+
+Top contributors (last 30 days):
+
+| Author | Commits |
+|---|---|
+| `nesquena-hermes` (bot, owned by Nathan) | 573 |
+| `Hermes Agent` (CI bot) | 231 |
+| Frank Song | 155 |
+| Michael Lam | 127 |
+| `Hermes Bot` | 95 |
+| `test`, `bergeouss`, `ai-ag2026`, etc. | 50 / 50 / 45 / 38 / 33 |
+| Nathan Esquenazi (real account) | 44 |
+
+**Reality:** the project is `nesquena`-driven with bot-mediated PR-merge automation. The bot accounts (`nesquena-hermes`, `Hermes Agent`, `Hermes Bot`) are all his automation. Real human contributors are a long tail. **Bus factor = 1**, full stop. The "stage-NNN: stamp CHANGELOG" commits are clearly automation Nathan owns.
+
+### Alignment with hermes-agent
+
+Hermes WebUI versions itself independently of hermes-agent (`v0.51.x` vs agent's `v0.13.x`). They do not ship in lockstep. **However**, the in-process imports (Section 1.6) mean a webui release that depends on a not-yet-released agent change *can* break. The Fox-bundled images pin both to specific tags at Docker build time, which mostly contains this risk.
+
+### Feature alignment with Fox needs
+
+- Recent shipped: Kanban v1 (would compete with Fox's Phase 5 routines if we wanted that surface), `transform_llm_output` plugin hook (which hermes-agent v0.13.0 added — Fox guardrails directly benefits), settings i18n, custom-providers list-format fix.
+- Recent missed-by-Fox: `:free`/`:beta`/`:thinking` suffix routing fix; named custom-provider routing (Stage-306) — these are exactly the things Fox patches `api/providers.py` for. Architect 1's plan calls these out as patches Fox should drop.
+
+### Has it ever been abandoned / restructured
+
+Per Architect 1's audit: no abandonment. Heavy continuous evolution. Some restructures (`api/onboarding.py` was rewritten when Codex OAuth landed). The patch surface Fox carries on `api/onboarding.py` is +227/−916 — meaning Fox effectively replaced upstream's onboarding wholesale. If upstream restructures something Fox has fully replaced, Fox is unaffected (already off the upstream code path). Where Fox tracks upstream (chat, sessions, models), restructures matter — and the overlay/monkey-patch model in Architect 1 buys debounceability.
+
+### What if `nesquena` disappears tomorrow
+
+Three scenarios:
+1. **Project continues under another maintainer:** plausible — Frank Song and Michael Lam are routinely landing PRs. Cadence might slow, security cadence is the worry.
+2. **Project goes dormant:** Fox is fine for ~6–12 months because we've already pinned tags and don't *need* every release. The day we need a security fix, we take ownership of one specific patch.
+3. **Project hostile fork by another party:** Fox can fork at the last good tag and own from there. Architect 1's plan already isolates Fox's deltas, so a fork-takeover by Fox would be feasible from the patch-series state.
+
+### The honest verdict on cadence
+
+The cadence is **a feature, not a bug, from Fox's perspective**. ~95 commits/day means upstream is fixing real bugs and adding capabilities Fox would otherwise have to build (PWA improvements, accessibility passes, locale work, Kanban, OAuth). The cadence is a *risk* only because Fox isn't tracking it — solve that with Architect 1's plan.
+
+Bus-factor (single maintainer) is the real risk. Mitigate by:
+1. Pinning tags in `versions.toml` (Architect 1 plan does this).
+2. Forking-and-owning if `nesquena` disappears — Fox is well-positioned to do this from the post-Architect-1 state, *less* well-positioned from a Path-B "we already replaced everything" state because then we have no patch series to graft back onto upstream code if we want re-alignment.
+
+**Path A is consistent with cadence resilience. Path B sacrifices it.**
+
+---
+
+## 6. Recommendation
+
+**Take Architect 1's overlay/patch-series plan now (12 eng-days). Defer the React rewrite. When you do build it, build Path A — not Path B — and time it as the v0.6.0 (Phase 3) UI overhaul work.**
+
+Three concrete moves, in order:
+
+1. **Now (Phase 0 cleanup, parallel to v0.5.4 / Phase 1 work):** Execute Architect 1's 12-day overlay+patch-series plan. This is non-optional and non-controversial regardless of any UI decision. Once shipped, Fox can absorb upstream weekly with ≤ 1 hour of effort per release.
+
+2. **At v0.6.0 (Phase 3, the planned 3–4 week UI overhaul):** **Replace the planned vanilla-CSS overhaul with Path A — React + shadcn/ui + Tailwind, keeping the Python backend.** Budget 7–11 calendar weeks (35–55 eng-days, plus QA/buffer). The visual quality lift will exceed what 3–4 weeks of vanilla-CSS overhaul could achieve, and the foundation makes Phase 4–5 UI work (Llama Guard banners, routines tab, status indicators) cheaper.
+
+3. **Never (or only on a customer-driven trigger):** Path B. The cost is 2–3× Path A for zero user-visible benefit. The only thing Path B buys is independence from `nesquena/hermes-webui`, and Architect 1's plan already buys 90% of that benefit at 8% of the cost.
+
+### The trade-off in one sentence
+
+> *We accept a continued (well-bounded) dependency on `nesquena/hermes-webui`'s Python backend in exchange for skipping a 100+ eng-day rewrite of code we don't get to upgrade thereafter — and we'll still get the React/shadcn/Tailwind UX upgrade by replacing only the static frontend in Phase 3.*
+
+### What this depends on (the two facts that could change the recommendation)
+
+1. **If `nesquena` disappears or hermes-webui goes hostile-fork in the next 6 months:** Path B becomes the right move because we can no longer benefit from upstream tracking. Today: not the case.
+2. **If hermes-agent changes its in-process import surface in a way that makes `from agent.* import …` calls untenable for Fox:** Path B's cost balloons further (now we need to build the agent-HTTP API too) — meaning Path A becomes even more strongly preferred. So this fact actually pushes harder toward A, not B.
+
+Neither fact is currently in motion. Recommendation stands.
+
+---
+
+## 7. Open questions for Dennis
+
+1. **Is the v0.6.0 Phase-3 UI overhaul the right vehicle for the React rewrite?** The roadmap calls Phase 3 a "3–4 week vanilla-CSS overhaul." Path A is 7–11 weeks. Are you willing to slip Phase 3 by ~6 weeks for the qualitative jump, or do you prefer the cheap CSS-only overhaul now and Path A later (e.g., as v0.7.5 between Llama Guard and Routines)?
+2. **Do you want i18n parity at React-rewrite launch, or English-only with locales as fast-follow?** Affects estimate by ~6–8 days.
+3. **Are you OK with Vite + React (no Next/Remix), Tailwind + shadcn, TanStack Query + Zustand?** If you have a stack preference (e.g., you've been building landing pages in Next), say so now — switching frameworks mid-rewrite costs ~5 days.
+4. **Are there any contracts where you'd want a Fox-owned alternative regardless** (e.g., the chat-stream SSE format)? This is the only place Path B's case strengthens — but the answer would be "build a Fox-owned SSE shim layer," not "build a whole new backend."
+5. **PWA / offline behavior**: today, Fox runs Electron-wrapped, so PWA install isn't user-facing. Should the React rewrite drop SW/manifest entirely, or maintain it for the (rare) "open in browser instead of Electron" path?
+6. **Browser/Electron version floor**: confirm we can target evergreen Chromium only (no IE/Safari ancients). Affects bundle size and dependency choices.
+7. **Headcount/runway for the rewrite window**: the 35–55 eng-day estimate assumes one full-time engineer. If it's a 50% engineer, double the calendar time. What's the actual capacity?


### PR DESCRIPTION
Six architecture docs driving the v0.6.0 release scope. Referenced by
epic #155 and all 61 v0.6.0 sub-issues (#156–#216) — those tickets cite
these docs by section number for full Validation gates and Rollback
procedures.

## What's added

| Doc | Purpose |
|---|---|
| `upstream-separation-plan.md` | 4-lane research synthesis (the foundational doc, originally drafted 2026-05-08) |
| `upstream-migration-execution-plan.md` | 10-phase execution plan (1,109 lines) — drives the migration |
| `webui-build-vs-fork-analysis.md` | React rewrite analysis — ruled out for v0.6.0 |
| `hermes-webui-dependency-risk-assessment.md` | Dependency risk + 10 tripwires |
| `v0.6.0-github-breakdown.md` | Initial issue-tree draft (v1) |
| `v0.6.0-github-breakdown-v2.md` | Final breakdown after unbiased reviewer scrub |

## Why now

These docs were drafted across the past week and need to land on `main` so
the 62 v0.6.0 issues' references resolve correctly. **Pre-flight #157 item:
unblocks Phase 1.**

## Out of scope
No code changes. Pure documentation.

Closes #157 partially (architecture docs landed checkbox).