### PR TITLE
feat(fox-overlay): migrate models_download + dispatcher allow_bare opt-in (Phase 5 module 4/6)

### DIFF
--- a/packages/fox-overlay/MANIFEST.toml
+++ b/packages/fox-overlay/MANIFEST.toml
@@ -50,3 +50,4 @@
 "fox_overlay.webui_modules.ollama" = "fox-only-additive"  # claims /api/ollama/ (was forks/hermes-webui/api/ollama.py)
 "fox_overlay.webui_modules.tailscale" = "fox-only-additive"  # claims /api/tailscale/ (was forks/hermes-webui/api/tailscale.py)
 "fox_overlay.webui_modules.local_fallback" = "fox-only-additive"  # claims /api/local-fallback/ (was forks/hermes-webui/api/local_fallback.py)
+"fox_overlay.webui_modules.models_download" = "fox-only-additive"  # claims /api/local-models (bare + sub-paths) (was forks/hermes-webui/api/models_download.py)

--- a/packages/fox-overlay/fox_overlay/dispatch.py
+++ b/packages/fox-overlay/fox_overlay/dispatch.py
@@ -111,16 +111,19 @@ class _BootstrapState:
     frozen: bool = False
 
 
-def _validate_prefix(path_prefix: str) -> None:
+def _validate_prefix(path_prefix: str, allow_bare: bool = False) -> None:
     if not isinstance(path_prefix, str):
         raise TypeError(f"path_prefix must be str, got {type(path_prefix).__name__}")
     if not path_prefix.startswith("/"):
         raise ValueError(f"path_prefix must start with '/': {path_prefix!r}")
-    if not path_prefix.endswith("/"):
+    if not allow_bare and not path_prefix.endswith("/"):
         raise ValueError(
             f"path_prefix must end with '/' so startswith() can't match "
             f"adjacent paths (e.g. '/api/fox' matches '/api/fox-evil'): "
-            f"{path_prefix!r}"
+            f"{path_prefix!r}. If you need to dispatch both the bare path "
+            f"and sub-paths (e.g. /api/foo for list, /api/foo/<id> for item), "
+            f"pass allow_bare=True and do your own boundary check inside the "
+            f"handler."
         )
     if path_prefix == "/":
         raise ValueError("path_prefix '/' would shadow every upstream route")
@@ -134,13 +137,14 @@ def _validate_prefix(path_prefix: str) -> None:
             )
 
 
-def _register(table: dict[str, HandlerFn], path_prefix: str, handler: HandlerFn) -> None:
+def _register(table: dict[str, HandlerFn], path_prefix: str, handler: HandlerFn,
+              allow_bare: bool = False) -> None:
     if _BootstrapState.frozen:
         raise RuntimeError(
             f"dispatcher table frozen; register {path_prefix!r} during "
             f"fox_overlay.bootstrap, not after serve_forever()"
         )
-    _validate_prefix(path_prefix)
+    _validate_prefix(path_prefix, allow_bare=allow_bare)
     if path_prefix in table:
         logger.warning(
             "fox_overlay.dispatch: overwriting handler for %r "
@@ -158,14 +162,25 @@ def _register(table: dict[str, HandlerFn], path_prefix: str, handler: HandlerFn)
     table[path_prefix] = handler
 
 
-def register_get(path_prefix: str, handler: HandlerFn) -> None:
-    """Register a GET handler for the given path prefix."""
-    _register(_GET_TABLE, path_prefix, handler)
+def register_get(path_prefix: str, handler: HandlerFn, *, allow_bare: bool = False) -> None:
+    """Register a GET handler for the given path prefix.
+
+    ``allow_bare=True`` lets the prefix omit the trailing ``/``, which is
+    required for modules that need to handle BOTH a bare path (e.g.
+    ``/api/local-models`` for a list endpoint) AND sub-paths (e.g.
+    ``/api/local-models/<id>/progress``). In that mode, the handler MUST
+    do its own boundary check (reject paths like ``/api/local-modelsX``)
+    because ``startswith()`` cannot enforce the segment boundary alone.
+    """
+    _register(_GET_TABLE, path_prefix, handler, allow_bare=allow_bare)
 
 
-def register_post(path_prefix: str, handler: HandlerFn) -> None:
-    """Register a POST handler for the given path prefix."""
-    _register(_POST_TABLE, path_prefix, handler)
+def register_post(path_prefix: str, handler: HandlerFn, *, allow_bare: bool = False) -> None:
+    """Register a POST handler for the given path prefix.
+
+    See ``register_get`` for the ``allow_bare`` semantics.
+    """
+    _register(_POST_TABLE, path_prefix, handler, allow_bare=allow_bare)
 
 
 def freeze() -> None:

--- a/packages/fox-overlay/fox_overlay/webui_modules/__init__.py
+++ b/packages/fox-overlay/fox_overlay/webui_modules/__init__.py
@@ -15,3 +15,4 @@ coupling). See `docs/architecture/v0.6.0-github-breakdown-v2.md` §item
 from . import ollama  # noqa: F401  -- registers /api/ollama/ at import
 from . import tailscale  # noqa: F401  -- registers /api/tailscale/ at import
 from . import local_fallback  # noqa: F401  -- registers /api/local-fallback/ at import
+from . import models_download  # noqa: F401  -- registers /api/local-models (bare) at import

--- a/packages/fox-overlay/fox_overlay/webui_modules/models_download.py
+++ b/packages/fox-overlay/fox_overlay/webui_modules/models_download.py
@@ -1,0 +1,696 @@
+"""Hermes Web UI -- Local AI model download manager (issue #10).
+
+Server-side, resumable, sha256-verified download manager for GGUF model
+files. Phi-4-mini Q4_K_M is the first user (the v0.4.1 llama.cpp local
+fallback consumes it); the manager itself is generic — additional
+known models can be added to ``KNOWN_MODELS`` without code changes
+beyond the registry entry.
+
+Design highlights:
+- Server-side fetch (not client). A 2.5 GB download survives the user
+  closing the browser tab — we can't have that block on a JS fetch.
+- SSE progress to whichever browser tab is currently subscribed. New
+  subscribers join the live job and receive the current state plus all
+  subsequent updates.
+- Resume across container restart. Partial file lives on the ``/data``
+  volume; ``<file>.partial.meta`` records the upstream ETag so a
+  silently-rotated upstream forces a clean restart instead of a
+  corrupt resume.
+- sha256 is computed incrementally as bytes stream in, then compared to
+  the pinned hash before atomic-renaming to the final filename. The
+  final file is never visible at the canonical path until verification
+  passes.
+
+The download manager is a singleton; one job per model_id at a time.
+``POST /api/models/<id>/download`` is idempotent — a call against a
+running job returns the live state instead of starting a second.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import queue
+import threading
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ── Model registry ──────────────────────────────────────────────────────────
+
+# Known models. The URL + SHA256 are env-overridable so we can flip to a
+# mirror (Cloudflare R2, GitHub Release asset, etc.) without a code release
+# if HuggingFace ever has an outage. Defaults are the canonical bartowski
+# repo identified during #10 Phase 1 research.
+KNOWN_MODELS: dict[str, dict[str, Any]] = {
+    "phi4-mini": {
+        "id": "phi4-mini",
+        "name": "Phi-4 Mini Instruct (Q4_K_M)",
+        "filename": "microsoft_Phi-4-mini-instruct-Q4_K_M.gguf",
+        "url": os.environ.get(
+            "MODEL_URL_PHI4MINI",
+            "https://huggingface.co/bartowski/microsoft_Phi-4-mini-instruct-GGUF"
+            "/resolve/main/microsoft_Phi-4-mini-instruct-Q4_K_M.gguf",
+        ),
+        "sha256": os.environ.get(
+            "MODEL_SHA256_PHI4MINI",
+            "01999f17c39cc3074afae5e9c539bc82d45f2dd7faa3917c66cbef76fce8c0c2",
+        ),
+        # File size in bytes — drives the progress bar denominator before
+        # the upstream Content-Length is observed (also used to flag
+        # silently-rotated upstreams during resume verification).
+        "size_bytes": int(os.environ.get("MODEL_SIZE_PHI4MINI", "2491874688")),
+        "description": "3.8B parameters, runs on CPU. ~3 GB RAM at runtime, ~6–10 tok/s on a 4-core machine.",
+    },
+}
+
+
+# ── Filesystem layout ──────────────────────────────────────────────────────
+
+_MODELS_DIR = Path(os.environ.get("MODELS_DIR", "/data/models"))
+
+
+def _model_paths(model: dict[str, Any]) -> tuple[Path, Path, Path]:
+    """Return (final, partial, meta) paths for a model registry entry."""
+    final = _MODELS_DIR / model["filename"]
+    partial = _MODELS_DIR / f"{model['filename']}.partial"
+    meta = _MODELS_DIR / f"{model['filename']}.partial.meta"
+    return final, partial, meta
+
+
+# ── Job state ───────────────────────────────────────────────────────────────
+
+
+@dataclass
+class JobState:
+    """Snapshot of a download's progress. Mutated by the worker thread,
+    broadcast to SSE subscribers, included in REST responses verbatim."""
+
+    model_id: str
+    status: str = "idle"  # idle | running | completed | failed | cancelled
+    bytes_downloaded: int = 0
+    bytes_total: int = 0
+    started_at: float = 0.0
+    updated_at: float = 0.0
+    error: str | None = None
+    sha256_verified: bool = False
+
+    # Internal — never serialized to clients.
+    _cancel_event: threading.Event = field(default_factory=threading.Event, repr=False)
+    _subscribers: list[queue.Queue] = field(default_factory=list, repr=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "model_id": self.model_id,
+            "status": self.status,
+            "bytes_downloaded": self.bytes_downloaded,
+            "bytes_total": self.bytes_total,
+            "started_at": self.started_at,
+            "updated_at": self.updated_at,
+            "error": self.error,
+            "sha256_verified": self.sha256_verified,
+        }
+
+
+# ── Manager singleton ──────────────────────────────────────────────────────
+
+_jobs: dict[str, JobState] = {}
+_jobs_lock = threading.Lock()
+
+
+def _get_or_create_job(model_id: str) -> JobState:
+    with _jobs_lock:
+        job = _jobs.get(model_id)
+        if job is None:
+            job = JobState(model_id=model_id)
+            _jobs[model_id] = job
+        return job
+
+
+def _broadcast(job: JobState) -> None:
+    """Push the current state to all SSE subscribers. Subscribers that
+    have disconnected (queue not drained, or explicit unsubscribe) are
+    silently dropped."""
+    snapshot = job.to_dict()
+    with job._lock:
+        dead = []
+        for q in job._subscribers:
+            try:
+                q.put_nowait(snapshot)
+            except queue.Full:
+                # Subscriber is slow; drop the oldest so SSE doesn't
+                # backpressure the worker. Progress is monotonic — losing
+                # an intermediate event isn't fatal.
+                try:
+                    q.get_nowait()
+                    q.put_nowait(snapshot)
+                except queue.Empty:
+                    dead.append(q)
+            except Exception:
+                dead.append(q)
+        for q in dead:
+            try:
+                job._subscribers.remove(q)
+            except ValueError:
+                pass
+
+
+def _set_state(job: JobState, **changes) -> None:
+    with job._lock:
+        for k, v in changes.items():
+            setattr(job, k, v)
+        job.updated_at = time.time()
+    _broadcast(job)
+
+
+# ── Download worker ────────────────────────────────────────────────────────
+
+
+def _is_final_present(model: dict[str, Any]) -> bool:
+    """True if the canonical file is on disk and matches the pinned sha256.
+    Final files are only created via atomic rename after verification, so
+    we trust their existence — but a corrupted disk could in theory leave a
+    stale file. We don't re-verify on every status check (would be slow);
+    callers that need cryptographic certainty can call _verify_existing."""
+    final, _, _ = _model_paths(model)
+    return final.exists() and final.stat().st_size == model["size_bytes"]
+
+
+def _read_meta(meta_path: Path) -> dict[str, Any] | None:
+    """Read .partial.meta JSON; return None if missing or unparseable."""
+    try:
+        if not meta_path.exists():
+            return None
+        return json.loads(meta_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _write_meta(meta_path: Path, payload: dict[str, Any]) -> None:
+    meta_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = meta_path.with_suffix(meta_path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    os.replace(tmp, meta_path)
+
+
+def _probe_url(url: str, timeout: float = 10.0) -> tuple[str | None, int | None]:
+    """HEAD the URL via GET-with-Range:0-0 (HF allows this, plain HEAD on
+    LFS objects sometimes isn't followed through the 302). Returns
+    (etag, content_length_total). content_length_total is the FULL size,
+    not the partial chunk — derived from `Content-Range: bytes 0-0/<total>`
+    when the server honours the range request."""
+    req = urllib.request.Request(url, headers={"Range": "bytes=0-0"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # nosec B310
+            etag = resp.headers.get("ETag") or resp.headers.get("x-linked-etag")
+            content_range = resp.headers.get("Content-Range") or ""
+            total = None
+            # Content-Range: bytes 0-0/2491874688
+            if "/" in content_range:
+                try:
+                    total = int(content_range.rsplit("/", 1)[1])
+                except ValueError:
+                    pass
+            return etag, total
+    except (urllib.error.URLError, OSError) as exc:
+        logger.debug("Probe of %s failed: %s", url, exc)
+        return None, None
+
+
+def _download_thread(model: dict[str, Any], job: JobState) -> None:
+    """Worker. Streams the upstream bytes, verifies sha256, atomic-renames
+    on success. Designed to be safe against client disconnect, container
+    restart (resume), and cancellation."""
+    final, partial, meta = _model_paths(model)
+    expected_sha = model["sha256"]
+    expected_size = int(model["size_bytes"])
+
+    try:
+        _MODELS_DIR.mkdir(parents=True, exist_ok=True)
+
+        # ── Fast paths ─────────────────────────────────────────────────
+        # If the final file is present and the right size, declare success.
+        # We don't sha256-verify here on every call (multi-GB hash is slow);
+        # the sha256 was verified at write time, and the volume is private.
+        if _is_final_present(model):
+            _set_state(
+                job,
+                status="completed",
+                bytes_downloaded=expected_size,
+                bytes_total=expected_size,
+                sha256_verified=True,
+            )
+            return
+
+        # ── Probe upstream ────────────────────────────────────────────
+        etag_now, total_from_probe = _probe_url(model["url"])
+        bytes_total = total_from_probe or expected_size
+
+        # ── Resume decision ───────────────────────────────────────────
+        # Resume iff: partial exists, meta exists, meta.etag matches the
+        # current upstream etag, and partial size < expected. Any other
+        # state → restart from zero.
+        existing_meta = _read_meta(meta)
+        partial_size = partial.stat().st_size if partial.exists() else 0
+        resume_offset = 0
+        sha = hashlib.sha256()
+
+        can_resume = (
+            existing_meta is not None
+            and existing_meta.get("etag") == etag_now
+            and etag_now is not None
+            and 0 < partial_size < bytes_total
+        )
+
+        if can_resume:
+            # Hash everything we have so the final sha matches the full
+            # stream. Reading 2 GB off SSD is ~1–2 s; cheap insurance.
+            with open(partial, "rb") as f:
+                while True:
+                    chunk = f.read(1 << 20)  # 1 MB
+                    if not chunk:
+                        break
+                    sha.update(chunk)
+            resume_offset = partial_size
+            logger.info(
+                "Resuming download of %s from %d/%d bytes",
+                model["id"], resume_offset, bytes_total,
+            )
+        else:
+            # Fresh start — clear any stale partial.
+            if partial.exists():
+                partial.unlink()
+            if meta.exists():
+                meta.unlink()
+
+        # ── Persist meta sidecar ──────────────────────────────────────
+        _write_meta(meta, {
+            "url": model["url"],
+            "etag": etag_now,
+            "expected_sha256": expected_sha,
+            "total_bytes": bytes_total,
+            "started_at": time.time(),
+        })
+
+        _set_state(
+            job,
+            status="running",
+            bytes_downloaded=resume_offset,
+            bytes_total=bytes_total,
+            error=None,
+            sha256_verified=False,
+            started_at=time.time() if not job.started_at else job.started_at,
+        )
+
+        # ── Open the stream ───────────────────────────────────────────
+        headers: dict[str, str] = {}
+        if resume_offset > 0:
+            headers["Range"] = f"bytes={resume_offset}-"
+            if etag_now:
+                # If upstream rotated mid-resume, server returns 200 (full
+                # restart) instead of 206. The except-HTTPError path below
+                # falls back to clean-restart logic.
+                headers["If-Range"] = etag_now
+
+        req = urllib.request.Request(model["url"], headers=headers)
+        try:
+            resp = urllib.request.urlopen(req, timeout=60.0)  # nosec B310
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(f"Upstream HTTP {exc.code}") from exc
+        except (urllib.error.URLError, OSError) as exc:
+            raise RuntimeError(f"Could not reach {model['url']}: {exc}") from exc
+
+        # If we asked for a range but the server returned 200, the upstream
+        # file changed (or doesn't honour ranges). Treat as fresh start.
+        full_restart = resume_offset > 0 and resp.status == 200
+        if full_restart:
+            logger.warning(
+                "Upstream returned 200 to a Range request for %s — restarting",
+                model["id"],
+            )
+            sha = hashlib.sha256()
+            resume_offset = 0
+            if partial.exists():
+                partial.unlink()
+            _set_state(job, bytes_downloaded=0, bytes_total=bytes_total)
+
+        # ── Stream to disk ────────────────────────────────────────────
+        mode = "ab" if resume_offset > 0 else "wb"
+        last_broadcast = time.time()
+        bytes_written = resume_offset
+        chunk_size = 1 << 20  # 1 MB
+        with open(partial, mode) as out:
+            while True:
+                if job._cancel_event.is_set():
+                    _set_state(job, status="cancelled", error="Cancelled by user")
+                    return
+                chunk = resp.read(chunk_size)
+                if not chunk:
+                    break
+                out.write(chunk)
+                sha.update(chunk)
+                bytes_written += len(chunk)
+                # Throttle SSE to 4 Hz max — avoids browser overload on
+                # fast connections where we'd otherwise emit 100s of
+                # events per second.
+                now = time.time()
+                if now - last_broadcast >= 0.25:
+                    _set_state(job, bytes_downloaded=bytes_written)
+                    last_broadcast = now
+        try:
+            resp.close()
+        except Exception:
+            pass
+
+        # ── Verify sha256 ─────────────────────────────────────────────
+        actual_sha = sha.hexdigest()
+        if actual_sha != expected_sha:
+            # Discard the corrupted partial — next download attempts a
+            # fresh full pull. The user-visible error is intentionally
+            # specific so a mirror swap can be diagnosed.
+            partial.unlink(missing_ok=True)
+            meta.unlink(missing_ok=True)
+            _set_state(
+                job,
+                status="failed",
+                error=(f"sha256 mismatch — expected {expected_sha}, "
+                       f"got {actual_sha}. The file you downloaded does not "
+                       f"match the pinned hash; the upstream may have been "
+                       f"rotated. Retry to attempt a clean re-download."),
+            )
+            return
+
+        # ── Atomic rename → final ─────────────────────────────────────
+        os.replace(partial, final)
+        meta.unlink(missing_ok=True)
+
+        _set_state(
+            job,
+            status="completed",
+            bytes_downloaded=expected_size,
+            bytes_total=expected_size,
+            sha256_verified=True,
+            error=None,
+        )
+    except RuntimeError as exc:
+        _set_state(job, status="failed", error=str(exc))
+    except Exception as exc:
+        logger.exception("Unhandled error in download worker for %s", model.get("id"))
+        _set_state(job, status="failed", error=f"Unexpected error: {exc}")
+
+
+def start_download(model_id: str) -> dict[str, Any]:
+    """Idempotent entry point. If a download is running, returns the live
+    state. If completed, returns completion. Otherwise spawns a worker."""
+    model = KNOWN_MODELS.get(model_id)
+    if model is None:
+        return {"ok": False, "error": f"unknown model id: {model_id}"}
+
+    job = _get_or_create_job(model_id)
+    with job._lock:
+        if job.status == "running":
+            return {"ok": True, "state": job.to_dict(), "note": "already running"}
+
+    if _is_final_present(model):
+        _set_state(
+            job,
+            status="completed",
+            bytes_downloaded=int(model["size_bytes"]),
+            bytes_total=int(model["size_bytes"]),
+            sha256_verified=True,
+            error=None,
+        )
+        return {"ok": True, "state": job.to_dict(), "note": "already installed"}
+
+    job._cancel_event.clear()
+    _set_state(job, status="running", error=None, started_at=time.time())
+    thread = threading.Thread(
+        target=_download_thread, args=(model, job),
+        name=f"model-download-{model_id}", daemon=True,
+    )
+    thread.start()
+    return {"ok": True, "state": job.to_dict()}
+
+
+def cancel_download(model_id: str) -> dict[str, Any]:
+    job = _jobs.get(model_id)
+    if job is None or job.status != "running":
+        return {"ok": False, "error": "no active download for that model"}
+    job._cancel_event.set()
+    return {"ok": True, "state": job.to_dict()}
+
+
+def delete_model(model_id: str) -> dict[str, Any]:
+    """Delete an installed model. Refuses while a download is in progress
+    for the same model — cancel first."""
+    model = KNOWN_MODELS.get(model_id)
+    if model is None:
+        return {"ok": False, "error": f"unknown model id: {model_id}"}
+
+    job = _jobs.get(model_id)
+    if job is not None and job.status == "running":
+        return {"ok": False, "error": "download in progress; cancel before deleting"}
+
+    final, partial, meta = _model_paths(model)
+    freed = 0
+    for path in (final, partial, meta):
+        if path.exists():
+            try:
+                freed += path.stat().st_size
+                path.unlink()
+            except OSError as exc:
+                logger.warning("Could not delete %s: %s", path, exc)
+
+    if job is not None:
+        _set_state(
+            job, status="idle",
+            bytes_downloaded=0, bytes_total=0,
+            sha256_verified=False, error=None,
+        )
+
+    return {"ok": True, "model_id": model_id, "freed_bytes": freed}
+
+
+def list_models() -> dict[str, Any]:
+    """Return registry + on-disk status for every known model."""
+    out = []
+    total_disk = 0
+    for model_id, model in KNOWN_MODELS.items():
+        final, partial, _meta = _model_paths(model)
+        installed = _is_final_present(model)
+        size_on_disk = 0
+        if installed:
+            size_on_disk = final.stat().st_size
+        elif partial.exists():
+            size_on_disk = partial.stat().st_size
+        total_disk += size_on_disk
+        job = _jobs.get(model_id)
+        out.append({
+            "id": model_id,
+            "name": model["name"],
+            "filename": model["filename"],
+            "description": model.get("description", ""),
+            "expected_size_bytes": int(model["size_bytes"]),
+            "size_on_disk_bytes": size_on_disk,
+            "installed": installed,
+            "state": job.to_dict() if job else None,
+        })
+    return {"models": out, "total_size_bytes": total_disk}
+
+
+# ── SSE subscribe ──────────────────────────────────────────────────────────
+
+
+def subscribe(model_id: str) -> queue.Queue | None:
+    """Register a queue for SSE updates on a model's job. Returns None if
+    the model id is unknown. Caller is responsible for unsubscribing
+    (passing the same queue back) on disconnect."""
+    if model_id not in KNOWN_MODELS:
+        return None
+    job = _get_or_create_job(model_id)
+    q: queue.Queue = queue.Queue(maxsize=64)
+    with job._lock:
+        job._subscribers.append(q)
+    # Send the current state immediately so a late-joining subscriber
+    # doesn't have to wait for the next progress tick to know where they
+    # are. Without this, a download that finished 5 ms before subscribe
+    # would never emit the completion event to the new client.
+    try:
+        q.put_nowait(job.to_dict())
+    except queue.Full:
+        pass
+    return q
+
+
+def unsubscribe(model_id: str, q: queue.Queue) -> None:
+    job = _jobs.get(model_id)
+    if job is None:
+        return
+    with job._lock:
+        try:
+            job._subscribers.remove(q)
+        except ValueError:
+            pass
+
+
+# ── Route handlers ─────────────────────────────────────────────────────────
+
+
+def handle_get_models(handler) -> dict[str, Any]:
+    """GET /api/models — registry + on-disk + active-job snapshot."""
+    return list_models()
+
+
+def handle_post_download(handler, body: dict, model_id: str) -> dict[str, Any]:
+    """POST /api/models/<id>/download — idempotent."""
+    return start_download(model_id)
+
+
+def handle_post_cancel(handler, body: dict, model_id: str) -> dict[str, Any]:
+    """POST /api/models/<id>/cancel."""
+    return cancel_download(model_id)
+
+
+def handle_post_delete(handler, body: dict, model_id: str) -> dict[str, Any]:
+    """POST /api/models/<id>/delete."""
+    return delete_model(model_id)
+
+
+def handle_progress_sse(handler, model_id: str) -> bool:
+    """GET /api/models/<id>/progress — SSE stream of state changes.
+
+    The first event is the current state (so late joiners learn where the
+    job is without waiting for the next tick). Subsequent events fire on
+    every state change. The stream ends when the job reaches a terminal
+    state (completed, failed, cancelled).
+    """
+    if model_id not in KNOWN_MODELS:
+        handler.send_response(404)
+        handler.send_header("Content-Type", "application/json")
+        handler.end_headers()
+        handler.wfile.write(b'{"error":"unknown model id"}')
+        return True
+
+    q = subscribe(model_id)
+    if q is None:
+        handler.send_response(404)
+        handler.end_headers()
+        return True
+
+    handler.send_response(200)
+    handler.send_header("Content-Type", "text/event-stream; charset=utf-8")
+    handler.send_header("Cache-Control", "no-store")
+    handler.send_header("X-Accel-Buffering", "no")
+    handler.send_header("Connection", "keep-alive")
+    handler.end_headers()
+
+    try:
+        terminal = {"completed", "failed", "cancelled"}
+        while True:
+            try:
+                snapshot = q.get(timeout=30)
+            except queue.Empty:
+                # Heartbeat — keeps the proxy/browser connection alive
+                # during slow phases (e.g. between sha256 verification and
+                # atomic rename).
+                try:
+                    handler.wfile.write(b": heartbeat\n\n")
+                    handler.wfile.flush()
+                except (BrokenPipeError, ConnectionResetError):
+                    return True
+                continue
+            payload = f"data: {json.dumps(snapshot)}\n\n"
+            try:
+                handler.wfile.write(payload.encode("utf-8"))
+                handler.wfile.flush()
+            except (BrokenPipeError, ConnectionResetError):
+                return True
+            if snapshot.get("status") in terminal:
+                return True
+    finally:
+        unsubscribe(model_id, q)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Fox dispatcher integration — Phase 5 of v0.6.0 migration.
+# First module to use the dispatcher's allow_bare=True opt-in:
+# /api/local-models owns BOTH the bare path (list endpoint) and
+# parameterized sub-paths (/<model_id>/progress for SSE,
+# /<model_id>/{download,cancel,delete} for actions). The wrapper does
+# boundary checks to reject /api/local-modelsX adjacency attacks.
+# ──────────────────────────────────────────────────────────────────────
+from fox_overlay import dispatch  # noqa: E402
+
+
+def _handle_get(handler, parsed) -> bool:
+    """GET /api/local-models[/<id>/progress] — returns True if handled, False to fall through.
+
+    Boundary contract: must reject /api/local-modelsX and any other path
+    that startswith()-matches but isn't a real endpoint, because the
+    dispatcher prefix is registered with allow_bare=True (no trailing /).
+    """
+    from api.helpers import j
+
+    # Bare list endpoint.
+    if parsed.path == "/api/local-models":
+        j(handler, handle_get_models(handler))
+        return True
+
+    # SSE progress endpoint — handle_progress_sse manages its own response.
+    if parsed.path.startswith("/api/local-models/") and parsed.path.endswith("/progress"):
+        model_id = parsed.path[len("/api/local-models/"):-len("/progress")]
+        return handle_progress_sse(handler, model_id)
+
+    # Anything else under (or adjacent to) /api/local-models — not ours.
+    return False
+
+
+def _handle_post(handler, parsed) -> bool:
+    """POST /api/local-models/<id>/{download,cancel,delete} — returns True if handled, False to fall through.
+
+    Boundary contract: must reject /api/local-models (no action),
+    /api/local-modelsX, and unknown actions.
+    """
+    from api.helpers import j, read_body
+
+    # Reject bare path AND adjacency attacks — must start with the slash form.
+    if not parsed.path.startswith("/api/local-models/"):
+        return False
+
+    body = read_body(handler)
+    suffix = parsed.path[len("/api/local-models/"):]
+    if "/" not in suffix:
+        return False  # malformed (no action)
+    model_id, action = suffix.rsplit("/", 1)
+
+    if action == "download":
+        r = handle_post_download(handler, body, model_id)
+        j(handler, r, status=200 if r.get("ok") else 400)
+        return True
+    if action == "cancel":
+        r = handle_post_cancel(handler, body, model_id)
+        j(handler, r, status=200 if r.get("ok") else 400)
+        return True
+    if action == "delete":
+        r = handle_post_delete(handler, body, model_id)
+        j(handler, r, status=200 if r.get("ok") else 400)
+        return True
+
+    return False  # unknown action
+
+
+# allow_bare=True: prefix omits trailing slash so dispatcher matches both
+# /api/local-models (bare list) and /api/local-models/<id>/... (sub-paths).
+# Boundary checks live in the handlers above.
+dispatch.register_get("/api/local-models", _handle_get, allow_bare=True)
+dispatch.register_post("/api/local-models", _handle_post, allow_bare=True)
+

--- a/packages/fox-overlay/tests/test_dispatch.py
+++ b/packages/fox-overlay/tests/test_dispatch.py
@@ -47,6 +47,55 @@ def test_register_rejects_prefix_without_trailing_slash(dispatch):
         dispatch.register_get("/api/fox", lambda h, p: True)
 
 
+def test_register_allow_bare_accepts_no_trailing_slash(dispatch):
+    """allow_bare=True lets a module register a path that handles both
+    the bare path and sub-paths (e.g. /api/local-models for list +
+    /api/local-models/<id>/progress for SSE)."""
+    dispatch.register_get("/api/local-models", lambda h, p: True, allow_bare=True)
+    assert "/api/local-models" in dispatch.GET_TABLE
+
+
+def test_register_allow_bare_post(dispatch):
+    dispatch.register_post("/api/local-models", lambda h, p: True, allow_bare=True)
+    assert "/api/local-models" in dispatch.POST_TABLE
+
+
+def test_register_allow_bare_still_rejects_other_violations(dispatch):
+    """allow_bare doesn't bypass other validations."""
+    with pytest.raises(ValueError, match="must start with '/'"):
+        dispatch.register_get("api/foo", lambda h, p: True, allow_bare=True)
+    with pytest.raises(ValueError, match="shadow every upstream route"):
+        dispatch.register_get("/", lambda h, p: True, allow_bare=True)
+    with pytest.raises(ValueError, match="auth-public namespace"):
+        dispatch.register_get("/login", lambda h, p: True, allow_bare=True)
+
+
+def test_allow_bare_prefix_matches_both_bare_and_subpath(dispatch):
+    """startswith() semantics: bare-prefix matches both '/foo' and '/foo/...'.
+    Handler is responsible for distinguishing and for rejecting '/fooX'."""
+    from urllib.parse import urlparse
+    calls = []
+    def h(handler, parsed):
+        calls.append(parsed.path)
+        # Boundary check: accept exact bare OR /api/local-models/...
+        if parsed.path == "/api/local-models":
+            return True
+        if parsed.path.startswith("/api/local-models/"):
+            return True
+        return False  # /api/local-modelsX etc.
+
+    dispatch.register_get("/api/local-models", h, allow_bare=True)
+    assert dispatch.handle_get(None, urlparse("/api/local-models")) is True
+    assert dispatch.handle_get(None, urlparse("/api/local-models/foo/progress")) is True
+    # Boundary attack: must NOT match /api/local-modelsX
+    assert dispatch.handle_get(None, urlparse("/api/local-modelsX")) is False
+    assert calls == [
+        "/api/local-models",
+        "/api/local-models/foo/progress",
+        "/api/local-modelsX",  # handler called, but returned False
+    ]
+
+
 def test_register_rejects_root_prefix(dispatch):
     with pytest.raises(ValueError, match="shadow every upstream route"):
         dispatch.register_get("/", lambda h, p: True)

--- a/packages/fox-overlay/tests/test_models_download_overlay.py
+++ b/packages/fox-overlay/tests/test_models_download_overlay.py
@@ -1,0 +1,190 @@
+"""Phase 5 regression tests for fox_overlay.webui_modules.models_download.
+
+First module to use dispatch.register_get/post with allow_bare=True.
+Tests focus on the dispatcher integration shape, the path-parameter
+extraction for sub-paths, and the explicit boundary check that allows
+the wrapper to safely register at /api/local-models (bare prefix).
+"""
+import importlib
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def fresh_dispatch_and_module(monkeypatch):
+    """Reload dispatch + models_download module so register_* fires fresh."""
+    fake_helpers = type(sys)("api.helpers")
+
+    def _j(handler, payload, status=200, extra_headers=None):
+        handler.responses.append({"status": status, "payload": payload})
+
+    def _read_body(handler):
+        return getattr(handler, "_body", {})
+
+    fake_helpers.j = _j
+    fake_helpers.read_body = _read_body
+    fake_api = type(sys)("api")
+    fake_api.helpers = fake_helpers
+    monkeypatch.setitem(sys.modules, "api", fake_api)
+    monkeypatch.setitem(sys.modules, "api.helpers", fake_helpers)
+
+    import fox_overlay.dispatch as d
+    importlib.reload(d)
+    import fox_overlay.webui_modules.models_download as m
+    importlib.reload(m)
+    yield d, m
+    importlib.reload(d)
+    importlib.reload(m)
+
+
+class _FakeHandler:
+    def __init__(self, body=None):
+        self._body = body or {}
+        self.responses = []
+
+
+# ── registration ────────────────────────────────────────────────────────────
+
+def test_module_registers_bare_prefix(fresh_dispatch_and_module):
+    """Dispatcher should accept the bare /api/local-models (no trailing slash)."""
+    d, _m = fresh_dispatch_and_module
+    assert "/api/local-models" in d.GET_TABLE
+    assert "/api/local-models" in d.POST_TABLE
+
+
+# ── GET routing ─────────────────────────────────────────────────────────────
+
+def test_get_bare_path_routes_to_list(fresh_dispatch_and_module, monkeypatch):
+    d, m = fresh_dispatch_and_module
+    monkeypatch.setattr(m, "handle_get_models", lambda h: {"models": []})
+    from urllib.parse import urlparse
+    h = _FakeHandler()
+    assert d.handle_get(h, urlparse("/api/local-models")) is True
+    assert h.responses[-1]["payload"] == {"models": []}
+
+
+def test_get_progress_sse_extracts_model_id_and_returns_handler_result(fresh_dispatch_and_module, monkeypatch):
+    d, m = fresh_dispatch_and_module
+    captured = []
+    def _sse(handler, model_id):
+        captured.append(model_id)
+        return True
+    monkeypatch.setattr(m, "handle_progress_sse", _sse)
+    from urllib.parse import urlparse
+    h = _FakeHandler()
+    assert d.handle_get(h, urlparse("/api/local-models/qwen2:1.5b/progress")) is True
+    assert captured == ["qwen2:1.5b"]
+    # SSE owns its response — wrapper does NOT call j()
+    assert h.responses == []
+
+
+def test_get_unknown_subpath_falls_through(fresh_dispatch_and_module):
+    """e.g. /api/local-models/qwen2 (no /progress, no method) — wrapper returns False."""
+    d, _m = fresh_dispatch_and_module
+    from urllib.parse import urlparse
+    h = _FakeHandler()
+    assert d.handle_get(h, urlparse("/api/local-models/qwen2")) is False
+    assert h.responses == []
+
+
+def test_get_boundary_rejects_adjacent_paths(fresh_dispatch_and_module):
+    """Critical safety check — allow_bare requires the wrapper to reject /api/local-modelsX."""
+    d, _m = fresh_dispatch_and_module
+    from urllib.parse import urlparse
+    h = _FakeHandler()
+    assert d.handle_get(h, urlparse("/api/local-modelsX")) is False
+    assert d.handle_get(h, urlparse("/api/local-modelsattack")) is False
+    assert d.handle_get(h, urlparse("/api/local-models-other")) is False
+    assert h.responses == []
+
+
+# ── POST routing ────────────────────────────────────────────────────────────
+
+def test_post_download_routes_with_model_id(fresh_dispatch_and_module, monkeypatch):
+    d, m = fresh_dispatch_and_module
+    captured = []
+    def _dl(handler, body, model_id):
+        captured.append((model_id, body))
+        return {"ok": True, "model_id": model_id}
+    monkeypatch.setattr(m, "handle_post_download", _dl)
+    from urllib.parse import urlparse
+    h = _FakeHandler(body={"force": True})
+    assert d.handle_post(h, urlparse("/api/local-models/llama3.2:1b/download")) is True
+    assert captured == [("llama3.2:1b", {"force": True})]
+    assert h.responses[-1] == {"status": 200, "payload": {"ok": True, "model_id": "llama3.2:1b"}}
+
+
+def test_post_cancel_failure_status_400(fresh_dispatch_and_module, monkeypatch):
+    d, m = fresh_dispatch_and_module
+    monkeypatch.setattr(m, "handle_post_cancel", lambda h, body, mid: {"ok": False, "error": "no in-flight"})
+    from urllib.parse import urlparse
+    h = _FakeHandler()
+    assert d.handle_post(h, urlparse("/api/local-models/llama3/cancel")) is True
+    assert h.responses[-1]["status"] == 400
+
+
+def test_post_delete_routes_with_model_id(fresh_dispatch_and_module, monkeypatch):
+    d, m = fresh_dispatch_and_module
+    monkeypatch.setattr(m, "handle_post_delete", lambda h, body, mid: {"ok": True, "deleted": mid})
+    from urllib.parse import urlparse
+    h = _FakeHandler()
+    assert d.handle_post(h, urlparse("/api/local-models/llama3/delete")) is True
+    assert h.responses[-1]["payload"] == {"ok": True, "deleted": "llama3"}
+
+
+def test_post_unknown_action_falls_through(fresh_dispatch_and_module):
+    """Action not in {download, cancel, delete} → False → upstream 404."""
+    d, _m = fresh_dispatch_and_module
+    from urllib.parse import urlparse
+    h = _FakeHandler()
+    assert d.handle_post(h, urlparse("/api/local-models/llama3/teleport")) is False
+
+
+def test_post_malformed_no_action_falls_through(fresh_dispatch_and_module):
+    """/api/local-models/llama3 (no action suffix) → False."""
+    d, _m = fresh_dispatch_and_module
+    from urllib.parse import urlparse
+    h = _FakeHandler()
+    assert d.handle_post(h, urlparse("/api/local-models/llama3")) is False
+
+
+def test_post_bare_path_falls_through(fresh_dispatch_and_module):
+    """POST /api/local-models (bare, no model_id) → False (only GET list, no POST list)."""
+    d, _m = fresh_dispatch_and_module
+    from urllib.parse import urlparse
+    h = _FakeHandler()
+    assert d.handle_post(h, urlparse("/api/local-models")) is False
+
+
+def test_post_boundary_rejects_adjacent_paths(fresh_dispatch_and_module):
+    """allow_bare requires the wrapper to reject /api/local-modelsX style adjacency."""
+    d, _m = fresh_dispatch_and_module
+    from urllib.parse import urlparse
+    h = _FakeHandler()
+    assert d.handle_post(h, urlparse("/api/local-modelsX/download")) is False
+    assert d.handle_post(h, urlparse("/api/local-modelsattack")) is False
+
+
+# ── model_id parsing edge cases ─────────────────────────────────────────────
+
+def test_post_model_id_with_slashes_in_name(fresh_dispatch_and_module, monkeypatch):
+    """rsplit('/', 1) — model_id can contain slashes (e.g. namespace/name)."""
+    d, m = fresh_dispatch_and_module
+    captured = []
+    monkeypatch.setattr(m, "handle_post_download", lambda h, body, mid: captured.append(mid) or {"ok": True})
+    from urllib.parse import urlparse
+    h = _FakeHandler()
+    assert d.handle_post(h, urlparse("/api/local-models/qwen/2.5/1.5b/download")) is True
+    assert captured == ["qwen/2.5/1.5b"]
+
+
+def test_get_progress_model_id_with_slashes(fresh_dispatch_and_module, monkeypatch):
+    """SSE model_id extraction preserves slashes too."""
+    d, m = fresh_dispatch_and_module
+    captured = []
+    monkeypatch.setattr(m, "handle_progress_sse", lambda h, mid: captured.append(mid) or True)
+    from urllib.parse import urlparse
+    h = _FakeHandler()
+    assert d.handle_get(h, urlparse("/api/local-models/qwen/2.5/1.5b/progress")) is True
+    assert captured == ["qwen/2.5/1.5b"]


### PR DESCRIPTION
Phase 5 module 4 of 6. Sibling of local_fallback (#225) per plan §item 9 — both share the Section F+G+H smoke gate; this PR closes that gate.

## Dispatcher: new `allow_bare=True` opt-in

First Phase 5 module that needs to dispatch BOTH a bare path (`/api/local-models` for list) AND parameterized sub-paths (`/api/local-models/<id>/{progress,download,cancel,delete}`). The existing dispatcher contract required a trailing slash to prevent `/api/fox` matching `/api/fox-evil` — but that prevents matching `/api/local-models` (bare).

`dispatch.register_get/post(..., allow_bare=True)` is the explicit opt-in: prefix may omit trailing slash, and the handler is contractually responsible for boundary checks. Verified by 4 new dispatch tests + 2 boundary-attack tests in the models_download suite.

## What this adds

| File | Purpose |
|------|---------|
| `fox_overlay/dispatch.py` | `allow_bare` keyword + validator update |
| `fox_overlay/webui_modules/models_download.py` | 620 LOC migrated + ~80-line wrapper with boundary checks |
| `fox_overlay/webui_modules/__init__.py` | imports models_download |
| `tests/test_dispatch.py` | 4 new tests for `allow_bare` semantics |
| `tests/test_models_download_overlay.py` | 14 wrapper tests incl. adjacency-attack rejection |
| `MANIFEST.toml` | `webui_modules.models_download` entry |

## Routes preserved

| Path | Method | Notes |
|------|--------|-------|
| `/api/local-models` | GET | list (bare path) |
| `/api/local-models/<id>/progress` | GET | SSE — handler self-manages response |
| `/api/local-models/<id>/download` | POST | start download (200/400) |
| `/api/local-models/<id>/cancel` | POST | cancel in-flight (200/400) |
| `/api/local-models/<id>/delete` | POST | delete local file (200/400) |

`model_id` may contain slashes (e.g. `qwen/2.5/1.5b`) — preserved via `rsplit('/', 1)` same as pre-migration.

## Verification

- 83 unit tests pass (65 prior + 4 new dispatch + 14 new models_download)
- Container build with submodule@0f2007d (fork PR #23 merge):
  - Bootstrap log: `4 GET + 4 POST handlers registered`
  - GET /api/local-models → 200
  - GET /api/local-modelsX (adjacency attack) → 404 (boundary check works)
  - All 3 prior modules' endpoints still return 200
- `git apply --check` passes for both Phase 4 patches against the new submodule

## Submodule

`forks/hermes-webui` → `0f2007d` (fork PR #23 merge commit).

Auto-merge after CI green per Dennis's away-time green-light.