### PR TITLE
feat(fox-overlay): dispatcher mechanism + webui patch series (Phase 4b)

### DIFF
--- a/packages/fox-overlay/fox_overlay/bootstrap.py
+++ b/packages/fox-overlay/fox_overlay/bootstrap.py
@@ -30,7 +30,12 @@ def install() -> None:
     if _INSTALLED:
         return
     _INSTALLED = True
-    _log.info("[fox-overlay] bootstrap installed (no-op skeleton)")
+    # Phase 5+ will import webui_modules here (e.g.
+    # `from fox_overlay import webui_modules`) so they can call
+    # register_get/post() at module-load time before freeze().
+    from fox_overlay import dispatch
+    dispatch.freeze()
+    _log.info("[fox-overlay] bootstrap installed (dispatcher frozen, table empty in Phase 4)")
 
 
 if os.environ.get("FOX_OVERLAY_AUTOINSTALL", "1") != "0":

--- a/packages/fox-overlay/fox_overlay/dispatch.py
+++ b/packages/fox-overlay/fox_overlay/dispatch.py
@@ -1,0 +1,209 @@
+"""Fox dispatcher: called by the 6-line patch in api/routes.py before
+the upstream `if/elif` chain.
+
+Phase 4 ships an EMPTY dispatch table — ``handle_get`` and
+``handle_post`` return ``False`` so every request falls through to
+upstream. The mechanism exists; nothing claims any route yet.
+
+* Phase 5 populates the table for Fox additive modules (ollama,
+  tailscale, local_fallback, models_download, hostname,
+  session_recovery) via ``register_get/post`` calls at module load.
+* Phase 7 wires the onboarding wholesale-replace through the same
+  table.
+
+## Threading contract
+
+Registration is bootstrap-only — call ``register_get/register_post``
+during ``fox_overlay.bootstrap`` (i.e. at server-module import, BEFORE
+``ThreadingHTTPServer.serve_forever``). Hermes WebUI runs on
+``ThreadingHTTPServer`` with ``daemon_threads=True`` (server.py),
+so mutating the tables after the server is serving requests races
+with iteration in ``handle_get``/``handle_post`` and CPython raises
+``RuntimeError: dictionary changed size during iteration``. The
+``_BootstrapState.frozen`` flag enforces this: any registration
+after ``freeze()`` raises.
+
+## Path-prefix contract
+
+``register_get/post`` enforces:
+
+* prefix MUST start with ``/`` and end with ``/`` (so
+  ``startswith`` matching can't accept ``/api/fox-evil`` as a hit on
+  prefix ``/api/fox``)
+* prefix MUST NOT be empty or ``/`` (would shadow everything)
+* prefix MUST NOT overlap auth-public namespaces (``/static/``,
+  ``/session/static/``, ``/login``, ``/api/auth/``, ``/health``,
+  ``/favicon.ico``, ``/sw.js``, ``/manifest``) — those bypass
+  ``check_auth`` in upstream, so a Fox handler registered there
+  would be reachable unauthenticated.
+
+Path-traversal note: ``parsed.path`` from ``urllib.parse.urlparse``
+is NOT normalized; ``/api/fox/../etc/passwd`` would match prefix
+``/api/fox/``. Each Fox handler is responsible for its own
+path-traversal sandbox (Phase 5+ handlers MUST use
+``pathlib.Path.resolve().relative_to(...)`` for any filesystem
+operation, matching upstream's ``_serve_static`` convention).
+
+## CSRF note (for Phase 5 handlers)
+
+Upstream's ``_check_csrf`` (api/routes.py) bypasses cross-origin
+rejection when the request has neither ``Origin`` nor ``Referer``
+headers — i.e. any non-browser caller (curl, native app, SSRF from
+inside the container's LAN) bypasses CSRF entirely. The
+dispatcher inherits this behavior because the hook runs AFTER
+``_check_csrf`` in ``handle_post``. Phase 5 handlers that perform
+state-changing operations (ollama install, tailscale auth,
+hostname rename) MUST treat all POSTs as potentially unauthenticated
+cross-origin until the Phase 5 design decision on per-prefix
+``requires_csrf=True`` lands.
+
+## Handler return contract
+
+Handlers receive ``(handler, parsed)``:
+
+* ``handler``: ``http.server.BaseHTTPRequestHandler`` subclass with
+  the active request. Read body with the upstream ``read_body(handler)``
+  helper if needed; the dispatcher does NOT consume the body.
+* ``parsed``: ``urllib.parse.ParseResult`` from ``urlparse(self.path)``.
+
+Return value:
+
+* ``True`` — the handler responded; the dispatcher returns ``True``
+  and upstream's ``if/elif`` chain is skipped.
+* ``False`` — the handler declined; the dispatcher moves to the next
+  registered prefix (or returns ``False`` so upstream handles it).
+* ``None`` or anything else — explicit ``RuntimeError``. Falsy
+  returns are too easy to produce by mistake (``return j(handler, ...)``
+  returns ``None``) and would silently double-respond when upstream
+  also takes the route. The dispatcher rejects them loudly.
+"""
+from __future__ import annotations
+
+import logging
+from http.server import BaseHTTPRequestHandler
+from types import MappingProxyType
+from typing import Callable
+from urllib.parse import ParseResult
+
+logger = logging.getLogger(__name__)
+
+HandlerFn = Callable[[BaseHTTPRequestHandler, ParseResult], bool]
+
+# Upstream namespaces that bypass check_auth (see hermes-webui api/auth.py
+# PUBLIC_PATHS and is_public_path). Registering a Fox handler on any of
+# these would make it reachable unauthenticated.
+_AUTH_PUBLIC_PREFIXES = (
+    "/static/",
+    "/session/static/",
+    "/login",
+    "/api/auth/",
+    "/health",
+    "/favicon.ico",
+    "/sw.js",
+    "/manifest",
+)
+
+_GET_TABLE: dict[str, HandlerFn] = {}
+_POST_TABLE: dict[str, HandlerFn] = {}
+
+
+class _BootstrapState:
+    frozen: bool = False
+
+
+def _validate_prefix(path_prefix: str) -> None:
+    if not isinstance(path_prefix, str):
+        raise TypeError(f"path_prefix must be str, got {type(path_prefix).__name__}")
+    if not path_prefix.startswith("/"):
+        raise ValueError(f"path_prefix must start with '/': {path_prefix!r}")
+    if not path_prefix.endswith("/"):
+        raise ValueError(
+            f"path_prefix must end with '/' so startswith() can't match "
+            f"adjacent paths (e.g. '/api/fox' matches '/api/fox-evil'): "
+            f"{path_prefix!r}"
+        )
+    if path_prefix == "/":
+        raise ValueError("path_prefix '/' would shadow every upstream route")
+    for public in _AUTH_PUBLIC_PREFIXES:
+        if path_prefix.startswith(public) or public.startswith(path_prefix):
+            raise ValueError(
+                f"path_prefix {path_prefix!r} overlaps auth-public namespace "
+                f"{public!r}; a Fox handler here would be reachable "
+                f"unauthenticated. If this is intentional, register from a "
+                f"non-overlapping prefix and forward."
+            )
+
+
+def _register(table: dict[str, HandlerFn], path_prefix: str, handler: HandlerFn) -> None:
+    if _BootstrapState.frozen:
+        raise RuntimeError(
+            f"dispatcher table frozen; register {path_prefix!r} during "
+            f"fox_overlay.bootstrap, not after serve_forever()"
+        )
+    _validate_prefix(path_prefix)
+    if path_prefix in table:
+        logger.warning(
+            "fox_overlay.dispatch: overwriting handler for %r "
+            "(previous: %s, new: %s)",
+            path_prefix,
+            getattr(table[path_prefix], "__qualname__", repr(table[path_prefix])),
+            getattr(handler, "__qualname__", repr(handler)),
+        )
+    else:
+        logger.info(
+            "fox_overlay.dispatch: registered %r -> %s",
+            path_prefix,
+            getattr(handler, "__qualname__", repr(handler)),
+        )
+    table[path_prefix] = handler
+
+
+def register_get(path_prefix: str, handler: HandlerFn) -> None:
+    """Register a GET handler for the given path prefix."""
+    _register(_GET_TABLE, path_prefix, handler)
+
+
+def register_post(path_prefix: str, handler: HandlerFn) -> None:
+    """Register a POST handler for the given path prefix."""
+    _register(_POST_TABLE, path_prefix, handler)
+
+
+def freeze() -> None:
+    """Freeze the dispatch tables; subsequent registrations raise.
+
+    Called by ``fox_overlay.bootstrap`` after all Phase 5+ overlay
+    modules have registered. Iteration after freeze is safe because
+    the dicts are never mutated again.
+    """
+    _BootstrapState.frozen = True
+
+
+def _dispatch(table: dict[str, HandlerFn], handler, parsed) -> bool:
+    for prefix, fn in table.items():
+        if parsed.path.startswith(prefix):
+            result = fn(handler, parsed)
+            if result is True:
+                return True
+            if result is False:
+                continue
+            raise RuntimeError(
+                f"Fox handler {getattr(fn, '__qualname__', fn)} returned "
+                f"{result!r} for {parsed.path!r}; must return True (handled) "
+                f"or False (decline). Falsy returns risk double-responding."
+            )
+    return False
+
+
+def handle_get(handler, parsed) -> bool:
+    """Dispatch a GET request. Returns False if no Fox handler claims it."""
+    return _dispatch(_GET_TABLE, handler, parsed)
+
+
+def handle_post(handler, parsed) -> bool:
+    """Dispatch a POST request. Returns False if no Fox handler claims it."""
+    return _dispatch(_POST_TABLE, handler, parsed)
+
+
+# Read-only views — for tests and introspection without leaking mutability.
+GET_TABLE = MappingProxyType(_GET_TABLE)
+POST_TABLE = MappingProxyType(_POST_TABLE)

--- a/packages/fox-overlay/patches/webui/001-server-py-bootstrap.patch
+++ b/packages/fox-overlay/patches/webui/001-server-py-bootstrap.patch
@@ -1,0 +1,21 @@
+diff --git a/server.py b/server.py
+index 4a57ea7..485b652 100644
+--- a/server.py
++++ b/server.py
+@@ -13,6 +13,16 @@ from urllib.parse import urlparse
+ 
+ logger = logging.getLogger(__name__)
+ 
++# Fox overlay bootstrap: installs monkey-patches + dispatcher table at import.
++# Wrapped so vanilla hermes-webui (no fox_overlay installed) keeps booting.
++try:
++    import fox_overlay.bootstrap  # noqa: F401
++except ModuleNotFoundError as _fox_e:
++    if _fox_e.name != "fox_overlay":
++        raise
++except Exception as _fox_e:
++    logger.warning("fox_overlay.bootstrap failed (%s); Fox routes disabled", _fox_e)
++
+ from api.auth import check_auth
+ from api.config import HOST, PORT, STATE_DIR, SESSION_DIR, DEFAULT_WORKSPACE
+ from api.helpers import j, get_profile_cookie

--- a/packages/fox-overlay/patches/webui/002-routes-py-dispatch-hook.patch
+++ b/packages/fox-overlay/patches/webui/002-routes-py-dispatch-hook.patch
@@ -1,0 +1,34 @@
+diff --git a/api/routes.py b/api/routes.py
+index 97be718..4f3c677 100644
+--- a/api/routes.py
++++ b/api/routes.py
+@@ -1503,6 +1503,14 @@ def _handle_insights(handler, parsed) -> bool:
+ def handle_get(handler, parsed) -> bool:
+     """Handle all GET routes. Returns True if handled, False for 404."""
+ 
++    try:
++        from fox_overlay.dispatch import handle_get as _fox_get
++        if _fox_get(handler, parsed):
++            return True
++    except ModuleNotFoundError as _fox_e:
++        if _fox_e.name not in ("fox_overlay", "fox_overlay.dispatch"):
++            raise
++
+     if parsed.path.startswith("/session/static/"):
+         # Strip the leading "/session" so _serve_static() sees a path that
+         # starts with "/static/" (its required prefix). _serve_static enforces
+@@ -2343,6 +2351,14 @@ def handle_post(handler, parsed) -> bool:
+     if not _check_csrf(handler):
+         return j(handler, {"error": "Cross-origin request rejected"}, status=403)
+ 
++    try:
++        from fox_overlay.dispatch import handle_post as _fox_post
++        if _fox_post(handler, parsed):
++            return True
++    except ModuleNotFoundError as _fox_e:
++        if _fox_e.name not in ("fox_overlay", "fox_overlay.dispatch"):
++            raise
++
+     if parsed.path == "/api/upload":
+         return handle_upload(handler)
+     if parsed.path == "/api/upload/extract":

--- a/packages/fox-overlay/patches/webui/series
+++ b/packages/fox-overlay/patches/webui/series
@@ -1,1 +1,12 @@
-# Phase 4 populates: 001-server-py-bootstrap.patch, 002-routes-py-dispatch-hook.patch
+# Quilt-style ordered patch series for hermes-webui.
+# Each line names a `.patch` file in this directory (relative path).
+# Lines starting with `#` and blank lines are stripped by the Dockerfile
+# consumer (see packages/integration/Dockerfile).
+#
+# Applied in order via `git apply --check` (anchor pre-flight) then
+# `git apply` against /app/hermes-webui at image build time.
+# Phase 9 nightly upstream-watch CI runs the same `git apply --check`
+# against new upstream tags — anchor drift fails fast.
+
+001-server-py-bootstrap.patch
+002-routes-py-dispatch-hook.patch

--- a/packages/fox-overlay/tests/test_dispatch.py
+++ b/packages/fox-overlay/tests/test_dispatch.py
@@ -1,0 +1,168 @@
+"""Phase 4 regression tests for fox_overlay.dispatch.
+
+Covers the contract documented in dispatch.py: prefix validation,
+re-registration warning, freeze, handler return semantics, and the
+dispatch fall-through behavior.
+"""
+import importlib
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def dispatch():
+    """Fresh dispatch module per test — clears tables and freeze state."""
+    import fox_overlay.dispatch as d
+    importlib.reload(d)
+    yield d
+    importlib.reload(d)
+
+
+def _parsed(path: str):
+    """Minimal stand-in for urllib.parse.ParseResult (only .path is read)."""
+    return SimpleNamespace(path=path)
+
+
+# ── prefix validation ───────────────────────────────────────────────────────
+
+def test_register_get_accepts_well_formed_prefix(dispatch):
+    dispatch.register_get("/api/fox/ollama/", lambda h, p: True)
+    assert "/api/fox/ollama/" in dispatch.GET_TABLE
+
+
+def test_register_post_accepts_well_formed_prefix(dispatch):
+    dispatch.register_post("/api/fox/hostname/", lambda h, p: True)
+    assert "/api/fox/hostname/" in dispatch.POST_TABLE
+
+
+def test_register_rejects_prefix_without_leading_slash(dispatch):
+    with pytest.raises(ValueError, match="must start with '/'"):
+        dispatch.register_get("api/fox/", lambda h, p: True)
+
+
+def test_register_rejects_prefix_without_trailing_slash(dispatch):
+    with pytest.raises(ValueError, match="must end with '/'"):
+        dispatch.register_get("/api/fox", lambda h, p: True)
+
+
+def test_register_rejects_root_prefix(dispatch):
+    with pytest.raises(ValueError, match="shadow every upstream route"):
+        dispatch.register_get("/", lambda h, p: True)
+
+
+@pytest.mark.parametrize(
+    "public_prefix",
+    [
+        "/static/foo/",
+        "/session/static/x/",
+        "/login/",
+        "/api/auth/login/",
+        "/health/",
+        "/favicon.ico/",
+        "/sw.js/",
+        "/manifest.json/",
+    ],
+)
+def test_register_rejects_auth_public_overlap(dispatch, public_prefix):
+    with pytest.raises(ValueError, match="auth-public namespace"):
+        dispatch.register_get(public_prefix, lambda h, p: True)
+
+
+def test_register_rejects_non_string(dispatch):
+    with pytest.raises(TypeError):
+        dispatch.register_get(123, lambda h, p: True)  # type: ignore[arg-type]
+
+
+# ── re-registration warning ─────────────────────────────────────────────────
+
+def test_reregister_warns(dispatch, caplog):
+    dispatch.register_get("/api/fox/ping/", lambda h, p: True)
+    with caplog.at_level(logging.WARNING, logger="fox_overlay.dispatch"):
+        dispatch.register_get("/api/fox/ping/", lambda h, p: True)
+    assert any("overwriting handler" in r.message for r in caplog.records)
+
+
+# ── freeze ──────────────────────────────────────────────────────────────────
+
+def test_freeze_blocks_subsequent_registration(dispatch):
+    dispatch.register_get("/api/fox/ping/", lambda h, p: True)
+    dispatch.freeze()
+    with pytest.raises(RuntimeError, match="dispatcher table frozen"):
+        dispatch.register_get("/api/fox/late/", lambda h, p: True)
+
+
+def test_freeze_does_not_break_dispatch(dispatch):
+    """Frozen tables must still be iterable and dispatchable."""
+    dispatch.register_get("/api/fox/ping/", lambda h, p: True)
+    dispatch.freeze()
+    assert dispatch.handle_get(None, _parsed("/api/fox/ping/x")) is True
+
+
+# ── dispatch behavior ──────────────────────────────────────────────────────
+
+def test_dispatch_returns_false_for_unregistered_prefix(dispatch):
+    assert dispatch.handle_get(None, _parsed("/not/registered/")) is False
+    assert dispatch.handle_post(None, _parsed("/not/registered/")) is False
+
+
+def test_dispatch_returns_true_when_handler_handles(dispatch):
+    called = []
+    def h(handler, parsed):
+        called.append(parsed.path)
+        return True
+    dispatch.register_get("/api/fox/ping/", h)
+    assert dispatch.handle_get(None, _parsed("/api/fox/ping/v1")) is True
+    assert called == ["/api/fox/ping/v1"]
+
+
+def test_dispatch_continues_when_handler_declines(dispatch):
+    """Handler returning False means 'not mine'; dispatcher tries next prefix."""
+    fox_calls = []
+    other_calls = []
+    def fox(handler, parsed):
+        fox_calls.append(parsed.path)
+        return False  # decline
+    def other(handler, parsed):
+        other_calls.append(parsed.path)
+        return True
+    dispatch.register_get("/api/fox/", fox)
+    dispatch.register_get("/api/fox/specific/", other)
+    # /api/fox/specific/x matches fox prefix first (insertion order); fox
+    # declines, dispatcher moves to next prefix (other), other handles.
+    assert dispatch.handle_get(None, _parsed("/api/fox/specific/x")) is True
+    assert fox_calls == ["/api/fox/specific/x"]
+    assert other_calls == ["/api/fox/specific/x"]
+
+
+def test_dispatch_raises_on_none_return(dispatch):
+    """Handler returning None is a contract violation — fail loud."""
+    def buggy(handler, parsed):
+        return None  # forgot `return True` after handling
+    dispatch.register_get("/api/fox/buggy/", buggy)
+    with pytest.raises(RuntimeError, match="must return True"):
+        dispatch.handle_get(None, _parsed("/api/fox/buggy/x"))
+
+
+def test_dispatch_raises_on_non_bool_return(dispatch):
+    """Truthy non-bool returns (e.g. accidental dict/string) also fail loud."""
+    def buggy(handler, parsed):
+        return {"status": "ok"}
+    dispatch.register_get("/api/fox/buggy/", buggy)
+    with pytest.raises(RuntimeError, match="must return True"):
+        dispatch.handle_get(None, _parsed("/api/fox/buggy/x"))
+
+
+# ── read-only views ─────────────────────────────────────────────────────────
+
+def test_get_table_view_is_read_only(dispatch):
+    dispatch.register_get("/api/fox/x/", lambda h, p: True)
+    with pytest.raises(TypeError):
+        dispatch.GET_TABLE["/api/fox/x/"] = lambda h, p: False  # type: ignore[index]
+
+
+def test_post_table_view_is_read_only(dispatch):
+    dispatch.register_post("/api/fox/x/", lambda h, p: True)
+    with pytest.raises(TypeError):
+        dispatch.POST_TABLE["/api/fox/x/"] = lambda h, p: False  # type: ignore[index]

--- a/packages/integration/Dockerfile
+++ b/packages/integration/Dockerfile
@@ -126,6 +126,70 @@ RUN chmod +x /app/scripts/*.sh
 # ── Hermes app source (git submodules — init before build) ─────────────────────
 COPY forks/hermes-agent /app/hermes-agent
 COPY forks/hermes-webui /app/hermes-webui
+
+# ── Fox webui patch series (Phase 4 of v0.6.0 migration) ──────────────────────
+# Apply the patch series to /app/hermes-webui BEFORE pip install so the editable
+# install registers the patched source. Submodule COPY brings in a `.git`
+# gitlink file pointing at the superproject's .git/modules/... which doesn't
+# exist in the container; `git apply` chokes on the broken pointer. The
+# gitlink is useless inside the container anyway (nothing reads it), so we
+# delete it before the apply loop — no rename/restore dance, no half-state
+# risk if a patch fails mid-loop.
+#
+# `git apply --check` runs first on every patch — fuzz-tolerance failure
+# surfaces here as a build-time error with a readable diagnostic rather than
+# silently degrading runtime behavior. Phase 9 nightly upstream-watch CI uses
+# the same `--check` against new upstream tags.
+#
+# FITB_DISABLE_WEBUI_OVERLAY=1 short-circuits the entire patch loop.
+# Useful for bisecting overlay-induced regressions (compare patched vs
+# vanilla container behavior) and for emergency rollback if a fresh
+# upstream tag breaks anchor matching before the patches have been
+# regenerated. The dispatcher hook in api/routes.py is the only runtime
+# coupling; routes.py without it is just Fox's routes.py which works
+# fine without the dispatcher (no Phase 5+ overlay handlers, but Fox's
+# fork-side handlers still serve every existing route).
+#
+# Submodule pointer drift: any drift surfaces as a `git apply --check`
+# anchor mismatch with the verbose error block below. Stronger pre-flight
+# (assert submodule SHA matches a build-arg) is not feasible inside the
+# container because the COPY'd submodule's `.git` is a broken gitlink.
+# Monorepo CI is the right gate — it runs `git submodule status` before
+# docker build; a stale submodule fails the workflow before we get here.
+ARG FITB_DISABLE_WEBUI_OVERLAY=0
+COPY packages/fox-overlay/patches/webui /tmp/fox-webui-patches
+RUN set -eu; \
+    if [ "${FITB_DISABLE_WEBUI_OVERLAY}" = "1" ]; then \
+        echo "[fox-patch] FITB_DISABLE_WEBUI_OVERLAY=1 — skipping webui patch series"; \
+        rm -rf /tmp/fox-webui-patches; \
+        exit 0; \
+    fi; \
+    cd /app/hermes-webui; \
+    rm -f .git; \
+    series_file=/tmp/fox-webui-patches/series; \
+    if [ ! -f "$series_file" ]; then \
+        echo "::error::missing series file: $series_file"; exit 1; \
+    fi; \
+    patches=$(tr -d '\r' < "$series_file" | grep -vE '^\s*$|^\s*#' || true); \
+    if [ -z "$patches" ]; then \
+        echo "[fox-patch] series file empty; nothing to apply"; \
+        rm -rf /tmp/fox-webui-patches; \
+        exit 0; \
+    fi; \
+    echo "$patches" | while IFS= read -r p; do \
+        [ -z "$p" ] && continue; \
+        echo "[fox-patch] applying webui/$p"; \
+        if ! err=$(git apply --check "/tmp/fox-webui-patches/$p" 2>&1); then \
+            echo "::error::patch webui/$p failed --check"; \
+            echo "----- git apply --check output -----"; \
+            echo "$err"; \
+            echo "------------------------------------"; \
+            exit 1; \
+        fi; \
+        git apply "/tmp/fox-webui-patches/$p"; \
+    done; \
+    rm -rf /tmp/fox-webui-patches
+
 RUN set -eux; \
     pip install -e /app/hermes-agent --quiet --no-cache-dir; \
     if [ -f /app/hermes-webui/pyproject.toml ] || [ -f /app/hermes-webui/setup.py ]; then \


### PR DESCRIPTION
Phase 4b of the v0.6.0 upstream-separation migration (#155, sub-issue #173). Ships the dispatcher mechanism that Phases 5/6/7 will use to register Fox handlers into hermes-webui without forking `api/routes.py` wholesale.

Companion to merged fork PR fox-in-the-box-ai/hermes-webui#19 (Fox `api/routes.py` restored after the original Phase 4a (#18) wholesale-reverted it to merge-base and broke webui boot via `api.onboarding` ImportError).

## Architecture decision: Option E — patch on top of Fox's routes.py

The original Phase 4 plan bundled "install dispatcher mechanism" with "wholesale-revert routes.py to merge-base". The revert assumed Phases 5/6/7 had already migrated Fox's additive handlers to the overlay. They hadn't. The merge-base `routes.py` imports `apply_onboarding_setup, get_onboarding_status, complete_onboarding, probe_provider_endpoint` from `api.onboarding` — symbols that Fox's wholesale-replaced 3-step setup wizard doesn't export. Webui FATAL at boot.

**Option E (this PR):** keep Fox's `routes.py`, patch the dispatcher hook on top of it. Phases 5/6/7 each delete their own Fox handlers from `routes.py` as overlay replacements ship. End-state is identical to the original plan (`routes.py` = upstream + 3-line dispatcher hook + dispatcher-table-registered Fox handlers); migration is piece-by-piece, no broken intermediate states.

## What ships

| File | Purpose |
|------|---------|
| `fox_overlay/dispatch.py` | Dispatcher table + prefix validation + freeze + None-return guard |
| `fox_overlay/bootstrap.py` | install() now calls dispatch.freeze() at end |
| `patches/webui/001-server-py-bootstrap.patch` | Wraps `import fox_overlay.bootstrap` after `logger =` in server.py |
| `patches/webui/002-routes-py-dispatch-hook.patch` | Dispatcher hook in handle_get (after docstring) and handle_post (after _check_csrf) |
| `patches/webui/series` | Quilt-style ordered patch list |
| `tests/test_dispatch.py` | 24 unit tests covering full dispatcher contract |
| `packages/integration/Dockerfile` | RUN block applies patch series at build time |
| `forks/hermes-webui` submodule | Bumped to `cd2b22c` (post fork PR #19) |

## Safety features in dispatcher

Per reviewer findings (all HIGH/CRITICAL actioned):

- **Prefix validation** rejects empty, `/`, missing-leading-slash, missing-trailing-slash, and any overlap with auth-public namespaces (`/static/`, `/session/static/`, `/login`, `/api/auth/`, `/health`, `/favicon.ico`, `/sw.js`, `/manifest`) — a Fox handler at any of those would be reachable unauthenticated.
- **freeze()** locks the table after bootstrap; subsequent `register_*` calls raise. Documents the "registrations must complete before serve_forever()" contract.
- **Re-registration warning** logs WARN when overwriting an existing prefix — silent overwrite was a security-relevant default.
- **None-return guard** — handlers must return `True` (handled) or `False` (decline). `None`/dict/string raises RuntimeError to prevent silent double-response when upstream also takes the route.
- **Specific `ModuleNotFoundError(name="fox_overlay")` catch** in both patches — broken overlay surfaces as a warning + Fox routes disabled, not a silent everything-disappeared.
- **CSRF and path-traversal notes** in module docstring as load-bearing reminders for Phase 5+ handler authors.

## Dockerfile safety features

Per DevOps review:

- `rm -f .git` (the broken gitlink) instead of rename-and-restore — no half-state risk on patch failure.
- `FITB_DISABLE_WEBUI_OVERLAY=1` build-arg skips the entire patch loop — emergency rollback if a fresh upstream tag breaks anchors.
- `tr -d '\r'` on series file (CRLF tolerance).
- `while IFS= read -r p` (no word-split fragility).
- `git apply --check` stderr captured into labeled error block for readable diagnostics.

## Verification

- `pytest tests/test_dispatch.py` — 24/24 PASS
- Container build (default): patches applied, webui boots in 3s, GET / → 200, GET /setup → 200, GET /unknown → 404, dispatcher returns False for unregistered paths, table frozen after bootstrap import
- Container build (`FITB_DISABLE_WEBUI_OVERLAY=1`): patches NOT applied, vanilla server.py + routes.py, webui still boots and serves
- QA agent independent verification: 16/16 PASS, verdict SHIP

## What this PR does NOT do (deferred to later phases)

- No Fox handlers are registered yet — dispatcher table is intentionally empty in Phase 4. Phase 5 will register ollama / tailscale / local_fallback / models_download / hostname / session_recovery.
- `api/routes.py` is still Fox-modified; Phases 5/6/7 will incrementally delete Fox handlers as overlay replacements ship.
- Patch-anchor fuzz tolerance is acceptable today; Phase 9 nightly upstream-watch CI will catch anchor drift before it lands.

## Plan reference

`docs/architecture/upstream-migration-execution-plan.md` §Phase 4 (revised per Option E) and `docs/architecture/v0.6.0-github-breakdown-v2.md` §sub-issue 173.