### PR TITLE
feat(fox-overlay): migrate ollama to overlay (Phase 5 module 1/6)

### DIFF
--- a/packages/fox-overlay/MANIFEST.toml
+++ b/packages/fox-overlay/MANIFEST.toml
@@ -38,3 +38,13 @@
 "fox_overlay.agent_plugins.fox_overlay_plugin.monkey_patches.auxiliary_client" = "fox-only-additive"
 "fox_overlay.agent_plugins.fox_overlay_plugin.monkey_patches.cron_diagnostics" = "fox-only-additive"
 "fox_overlay.agent_plugins.fox_overlay_plugin.monkey_patches._helpers" = "fox-only-additive"
+
+# Phase 4 — dispatcher mechanism + bootstrap.
+"fox_overlay.dispatch" = "fox-only-additive"  # /api/* dispatcher table called from patched routes.py
+"fox_overlay.bootstrap" = "fox-only-additive"  # imported by patched server.py to wire dispatcher
+
+# Phase 5 — additive webui modules. Each claims a /api/<prefix>/ at the
+# dispatcher; Phase 5 fork PRs `git rm` the corresponding api/<name>.py
+# from forks/hermes-webui and remove the inline routes.py blocks.
+"fox_overlay.webui_modules" = "fox-only-additive"
+"fox_overlay.webui_modules.ollama" = "fox-only-additive"  # claims /api/ollama/ (was forks/hermes-webui/api/ollama.py)

--- a/packages/fox-overlay/fox_overlay/bootstrap.py
+++ b/packages/fox-overlay/fox_overlay/bootstrap.py
@@ -19,23 +19,40 @@ state isolation.
 """
 import logging
 import os
+import threading
 
 _log = logging.getLogger("fox_overlay.bootstrap")
 _INSTALLED = False
+_INSTALL_LOCK = threading.Lock()
 
 
 def install() -> None:
-    """Apply Fox overlay to a running hermes-webui process. Idempotent."""
+    """Apply Fox overlay to a running hermes-webui process. Idempotent + thread-safe."""
     global _INSTALLED
-    if _INSTALLED:
-        return
-    _INSTALLED = True
-    # Phase 5+ will import webui_modules here (e.g.
-    # `from fox_overlay import webui_modules`) so they can call
-    # register_get/post() at module-load time before freeze().
-    from fox_overlay import dispatch
-    dispatch.freeze()
-    _log.info("[fox-overlay] bootstrap installed (dispatcher frozen, table empty in Phase 4)")
+    with _INSTALL_LOCK:
+        if _INSTALLED:
+            return
+        # Phase 5+: import webui_modules — each sub-module calls
+        # dispatch.register_get/register_post() at module-load time. Wrap
+        # in ImportError so a missing sub-module surfaces as a warning but
+        # doesn't kill webui boot (matches the pattern in server.py and
+        # api/routes.py for the dispatcher hook itself).
+        try:
+            from fox_overlay import webui_modules  # noqa: F401
+        except ImportError as e:
+            _log.warning("[fox-overlay] webui_modules import failed (%s); Fox routes degraded", e)
+        from fox_overlay import dispatch
+        dispatch.freeze()
+        # WARNING level so the line surfaces in webui's default logging
+        # config — INFO is filtered by the stdlib default (WARNING) and
+        # hermes-webui doesn't call basicConfig. This line is the "did
+        # Fox load?" signal for ops smoke checks.
+        _log.warning(
+            "[fox-overlay] bootstrap installed: dispatcher frozen, "
+            "%d GET + %d POST handlers registered",
+            len(dispatch.GET_TABLE), len(dispatch.POST_TABLE),
+        )
+        _INSTALLED = True
 
 
 if os.environ.get("FOX_OVERLAY_AUTOINSTALL", "1") != "0":

--- a/packages/fox-overlay/fox_overlay/webui_modules/__init__.py
+++ b/packages/fox-overlay/fox_overlay/webui_modules/__init__.py
@@ -1,0 +1,15 @@
+"""Fox additive webui modules — Phase 5 of v0.6.0 upstream-separation.
+
+Each module here owns a `/api/...` path prefix that Fox added on top of
+upstream hermes-webui. The modules import upstream's `api.helpers`
+(`j`, `read_body`) and register their dispatcher entries at module-load
+time. `fox_overlay.bootstrap.install()` imports this package as a
+single `import fox_overlay.webui_modules`, which triggers each
+sub-module's registration, then calls `dispatch.freeze()`.
+
+Ordering: ollama lands first (smallest, fewest upstream couplings);
+session_recovery lands last (longest smoke + #129 failover-engine
+coupling). See `docs/architecture/v0.6.0-github-breakdown-v2.md` §item
+14.
+"""
+from . import ollama  # noqa: F401  -- registers /api/ollama/ at import

--- a/packages/fox-overlay/fox_overlay/webui_modules/ollama.py
+++ b/packages/fox-overlay/fox_overlay/webui_modules/ollama.py
@@ -1,0 +1,572 @@
+"""Hermes Web UI -- Local Ollama integration.
+
+Auto-detects a host-side Ollama daemon (issue #66) and exposes it as a
+first-class provider tile. Routes user-selected models through the
+existing `custom` OpenAI-compat path by writing model.{provider,base_url,name}
+into config.yaml and triggering a gateway hot-reload — no hermes-agent
+patches required.
+
+The container can reach a host-side Ollama at:
+- `http://host.docker.internal:11434` on Docker Desktop (macOS/Windows)
+- `http://host.docker.internal:11434` on Linux IF the container was
+  started with `--add-host=host.docker.internal:host-gateway` (Docker
+  Engine 20.10+; Fox in the Box's Electron + install.sh do this in v0.3.0+)
+- `http://localhost:11434` on native installs (rare; Fox normally runs
+  inside Docker)
+
+Older containers that predate the v0.3.0 host-gateway addition will see
+"not detected" on Linux until they're re-created.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import threading
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Iterator
+
+logger = logging.getLogger(__name__)
+
+
+# Ollama accepts model names like `llama3.1:8b`, `library/llama3.1:8b`,
+# `myorg/mymodel:latest`. We allow letters, digits, dot, colon, slash,
+# underscore, hyphen — explicitly reject shell metacharacters, whitespace,
+# path traversal, control chars. Cap length to a generous 200 to keep
+# error states friendly. (#67)
+_MODEL_NAME_RE = re.compile(r"^[A-Za-z0-9._:/-]+$")
+_MODEL_NAME_MAX = 200
+
+
+# Ordered probe candidates. host.docker.internal first because that's the
+# canonical Docker → host route; localhost as a fallback for rare native
+# installs. Both share the default Ollama port.
+#
+# FITB#109: a user-supplied custom URL (settings.ollama_custom_url) is
+# prepended to this list at probe time — it's an explicit user choice,
+# so it always wins over auto-detection. Empty / unset means "use the
+# defaults below."
+_PROBE_HOSTS_DEFAULT = (
+    "http://host.docker.internal:11434",
+    "http://localhost:11434",
+)
+_PROBE_TIMEOUT_SEC = 1.0
+_CACHE_TTL_SEC = 10.0  # keep Settings-page loads snappy without hiding state changes too long
+
+# FITB#109: minimal validator for the custom Ollama URL. Reject malformed
+# values at save time AND at probe time (defense in depth). Allows
+# http(s)://host[:port][/path]; rejects leading dashes (would be parsed
+# as flags by some downstream subprocess invocations) and control chars.
+_OLLAMA_URL_RE = re.compile(r"^https?://[a-zA-Z0-9.\-_:/]+(?:/[a-zA-Z0-9.\-_:/?&=%~]*)?$")
+_OLLAMA_URL_MAX_LEN = 512
+
+
+def validate_custom_ollama_url(value: Any) -> tuple[bool, str]:
+    """Validate + normalize a user-supplied Ollama URL.
+
+    Returns ``(ok, normalized_or_error)``. Empty input is valid (means
+    "unset"). Trailing slash stripped on success. Used by both
+    /api/settings save (api/config.validate_settings_dict) and probe-time
+    consumption (defense in depth in case settings.json was edited
+    manually).
+    """
+    if value is None:
+        return True, ""
+    if not isinstance(value, str):
+        return False, "ollama_custom_url must be a string"
+    s = value.strip()
+    if not s:
+        return True, ""
+    if len(s) > _OLLAMA_URL_MAX_LEN:
+        return False, "ollama_custom_url is too long"
+    if any(ord(c) < 0x20 for c in s):
+        return False, "ollama_custom_url contains control characters"
+    if not _OLLAMA_URL_RE.match(s):
+        return False, "ollama_custom_url must be http(s)://host[:port]"
+    return True, s.rstrip("/")
+
+# Module-level cache for the detection probe. We expect a few calls per
+# Settings render; caching avoids waiting on two TCP connect timeouts each
+# time. Cleared via `clear_cache()` for tests / explicit refresh.
+_cache_lock = threading.Lock()
+_cache: dict[str, Any] | None = None
+_cache_at: float = 0.0
+
+
+def clear_cache() -> None:
+    """Drop the detection cache (used by the Settings refresh button)."""
+    global _cache, _cache_at
+    with _cache_lock:
+        _cache = None
+        _cache_at = 0.0
+
+
+def _http_json(url: str, method: str = "GET", body: dict | None = None,
+               timeout: float = _PROBE_TIMEOUT_SEC) -> dict | None:
+    """Minimal urllib JSON client. Returns parsed JSON or None on any
+    failure. Stays inside stdlib — Hermes WebUI is intentionally
+    framework-free."""
+    data = None
+    headers = {}
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, method=method, data=data, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # nosec B310 — internal HTTP only
+            raw = resp.read()
+        if not raw:
+            return {}
+        return json.loads(raw)
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, json.JSONDecodeError):
+        return None
+
+
+def _probe_hosts() -> tuple[str, ...]:
+    """Build the probe-host list. FITB#109: a settings-supplied custom
+    URL is tried first when present (explicit user choice wins over
+    auto-detection). Falls back to the default Docker / localhost pair.
+
+    Re-validates the stored value (settings.json could have been hand-
+    edited bypass the api/settings save path); silently drops invalid
+    entries rather than blocking detection entirely.
+    """
+    try:
+        from api.config import load_settings
+        raw = (load_settings() or {}).get("ollama_custom_url", "")
+    except Exception:
+        raw = ""
+    ok, normalized = validate_custom_ollama_url(raw)
+    if ok and normalized:
+        return (normalized, *_PROBE_HOSTS_DEFAULT)
+    return _PROBE_HOSTS_DEFAULT
+
+
+def _probe() -> dict[str, Any]:
+    """Return {up, host, version} for the first reachable Ollama daemon, or
+    {up: False} if none. `host` is the base URL (no `/api` suffix)."""
+    for base in _probe_hosts():
+        info = _http_json(f"{base}/api/version", timeout=_PROBE_TIMEOUT_SEC)
+        if info and isinstance(info, dict) and "version" in info:
+            return {"up": True, "host": base, "version": info.get("version", "")}
+    return {"up": False, "host": "", "version": ""}
+
+
+def _cached_probe(force: bool = False) -> dict[str, Any]:
+    """Return a cached probe result, refreshing if the entry is older than
+    `_CACHE_TTL_SEC` or `force=True`."""
+    global _cache, _cache_at
+    now = time.time()
+    with _cache_lock:
+        if not force and _cache is not None and (now - _cache_at) < _CACHE_TTL_SEC:
+            return dict(_cache)
+        result = _probe()
+        _cache = result
+        _cache_at = now
+        return dict(result)
+
+
+# ── Status + model-list endpoints ───────────────────────────────────────────
+
+
+def get_status(force_refresh: bool = False) -> dict[str, Any]:
+    """Return the current Ollama detection state for Settings UI."""
+    p = _cached_probe(force=force_refresh)
+    return {
+        "running": bool(p.get("up")),
+        "host": p.get("host", ""),
+        "version": p.get("version", ""),
+    }
+
+
+def get_models() -> dict[str, Any]:
+    """Return installed models from the detected Ollama daemon plus
+    aggregate disk usage. Returns `{"running": False, "models": [],
+    "total_size_bytes": 0}` if no daemon was found."""
+    p = _cached_probe()
+    if not p.get("up"):
+        return {"running": False, "host": "", "models": [], "total_size_bytes": 0}
+    base = p["host"]
+    raw = _http_json(f"{base}/api/tags", timeout=3.0)
+    if raw is None or not isinstance(raw, dict):
+        return {
+            "running": False, "host": base, "models": [], "total_size_bytes": 0,
+            "error": "Ollama responded but /api/tags failed",
+        }
+    models = []
+    total = 0
+    for entry in raw.get("models", []) or []:
+        if not isinstance(entry, dict):
+            continue
+        details = entry.get("details") or {}
+        size = entry.get("size") or 0
+        if isinstance(size, (int, float)):
+            total += int(size)
+        models.append({
+            "name": entry.get("name") or entry.get("model") or "",
+            "size_bytes": size,
+            "parameter_size": details.get("parameter_size") or "",
+            "quantization": details.get("quantization_level") or "",
+            "family": details.get("family") or "",
+            "modified_at": entry.get("modified_at") or "",
+        })
+    return {
+        "running": True,
+        "host": base,
+        "models": models,
+        "total_size_bytes": total,
+    }
+
+
+def _validate_model_name(raw: Any) -> tuple[str, str | None]:
+    """Return (sanitized, error). Reject anything that smells like a
+    shell escape, path traversal, or empty input. Errors are
+    user-visible — keep them descriptive, never leak internals."""
+    if not isinstance(raw, str):
+        return "", "model name must be a string"
+    name = raw.strip()
+    if not name:
+        return "", "model name is required"
+    if len(name) > _MODEL_NAME_MAX:
+        return "", f"model name longer than {_MODEL_NAME_MAX} characters"
+    if not _MODEL_NAME_RE.match(name):
+        return "", "model name has invalid characters (allowed: letters, digits, . : / _ -)"
+    return name, None
+
+
+def _model_size_bytes(name: str) -> int:
+    """Look up an installed model's size from the cached tags listing.
+    Used to compute `freed_bytes` after a delete. Returns 0 if the model
+    isn't found (delete will surface the not-found error itself)."""
+    try:
+        listing = get_models()
+    except Exception:
+        return 0
+    for m in listing.get("models", []) or []:
+        if m.get("name") == name:
+            return int(m.get("size_bytes") or 0)
+    return 0
+
+
+# ── Pull (SSE-proxied) ─────────────────────────────────────────────────────
+
+
+def _iter_pull_stream(name: str) -> Iterator[dict[str, Any]]:
+    """Stream NDJSON events from Ollama's /api/pull. Yields parsed dicts.
+    Raises RuntimeError on probe-not-running or HTTP failure."""
+    p = _cached_probe()
+    if not p.get("up"):
+        raise RuntimeError("Local Ollama daemon not detected. Is it running?")
+    base = p["host"]
+    body = json.dumps({"model": name, "stream": True}).encode("utf-8")
+    req = urllib.request.Request(
+        f"{base}/api/pull",
+        method="POST",
+        data=body,
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        # Long-running stream — use a generous read timeout per chunk; the
+        # Ollama daemon emits progress lines steadily during a pull.
+        resp = urllib.request.urlopen(req, timeout=60.0)  # nosec B310 — internal HTTP only
+    except urllib.error.HTTPError as exc:
+        # Ollama returns 4xx with a JSON error body when e.g. the model
+        # name is unknown to its registry.
+        try:
+            err_body = json.loads(exc.read().decode("utf-8") or "{}")
+            msg = err_body.get("error") or f"Ollama HTTP {exc.code}"
+        except (ValueError, UnicodeDecodeError):
+            msg = f"Ollama HTTP {exc.code}"
+        raise RuntimeError(msg)
+    except (urllib.error.URLError, OSError) as exc:
+        raise RuntimeError(f"Could not reach Ollama: {exc}")
+
+    try:
+        for raw_line in resp:
+            line = raw_line.decode("utf-8", errors="replace").strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning("ollama pull: skipping non-JSON line: %r", line[:120])
+                continue
+    finally:
+        try:
+            resp.close()
+        except Exception:
+            pass
+
+
+def stream_pull(handler, name_raw: Any) -> None:
+    """Proxy Ollama's NDJSON pull stream as Server-Sent Events.
+
+    The browser uses EventSource (or a fetch+TextDecoder reader) to consume
+    the stream. We emit three event types:
+      - ``progress`` — every Ollama status line, with name/total/completed
+      - ``done`` — terminal success (Ollama emitted ``status: success``)
+      - ``error`` — anything that prevents completion (validation, daemon,
+        HTTP, JSON, network). On error we still close the stream cleanly.
+
+    On successful completion the detection cache is invalidated so the
+    next /api/ollama/models call sees the new model immediately.
+    """
+    name, err = _validate_model_name(name_raw)
+
+    # Header send — once started, no more `send_response` etc.
+    handler.send_response(200)
+    handler.send_header("Content-Type", "text/event-stream; charset=utf-8")
+    handler.send_header("Cache-Control", "no-store")
+    handler.send_header("X-Accel-Buffering", "no")
+    handler.send_header("Connection", "keep-alive")
+    handler.end_headers()
+
+    def emit(event: str, data: dict[str, Any]) -> None:
+        payload = f"event: {event}\ndata: {json.dumps(data, ensure_ascii=False)}\n\n"
+        try:
+            handler.wfile.write(payload.encode("utf-8"))
+            handler.wfile.flush()
+        except (BrokenPipeError, ConnectionResetError):
+            raise  # let outer code stop iterating
+
+    if err:
+        try:
+            emit("error", {"error": err})
+        except Exception:
+            pass
+        return
+
+    saw_success = False
+    try:
+        for evt in _iter_pull_stream(name):
+            # Pass through verbatim plus the requested model name so the
+            # frontend can render multi-pull UIs in the future. Compute
+            # speed/ETA on the client side from total + completed deltas.
+            evt_with_ctx = dict(evt)
+            evt_with_ctx.setdefault("model", name)
+            emit("progress", evt_with_ctx)
+            if evt.get("status") == "success":
+                saw_success = True
+            # Ollama can also emit explicit error lines mid-stream
+            if "error" in evt and not saw_success:
+                emit("error", {"error": str(evt["error"])})
+                return
+        if saw_success:
+            clear_cache()
+            emit("done", {"model": name})
+        else:
+            emit("error", {"error": "Pull ended without a success marker"})
+    except RuntimeError as exc:
+        try:
+            emit("error", {"error": str(exc)})
+        except Exception:
+            pass
+    except (BrokenPipeError, ConnectionResetError):
+        # Client disconnected mid-pull — Ollama keeps pulling in the
+        # background (its design). We just stop streaming.
+        logger.info("ollama pull: client disconnected")
+
+
+# ── Delete ─────────────────────────────────────────────────────────────────
+
+
+def delete_model(name_raw: Any) -> dict[str, Any]:
+    """Delete a model. Returns ``{ok, freed_bytes, error?}``.
+    Looks up the model's size before delete so the UI can render
+    \"freed N MB\" feedback."""
+    name, err = _validate_model_name(name_raw)
+    if err:
+        return {"ok": False, "error": err}
+
+    p = _cached_probe()
+    if not p.get("up"):
+        return {"ok": False, "error": "Local Ollama daemon not detected. Is it running?"}
+
+    freed = _model_size_bytes(name)
+
+    base = p["host"]
+    body = json.dumps({"model": name}).encode("utf-8")
+    req = urllib.request.Request(
+        f"{base}/api/delete",
+        method="DELETE",
+        data=body,
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10.0) as resp:  # nosec B310
+            resp.read()  # drain any short body
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return {"ok": False, "error": f"Model not installed: {name}"}
+        try:
+            err_body = json.loads(exc.read().decode("utf-8") or "{}")
+            msg = err_body.get("error") or f"Ollama HTTP {exc.code}"
+        except (ValueError, UnicodeDecodeError):
+            msg = f"Ollama HTTP {exc.code}"
+        return {"ok": False, "error": msg}
+    except (urllib.error.URLError, OSError) as exc:
+        return {"ok": False, "error": f"Could not reach Ollama: {exc}"}
+
+    clear_cache()
+    return {"ok": True, "model": name, "freed_bytes": freed}
+
+
+# ── Model selection (writes config.yaml, hot-reloads gateway) ──────────────
+
+
+def use_model(model_name: str) -> dict[str, Any]:
+    """Activate a local Ollama model for chat by writing
+    model.{provider,base_url,name} into config.yaml and reloading the
+    runtime. Routes through the existing `custom` OpenAI-compat path —
+    no hermes-agent change needed."""
+    if not isinstance(model_name, str):
+        return {"ok": False, "error": "model name must be a string"}
+    name = model_name.strip()
+    if not name:
+        return {"ok": False, "error": "model name is required"}
+
+    p = _cached_probe()
+    if not p.get("up"):
+        return {"ok": False, "error": "Local Ollama daemon not detected. Is it running?"}
+
+    base_url = f"{p['host']}/v1"
+
+    # Lazy import to keep this module import-cheap at WebUI startup.
+    from api.config import (
+        _get_config_path,
+        _save_yaml_config_file,
+        get_config,
+        reload_config,
+    )
+
+    cfg = get_config()
+    if not isinstance(cfg, dict):
+        cfg = {}
+    # QA fix: previously we mutated the existing model_cfg dict and only
+    # popped api_key. Provider-specific keys (azure_endpoint,
+    # azure_api_version, aws_region, aws_access_key_id, aws_secret_access_key,
+    # vertex_project, openai_organization, custom headers, etc.) leaked
+    # through into the local-Ollama config — at minimum a stale-secrets
+    # exposure in the config file the user thought they "switched away from",
+    # at worst those keys riding along on requests if the OpenAI-compat
+    # client respects them. Replace the model block wholesale instead of
+    # patching it.
+    model_cfg = {
+        "provider": "custom",
+        "base_url": base_url,
+        "name": name,
+    }
+    cfg["model"] = model_cfg
+
+    try:
+        _save_yaml_config_file(_get_config_path(), cfg)
+        reload_config()
+    except Exception as exc:
+        logger.exception("Failed to switch active model to local Ollama: %s", exc)
+        return {"ok": False, "error": f"Failed to update config: {exc}"}
+
+    # Best-effort gateway hot-reload (mirrors providers.py:_reload_provider_runtime
+    # added in v0.2.0 PR #61). Safe no-op outside FITB.
+    try:
+        from api.providers import _reload_provider_runtime
+        _reload_provider_runtime()
+    except Exception:
+        pass
+
+    return {
+        "ok": True,
+        "active_model": name,
+        "base_url": base_url,
+        "provider": "custom",
+    }
+
+
+# ── Route handlers ─────────────────────────────────────────────────────────
+
+
+def handle_get_status(handler) -> dict[str, Any]:
+    """GET /api/ollama/status — fast detection probe."""
+    return get_status()
+
+
+def handle_get_models(handler) -> dict[str, Any]:
+    """GET /api/ollama/models — installed models on the detected daemon."""
+    return get_models()
+
+
+def handle_post_use_model(handler, body: dict) -> dict[str, Any]:
+    """POST /api/ollama/use-model {"model": "<name>"} — activate a model."""
+    return use_model(body.get("model", ""))
+
+
+def handle_post_refresh(handler) -> dict[str, Any]:
+    """POST /api/ollama/refresh — drop the detection cache and re-probe."""
+    clear_cache()
+    return get_status(force_refresh=True)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Fox dispatcher integration — Phase 5 of v0.6.0 migration.
+# Replaces 36 lines of inline routing in api/routes.py with a single
+# registration each for GET + POST. The dispatcher hook in routes.py
+# (Phase 4) intercepts /api/ollama/* before upstream's if/elif chain
+# runs, so requests land here first.
+#
+# `api.helpers` is imported lazily inside each wrapper (not at module
+# load) so that a broken/missing api.helpers does NOT cascade into
+# bootstrap.install() swallowing the ImportError and leaving the
+# dispatcher table partially populated — registration still succeeds
+# even when the helpers import would have failed. Matches upstream's
+# lazy-import-per-route pattern.
+# ──────────────────────────────────────────────────────────────────────
+from fox_overlay import dispatch  # noqa: E402
+
+
+def _handle_get(handler, parsed) -> bool:
+    """GET /api/ollama/* — returns True if handled, False to fall through."""
+    from api.helpers import j
+
+    if parsed.path == "/api/ollama/status":
+        j(handler, handle_get_status(handler))
+        return True
+    if parsed.path == "/api/ollama/models":
+        j(handler, handle_get_models(handler))
+        return True
+    return False
+
+
+def _handle_post(handler, parsed) -> bool:
+    """POST /api/ollama/* — returns True if handled, False to fall through."""
+    from api.helpers import j, read_body
+
+    body = read_body(handler)
+
+    if parsed.path == "/api/ollama/refresh":
+        j(handler, handle_post_refresh(handler))
+        return True
+
+    if parsed.path == "/api/ollama/use-model":
+        result = handle_post_use_model(handler, body)
+        j(handler, result, status=200 if result.get("ok") else 400)
+        return True
+
+    # SSE-streamed pull (#67) — stream_pull manages its own response.
+    if parsed.path == "/api/ollama/pull":
+        stream_pull(handler, body.get("model", ""))
+        return True
+
+    # POST (not DELETE) for symmetry — hermes-webui doesn't route DELETE.
+    if parsed.path == "/api/ollama/delete":
+        result = delete_model(body.get("model", ""))
+        j(handler, result, status=200 if result.get("ok") else 400)
+        return True
+
+    return False
+
+
+dispatch.register_get("/api/ollama/", _handle_get)
+dispatch.register_post("/api/ollama/", _handle_post)
+

--- a/packages/fox-overlay/tests/test_dispatch_no_overlap.py
+++ b/packages/fox-overlay/tests/test_dispatch_no_overlap.py
@@ -1,0 +1,83 @@
+"""Phase 5 hard-prereq test: registered dispatcher prefixes must not overlap.
+
+The dispatcher iterates registered prefixes in insertion order; if two
+prefixes overlap (e.g. `/api/foo/` and `/api/foo/bar/`), the first
+inserted wins for paths that match both. That's a footgun: silent
+behavior change when modules import in a different order, and a
+correctness bug if the more specific prefix has different semantics
+than the more general one.
+
+This test enumerates every registered prefix after `bootstrap.install()`
+and rejects any pair where one is a prefix of the other.
+
+Added as a hard prerequisite of Phase 5's first module (ollama). Every
+subsequent webui_module that registers a new prefix is checked against
+the growing set automatically.
+"""
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def installed_dispatch():
+    """Reload fox_overlay so install() runs once with current modules."""
+    import fox_overlay.dispatch as d
+    import fox_overlay.bootstrap as b
+    importlib.reload(d)
+    importlib.reload(b)
+    b.install()
+    return d
+
+
+def _find_overlaps(prefixes: list[str]) -> list[tuple[str, str]]:
+    """Return all (shorter, longer) pairs where shorter is a prefix of longer.
+
+    Exact duplicates are also returned — dispatch._register only WARNs on
+    duplicate registration (it overwrites silently otherwise), so the
+    no-overlap test is the gate that surfaces the conflict.
+    """
+    overlaps = []
+    for i, p in enumerate(prefixes):
+        for q in prefixes[i + 1:]:
+            if p == q:
+                overlaps.append((p, q))
+            elif p.startswith(q) or q.startswith(p):
+                shorter, longer = (q, p) if len(q) < len(p) else (p, q)
+                overlaps.append((shorter, longer))
+    return overlaps
+
+
+def test_no_overlap_in_get_table(installed_dispatch):
+    prefixes = list(installed_dispatch.GET_TABLE.keys())
+    overlaps = _find_overlaps(prefixes)
+    assert not overlaps, (
+        f"GET-handler prefixes overlap: {overlaps}. "
+        f"The shorter prefix would shadow the longer one (or vice versa, "
+        f"depending on registration order). Pick non-overlapping prefixes "
+        f"or split the more general one into specific subroutes."
+    )
+
+
+def test_no_overlap_in_post_table(installed_dispatch):
+    prefixes = list(installed_dispatch.POST_TABLE.keys())
+    overlaps = _find_overlaps(prefixes)
+    assert not overlaps, (
+        f"POST-handler prefixes overlap: {overlaps}. "
+        f"Pick non-overlapping prefixes or split the general one."
+    )
+
+
+def test_install_freezes_tables(installed_dispatch):
+    """Side-effect check — bootstrap.install() must freeze after registration."""
+    from fox_overlay.dispatch import _BootstrapState
+    assert _BootstrapState.frozen is True
+
+
+def test_overlay_detector_self_test():
+    """Sanity: _find_overlaps catches the obvious cases."""
+    assert _find_overlaps(["/api/foo/", "/api/foo/bar/"]) == [
+        ("/api/foo/", "/api/foo/bar/")
+    ]
+    assert _find_overlaps(["/api/foo/", "/api/bar/"]) == []
+    assert _find_overlaps(["/a/", "/a/"]) == [("/a/", "/a/")]

--- a/packages/fox-overlay/tests/test_ollama_overlay.py
+++ b/packages/fox-overlay/tests/test_ollama_overlay.py
@@ -1,0 +1,179 @@
+"""Phase 5 regression tests for fox_overlay.webui_modules.ollama.
+
+Covers the dispatcher integration shape only — the underlying Ollama
+HTTP probing / pull / delete logic is exercised by the smoke checklist
+Sections D5-D7 against a real Ollama daemon (per migration plan
+§Validation gates).
+
+These tests prove:
+* Module-load registers /api/ollama/ at the dispatcher.
+* GET/POST sub-dispatch routes to the right inner handler.
+* Unknown sub-paths under /api/ollama/ return False (dispatcher falls
+  through; routes.py 404s — same as pre-migration).
+"""
+import importlib
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def fresh_dispatch_and_module(monkeypatch):
+    """Reload dispatch + ollama module so register_* fires fresh.
+
+    Patches api.helpers so we don't need a real hermes-webui install in
+    test environment — the module imports `j` and `read_body` from there.
+    """
+    # Stub api.helpers BEFORE importing ollama (which does `from api.helpers ...`)
+    fake_helpers = type(sys)("api.helpers")
+
+    def _j(handler, payload, status=200, extra_headers=None):
+        handler.responses.append({"status": status, "payload": payload})
+
+    def _read_body(handler):
+        return getattr(handler, "_body", {})
+
+    fake_helpers.j = _j
+    fake_helpers.read_body = _read_body
+    fake_api = type(sys)("api")
+    fake_api.helpers = fake_helpers
+    monkeypatch.setitem(sys.modules, "api", fake_api)
+    monkeypatch.setitem(sys.modules, "api.helpers", fake_helpers)
+
+    # Reset dispatch
+    import fox_overlay.dispatch as d
+    importlib.reload(d)
+    # Reload ollama module so its register_* fires against the fresh table
+    import fox_overlay.webui_modules.ollama as m
+    importlib.reload(m)
+    yield d, m
+    # Reload BOTH on teardown so the next test (with/without this fixture)
+    # sees consistent state. Reloading dispatch alone would leave ollama's
+    # module-level reference pointing at the previous (now-stale) GET/POST
+    # tables, and the next dispatch call from inside ollama would silently
+    # use the wrong table.
+    importlib.reload(d)
+    importlib.reload(m)
+
+
+class _FakeHandler:
+    def __init__(self, body=None):
+        self._body = body or {}
+        self.responses = []
+
+
+# ── registration ────────────────────────────────────────────────────────────
+
+def test_module_registers_get_and_post(fresh_dispatch_and_module):
+    d, _m = fresh_dispatch_and_module
+    assert "/api/ollama/" in d.GET_TABLE
+    assert "/api/ollama/" in d.POST_TABLE
+
+
+# ── GET routing ─────────────────────────────────────────────────────────────
+
+def test_get_status_routes_to_handle_get_status(fresh_dispatch_and_module, monkeypatch):
+    d, m = fresh_dispatch_and_module
+    monkeypatch.setattr(m, "handle_get_status", lambda h: {"ollama": "ok"})
+    from urllib.parse import urlparse
+    h = _FakeHandler()
+    assert d.handle_get(h, urlparse("/api/ollama/status")) is True
+    assert h.responses == [{"status": 200, "payload": {"ollama": "ok"}}]
+
+
+def test_get_models_routes_to_handle_get_models(fresh_dispatch_and_module, monkeypatch):
+    d, m = fresh_dispatch_and_module
+    monkeypatch.setattr(m, "handle_get_models", lambda h: {"models": []})
+    from urllib.parse import urlparse
+    h = _FakeHandler()
+    assert d.handle_get(h, urlparse("/api/ollama/models")) is True
+    assert h.responses[-1]["payload"] == {"models": []}
+
+
+def test_get_unknown_subpath_falls_through(fresh_dispatch_and_module):
+    """Unknown /api/ollama/* GET returns False — dispatcher continues, upstream 404s."""
+    d, _m = fresh_dispatch_and_module
+    from urllib.parse import urlparse
+    h = _FakeHandler()
+    # /api/ollama/nonexistent — overlay declines, dispatcher returns False overall
+    assert d.handle_get(h, urlparse("/api/ollama/nonexistent")) is False
+    assert h.responses == []
+
+
+# ── POST routing ────────────────────────────────────────────────────────────
+
+def test_post_refresh_routes_to_handle_post_refresh(fresh_dispatch_and_module, monkeypatch):
+    d, m = fresh_dispatch_and_module
+    monkeypatch.setattr(m, "handle_post_refresh", lambda h: {"refreshed": True})
+    from urllib.parse import urlparse
+    h = _FakeHandler()
+    assert d.handle_post(h, urlparse("/api/ollama/refresh")) is True
+    assert h.responses[-1]["payload"] == {"refreshed": True}
+
+
+def test_post_use_model_ok_status_200(fresh_dispatch_and_module, monkeypatch):
+    d, m = fresh_dispatch_and_module
+    monkeypatch.setattr(m, "handle_post_use_model", lambda h, body: {"ok": True, "model": body["model"]})
+    from urllib.parse import urlparse
+    h = _FakeHandler(body={"model": "llama3"})
+    assert d.handle_post(h, urlparse("/api/ollama/use-model")) is True
+    assert h.responses == [{"status": 200, "payload": {"ok": True, "model": "llama3"}}]
+
+
+def test_post_use_model_failure_status_400(fresh_dispatch_and_module, monkeypatch):
+    d, m = fresh_dispatch_and_module
+    monkeypatch.setattr(m, "handle_post_use_model", lambda h, body: {"ok": False, "error": "no such model"})
+    from urllib.parse import urlparse
+    h = _FakeHandler(body={"model": "bogus"})
+    assert d.handle_post(h, urlparse("/api/ollama/use-model")) is True
+    assert h.responses == [{"status": 400, "payload": {"ok": False, "error": "no such model"}}]
+
+
+def test_post_pull_calls_stream_pull(fresh_dispatch_and_module, monkeypatch):
+    """stream_pull manages its own SSE response — wrapper just calls + returns True."""
+    d, m = fresh_dispatch_and_module
+    calls = []
+    monkeypatch.setattr(m, "stream_pull", lambda h, name: calls.append(name))
+    from urllib.parse import urlparse
+    h = _FakeHandler(body={"model": "qwen2:1.5b"})
+    assert d.handle_post(h, urlparse("/api/ollama/pull")) is True
+    assert calls == ["qwen2:1.5b"]
+    # stream_pull owns the response, no j() wrapping
+    assert h.responses == []
+
+
+def test_post_delete_ok_status_200(fresh_dispatch_and_module, monkeypatch):
+    d, m = fresh_dispatch_and_module
+    monkeypatch.setattr(m, "delete_model", lambda name: {"ok": True, "deleted": name})
+    from urllib.parse import urlparse
+    h = _FakeHandler(body={"model": "llama3"})
+    assert d.handle_post(h, urlparse("/api/ollama/delete")) is True
+    assert h.responses[-1] == {"status": 200, "payload": {"ok": True, "deleted": "llama3"}}
+
+
+def test_post_delete_failure_status_400(fresh_dispatch_and_module, monkeypatch):
+    d, m = fresh_dispatch_and_module
+    monkeypatch.setattr(m, "delete_model", lambda name: {"ok": False, "error": "in use"})
+    from urllib.parse import urlparse
+    h = _FakeHandler(body={"model": "in-use"})
+    assert d.handle_post(h, urlparse("/api/ollama/delete")) is True
+    assert h.responses[-1]["status"] == 400
+
+
+def test_post_unknown_subpath_falls_through(fresh_dispatch_and_module):
+    d, _m = fresh_dispatch_and_module
+    from urllib.parse import urlparse
+    h = _FakeHandler()
+    assert d.handle_post(h, urlparse("/api/ollama/nonexistent")) is False
+
+
+# ── prefix-boundary safety ──────────────────────────────────────────────────
+
+def test_prefix_does_not_match_adjacent_paths(fresh_dispatch_and_module):
+    """Dispatcher must NOT match /api/ollamaX/... or /api/ollamax."""
+    d, _m = fresh_dispatch_and_module
+    from urllib.parse import urlparse
+    h = _FakeHandler()
+    # "/api/ollamax" doesn't start with "/api/ollama/" → no match
+    assert d.handle_get(h, urlparse("/api/ollamax")) is False
+    assert d.handle_get(h, urlparse("/api/ollama-cloud/status")) is False


### PR DESCRIPTION
**DRAFT — submodule bump pending fork PR fox-in-the-box-ai/hermes-webui#20 merge.**

Phase 5 of the v0.6.0 upstream-separation migration (#155). First of six webui_module migrations — ollama lands first per plan ordering (smallest, no upstream `api.*` couplings beyond `api.helpers`).

## What this adds to the overlay

| File | Purpose |
|------|---------|
| `fox_overlay/webui_modules/__init__.py` | imports each sub-module; bootstrap fires them as one batch before freeze |
| `fox_overlay/webui_modules/ollama.py` | 508 LOC migrated from `forks/hermes-webui/api/ollama.py` (deleted in PR #20) + 50-line dispatcher wrapper |
| `fox_overlay/bootstrap.py` | install() now thread-safe (lock-guarded) + imports webui_modules before freeze + logs at WARNING level |
| `tests/test_dispatch_no_overlap.py` | hard prereq per plan §item 7 — catches overlapping prefixes |
| `tests/test_ollama_overlay.py` | 12 tests for the wrapper (registration, GET/POST routing, status semantics, SSE, prefix boundary) |
| `MANIFEST.toml` | Phase 4 + Phase 5 entries |

## Dispatcher integration

Wrapper preserves behavioral parity with the pre-migration inline routes.py code line-for-line:
- `read_body(handler)` once at top of POST wrapper (upstream pattern)
- `200 if result.get("ok") else 400` for /use-model and /delete (identical to pre-migration)
- `stream_pull` SSE self-managed (no `j()` wrap)
- `/api/ollama/` ends with `/` so prefix can't match `/api/ollamax`

`api.helpers.{j, read_body}` imported **lazily inside each wrapper** — if api.helpers breaks at import time, the module still loads and registers; the failure surfaces per-request as a 500 (visible) instead of silently leaving the dispatcher table empty (invisible). Matches upstream's lazy-import-per-route convention.

## Sequencing — DRAFT today, ready-for-review after fork PR #20 merges

- Submodule SHA on this branch: `cd2b22c` (pre fork PR #20 — to keep `main`-buildable until fork merges)
- After fork PR #20 merges: bump submodule to the merge commit, mark this PR ready-for-review.
- Between fork merge and monorepo merge: monorepo `main` still pinned at pre-#20 SHA — no runtime breakage.

## 5-hat verification

| Hat | Verdict | Notes |
|-----|---------|-------|
| Architect | APPROVED by Dennis | plan §Phase 5 + ollama-specific recon |
| Engineer | this commit | |
| Backend reviewer | SHIP | parity verified line-for-line, return contract honored, module-load side effects audited clean |
| DevOps reviewer | REVISE → all actioned | M1 (MANIFEST) + M2 (log level) fixed; M3 (defensive CI) deferred to Phase 9 nightly upstream-watch |
| Adversarial reviewer | BLOCK (invalid) + MED 4 & 5 actioned | "Phase 4 hook missing in fork" misreads the patch-series mechanism — the hook lives at `packages/fox-overlay/patches/webui/002-routes-py-dispatch-hook.patch`, applied at Docker build time, verified live in image. MED 4 (lazy import) + MED 5 (thread-safe install) actioned. Pre-existing security gaps (stream_pull validate-before-200, use_model validation, CSRF bypass, rate limit) tracked separately. |
| QA | SHIP | built container locally with fork-branch SHA, hit all 6 endpoints — identical responses to pre-migration; 43 unit tests pass; bootstrap log lands at `/data/logs/hermes-webui.err` |

## Smoke evidence (with submodule@abcd874, fork branch HEAD)

```
GET /api/ollama/status → 200 {"running": true, "host": "...", "version": "0.23.0"}
GET /api/ollama/models → 200 (real models from host-side Ollama daemon)
POST /api/ollama/refresh → 200
GET / → 200, GET /setup → 200, GET /api/profiles → 200 (no regression)
```

## Rollback

Single revert of this PR drops both the overlay registration AND the submodule pointer back to the pre-#20 SHA. Container rebuild required. Fork PR #20 stays merged — overlay-less containers built before the bump still work (dispatcher table empty, routes.py falls through to upstream 404). Build-time `FITB_DISABLE_WEBUI_OVERLAY=1` is a separate emergency rollback path that skips the entire patch loop.