### PR TITLE
chore(ci): pause sync-submodules.yml repository_dispatch for v0.6.0 migration

### DIFF
--- a/.github/workflows/sync-submodules.yml
+++ b/.github/workflows/sync-submodules.yml
@@ -7,8 +7,10 @@ name: Sync Submodules to Latest
 # CI to run, instead of trying to push to main itself.
 
 on:
-  repository_dispatch:
-    types: [hermes-webui-updated, hermes-agent-updated]
+  # repository_dispatch trigger PAUSED for v0.6.0 upstream-separation migration
+  # (epic #155 / pre-flight #157). Auto-bumping the submodule pointer mid-migration
+  # would whipsaw the pin while phases 2-7 are in flight. Restored when v0.6.0
+  # ships and the submodules re-point at virgin upstream (Phase 8 #200).
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Pre-flight #157 item.

## Problem
`repository_dispatch` on this workflow auto-bumps the fork submodule pointer
when forks/hermes-{agent,webui} push to their default branches. During the
v0.6.0 upstream-separation migration (#155, phases 2-7), submodule pointers
move many times across many PRs. An auto-bump mid-migration would whipsaw
the pin and trigger a conflict cascade.

## Change
Single 4-line edit. `repository_dispatch` block commented-out with rationale.
`workflow_dispatch` remains available for manual invocation if needed during
the migration.

## When this gets restored
When Phase 8 #200 lands and the submodules re-point at virgin upstream, this
workflow is obsolete anyway — replaced by Phase 9 #202 nightly upstream-watch.
Phase 10 cleanup #204 will delete this file outright.

## Out of scope
Workflow logic itself is unchanged. No other files touched.

Refs #157.