### PR TITLE
feat(fox-overlay): migrate hostname to overlay (Phase 5 module 5/6)

### DIFF
--- a/packages/fox-overlay/MANIFEST.toml
+++ b/packages/fox-overlay/MANIFEST.toml
@@ -51,3 +51,4 @@
 "fox_overlay.webui_modules.tailscale" = "fox-only-additive"  # claims /api/tailscale/ (was forks/hermes-webui/api/tailscale.py)
 "fox_overlay.webui_modules.local_fallback" = "fox-only-additive"  # claims /api/local-fallback/ (was forks/hermes-webui/api/local_fallback.py)
 "fox_overlay.webui_modules.models_download" = "fox-only-additive"  # claims /api/local-models (bare + sub-paths) (was forks/hermes-webui/api/models_download.py)
+"fox_overlay.webui_modules.hostname" = "fox-only-additive"  # claims /api/settings/hostname (bare + /dismiss-prompt) (was forks/hermes-webui/api/hostname.py)

--- a/packages/fox-overlay/fox_overlay/webui_modules/__init__.py
+++ b/packages/fox-overlay/fox_overlay/webui_modules/__init__.py
@@ -16,3 +16,4 @@ from . import ollama  # noqa: F401  -- registers /api/ollama/ at import
 from . import tailscale  # noqa: F401  -- registers /api/tailscale/ at import
 from . import local_fallback  # noqa: F401  -- registers /api/local-fallback/ at import
 from . import models_download  # noqa: F401  -- registers /api/local-models (bare) at import
+from . import hostname  # noqa: F401  -- registers /api/settings/hostname (bare) at import

--- a/packages/fox-overlay/fox_overlay/webui_modules/hostname.py
+++ b/packages/fox-overlay/fox_overlay/webui_modules/hostname.py
@@ -1,0 +1,331 @@
+"""Hermes Web UI -- Tailscale hostname management.
+
+Persists ``FOX_HOSTNAME`` to the FITB env file and applies it live to the
+running tailscaled via ``tailscale set --hostname``. Re-reads
+``tailscale status --json`` after applying so collision suffixes
+(`-1`, `-2`, …) are surfaced to the caller.
+
+Issue #44 — Electron desktop-app first-run parity with the install.sh
+hostname work from #3.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import random
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from api.onboarding import _write_env_key
+
+logger = logging.getLogger(__name__)
+
+
+# Mirrors the curated list in packages/scripts/install.sh:_default_hostname().
+# Kept in sync intentionally — both places generate names from the same pool so
+# host-script users and Electron users produce indistinguishable defaults.
+_ADJECTIVES = (
+    "quick", "clever", "bright", "swift", "keen",
+    "amber", "nimble", "fierce", "bold", "sly",
+    "golden", "autumn",
+)
+
+# Tailscale's effective hostname rule, derived from
+# util/dnsname/dnsname.go:SanitizeLabel — RFC 1035 DNS label form.
+_HOSTNAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")
+_MAX_LEN = 63
+
+_ENV_PATH = Path(os.environ.get("HERMES_ENV_PATH", "/data/config/hermes.env"))
+_FOX_HOSTNAME_KEY = "FOX_HOSTNAME"
+
+
+def default_hostname() -> str:
+    """Generate a fox-<adjective> default. Random pick keeps tailnets
+    collision-free best-effort; Tailscale auto-suffixes on real collision."""
+    return f"fox-{random.choice(_ADJECTIVES)}"
+
+
+def sanitize_hostname(raw: str) -> str:
+    """Lowercase, replace runs of non-[a-z0-9-] with a single -, strip
+    leading/trailing -, truncate to 63 chars. Mirrors install.sh's
+    _sanitize_hostname() byte-for-byte."""
+    if not raw:
+        return ""
+    s = raw.strip().lower()
+    s = re.sub(r"[^a-z0-9-]+", "-", s)
+    s = s.strip("-")
+    return s[:_MAX_LEN]
+
+
+def validate_hostname(s: str) -> str | None:
+    """Return ``None`` if valid, else a human-readable error message.
+    Stricter than sanitize_hostname — caller should sanitize first if it
+    wants automatic correction; this rejects anything not already valid."""
+    if not s:
+        return "Hostname is required."
+    if len(s) > _MAX_LEN:
+        return f"Hostname must be {_MAX_LEN} characters or fewer."
+    if not _HOSTNAME_RE.match(s):
+        return (
+            "Hostname must contain only lowercase letters, digits, and hyphens, "
+            "and must start and end with a letter or digit."
+        )
+    return None
+
+
+def _read_configured_hostname() -> str:
+    """Read FOX_HOSTNAME from hermes.env, or empty string if unset."""
+    try:
+        if not _ENV_PATH.exists():
+            return ""
+        for raw in _ENV_PATH.read_text(encoding="utf-8").splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            if key.strip() == _FOX_HOSTNAME_KEY:
+                return value.strip().strip('"').strip("'")
+    except OSError:
+        pass
+    return ""
+
+
+def _run_tailscale(args: list[str], timeout: float = 10.0) -> tuple[int, str, str]:
+    """Run a `tailscale` subcommand. Returns (returncode, stdout, stderr).
+    Returncode 127 indicates the binary isn't on PATH (e.g. running outside
+    the FITB container during dev/tests)."""
+    try:
+        result = subprocess.run(
+            ["tailscale", *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return result.returncode, result.stdout, result.stderr
+    except FileNotFoundError:
+        return 127, "", "tailscale binary not found"
+    except subprocess.TimeoutExpired:
+        return 124, "", f"tailscale {args[0] if args else ''} timed out"
+
+
+def _read_effective_hostname() -> str | None:
+    """Read the running daemon's current effective hostname from
+    ``tailscale status --json``. Returns ``None`` if tailscaled isn't
+    reachable. The control plane appends `-1`, `-2`, … on hostname
+    collision; ``Self.HostName`` reflects the suffixed form."""
+    rc, out, _err = _run_tailscale(["status", "--json"], timeout=5.0)
+    if rc != 0 or not out:
+        return None
+    try:
+        status = json.loads(out)
+    except json.JSONDecodeError:
+        return None
+    self_node = status.get("Self") or {}
+    return self_node.get("HostName") or None
+
+
+def _read_backend_state() -> str:
+    """Return the BackendState (NoState / NeedsLogin / NeedsMachineAuth /
+    Stopped / Starting / Running) or empty string. Used to gate the
+    post-wizard hostname prompt — Self.HostName is set well before the
+    user has actually authenticated, so checking only "tailscale running"
+    fired the prompt before the user joined the tailnet (#68 QA bug)."""
+    rc, out, _err = _run_tailscale(["status", "--json"], timeout=5.0)
+    if rc != 0 or not out:
+        return ""
+    try:
+        status = json.loads(out)
+    except json.JSONDecodeError:
+        return ""
+    return status.get("BackendState") or ""
+
+
+def get_hostname_state() -> dict[str, Any]:
+    """Read everything the Settings UI needs to render the hostname field."""
+    configured = _read_configured_hostname()
+    effective = _read_effective_hostname()
+    # `prompted` is the post-wizard one-time-prompt flag (#68). The chat-UI
+    # reads it on first load to decide whether to show the hostname modal;
+    # Settings ignores it.
+    try:
+        from api.config import load_settings
+        prompted = bool(load_settings().get("hostname_prompted", False))
+    except Exception:
+        prompted = False
+    return {
+        "configured": configured,
+        "effective": effective or "",
+        "default_suggestion": default_hostname() if not configured else "",
+        "tailscale_running": effective is not None,
+        # QA fix: explicit BackendState so the post-wizard prompt
+        # (hostname-prompt.js) can fire only after the user has actually
+        # joined the tailnet — Self.HostName is populated long before
+        # BackendState reaches Running, so the previous predicate
+        # (tailscale_running && !configured && !prompted) fired the
+        # prompt during NeedsLogin state and the user dismissed it
+        # because "I haven't even auth'd yet".
+        "backend_state": _read_backend_state(),
+        "prompted": prompted,
+    }
+
+
+def mark_hostname_prompted() -> dict[str, Any]:
+    """Persist hostname_prompted=true so the post-wizard modal never re-fires.
+    Used by both the explicit "Skip" button and implicitly when the modal saves."""
+    try:
+        from api.config import save_settings
+        save_settings({"hostname_prompted": True})
+        return {"ok": True}
+    except Exception as exc:
+        logger.exception("Failed to mark hostname_prompted")
+        return {"ok": False, "error": str(exc)}
+
+
+def apply_hostname(hostname: str) -> dict[str, Any]:
+    """Persist FOX_HOSTNAME and apply it live to tailscaled.
+
+    Sanitizes and validates, then:
+      1. Writes ``FOX_HOSTNAME=<name>`` to /data/config/hermes.env so the
+         next container start (or supervisord restart) picks it up.
+      2. Calls ``tailscale set --hostname=<name>`` against the running
+         daemon. Surgical mutation — only the hostname pref is changed
+         (cf. ``tailscale up``, which would re-apply a full preferences
+         set and risk resetting unrelated flags).
+      3. Re-reads ``tailscale status --json`` so the caller sees the
+         effective name (control plane may have appended a collision
+         suffix).
+    """
+    sanitized = sanitize_hostname(hostname)
+    err = validate_hostname(sanitized)
+    if err:
+        return {"ok": False, "error": err}
+
+    try:
+        _write_env_key(_FOX_HOSTNAME_KEY, sanitized)
+    except OSError as exc:
+        logger.error("Failed to write FOX_HOSTNAME to hermes.env: %s", exc)
+        return {"ok": False, "error": "Failed to persist hostname."}
+
+    rc, _out, err_text = _run_tailscale(["set", f"--hostname={sanitized}"], timeout=10.0)
+
+    # The persist already succeeded — `FOX_HOSTNAME` is in hermes.env. The
+    # live `tailscale set` is a best-effort hot-apply: if it fails (daemon
+    # not authed yet, not running, binary missing, etc.) the value still
+    # takes effect on the next container/daemon start. Surface the reason
+    # in `note` rather than failing the whole call, so first-run users who
+    # haven't yet authed Tailscale don't see a scary error for what is
+    # actually a successful save.
+    if rc != 0:
+        if rc == 127:
+            note = ("Saved. Tailscale binary not on PATH from this process; "
+                    "the new name will apply on the next container start.")
+        else:
+            note = ("Saved. Live apply skipped — Tailscale daemon may not be "
+                    "running or authenticated yet. The new name will apply "
+                    "on the next start.")
+        if err_text.strip():
+            logger.info("tailscale set --hostname rc=%d stderr=%s", rc, err_text.strip())
+        return {
+            "ok": True,
+            "requested_hostname": sanitized,
+            "effective_hostname": "",
+            "applied_live": False,
+            "note": note,
+        }
+
+    effective = _read_effective_hostname() or sanitized
+    return {
+        "ok": True,
+        "requested_hostname": sanitized,
+        "effective_hostname": effective,
+        "applied_live": True,
+        "collision_suffixed": effective != sanitized,
+    }
+
+
+# ── Route handlers ──────────────────────────────────────────────────────────
+
+
+def handle_get_hostname(handler) -> dict[str, Any]:
+    """GET /api/settings/hostname — returns current state for the UI."""
+    return get_hostname_state()
+
+
+def handle_set_hostname(handler, body: dict) -> dict[str, Any]:
+    """POST /api/settings/hostname — body {"hostname": "<name>"}."""
+    raw = body.get("hostname", "")
+    if not isinstance(raw, str):
+        return {"ok": False, "error": "hostname must be a string"}
+    result = apply_hostname(raw)
+    # Setting a hostname (whether from the wizard modal or Settings) implicitly
+    # answers the post-wizard prompt — never re-fire it. Best-effort; failure
+    # to set the flag must not fail the hostname save itself.
+    if result.get("ok"):
+        try:
+            mark_hostname_prompted()
+        except Exception:
+            logger.exception("Failed to set hostname_prompted after save")
+    return result
+
+
+def handle_dismiss_hostname_prompt(handler, body: dict) -> dict[str, Any]:
+    """POST /api/settings/hostname/dismiss-prompt — Skip button on the
+    post-wizard modal. Marks prompted=true without setting any hostname,
+    so Tailscale auto-naming continues to apply."""
+    return mark_hostname_prompted()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Fox dispatcher integration — Phase 5 of v0.6.0 migration.
+# Uses allow_bare=True because the module owns BOTH the bare
+# /api/settings/hostname (GET + POST) and the /dismiss-prompt sub-path
+# (POST). Wrapper does its own boundary check.
+#
+# Pre-existing coupling: `from api.onboarding import _write_env_key`
+# at module top stays intact. Phase 7 (wholesale-replace onboarding
+# via overlay) will need to keep _write_env_key reachable or update
+# this import.
+# ──────────────────────────────────────────────────────────────────────
+from fox_overlay import dispatch  # noqa: E402
+
+
+def _handle_get(handler, parsed) -> bool:
+    """GET /api/settings/hostname — returns True if handled, False to fall through."""
+    from api.helpers import j
+
+    if parsed.path == "/api/settings/hostname":
+        j(handler, handle_get_hostname(handler))
+        return True
+    return False
+
+
+def _handle_post(handler, parsed) -> bool:
+    """POST /api/settings/hostname[/dismiss-prompt] — returns True if handled, False to fall through."""
+    from api.helpers import j, read_body
+
+    if parsed.path == "/api/settings/hostname":
+        body = read_body(handler)
+        result = handle_set_hostname(handler, body)
+        j(handler, result, status=200 if result.get("ok") else 400)
+        return True
+
+    if parsed.path == "/api/settings/hostname/dismiss-prompt":
+        body = read_body(handler)
+        result = handle_dismiss_hostname_prompt(handler, body)
+        j(handler, result, status=200 if result.get("ok") else 400)
+        return True
+
+    # /api/settings/hostnameX adjacency, or unknown sub-path → not ours.
+    return False
+
+
+# allow_bare=True: prefix omits trailing slash so dispatcher matches both
+# /api/settings/hostname (bare) and /api/settings/hostname/dismiss-prompt.
+# Boundary check above rejects /api/settings/hostnameX etc.
+dispatch.register_get("/api/settings/hostname", _handle_get, allow_bare=True)
+dispatch.register_post("/api/settings/hostname", _handle_post, allow_bare=True)
+

--- a/packages/fox-overlay/tests/test_hostname_overlay.py
+++ b/packages/fox-overlay/tests/test_hostname_overlay.py
@@ -1,0 +1,127 @@
+"""Phase 5 regression tests for fox_overlay.webui_modules.hostname.
+
+Uses dispatch.register_*(allow_bare=True). Tests verify both the bare
+endpoint (/api/settings/hostname GET + POST) and the sub-path
+(/api/settings/hostname/dismiss-prompt POST), plus boundary checks.
+"""
+import importlib
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def fresh_dispatch_and_module(monkeypatch):
+    """Reload dispatch + hostname module so register_* fires fresh.
+
+    hostname.py imports from api.helpers AND api.onboarding (the latter
+    is Fox's setup-wizard module). Stub both.
+    """
+    fake_helpers = type(sys)("api.helpers")
+    def _j(handler, payload, status=200, extra_headers=None):
+        handler.responses.append({"status": status, "payload": payload})
+    def _read_body(handler):
+        return getattr(handler, "_body", {})
+    fake_helpers.j = _j
+    fake_helpers.read_body = _read_body
+
+    fake_onboarding = type(sys)("api.onboarding")
+    fake_onboarding._write_env_key = lambda *a, **kw: None
+
+    fake_api = type(sys)("api")
+    fake_api.helpers = fake_helpers
+    fake_api.onboarding = fake_onboarding
+
+    monkeypatch.setitem(sys.modules, "api", fake_api)
+    monkeypatch.setitem(sys.modules, "api.helpers", fake_helpers)
+    monkeypatch.setitem(sys.modules, "api.onboarding", fake_onboarding)
+
+    import fox_overlay.dispatch as d
+    importlib.reload(d)
+    import fox_overlay.webui_modules.hostname as m
+    importlib.reload(m)
+    yield d, m
+    importlib.reload(d)
+    importlib.reload(m)
+
+
+class _FakeHandler:
+    def __init__(self, body=None):
+        self._body = body or {}
+        self.responses = []
+
+
+# ── registration ────────────────────────────────────────────────────────────
+
+def test_module_registers_bare_prefix(fresh_dispatch_and_module):
+    """Bare prefix /api/settings/hostname (allow_bare=True)."""
+    d, _m = fresh_dispatch_and_module
+    assert "/api/settings/hostname" in d.GET_TABLE
+    assert "/api/settings/hostname" in d.POST_TABLE
+
+
+# ── GET routing ─────────────────────────────────────────────────────────────
+
+def test_get_bare_path_routes_to_get_hostname(fresh_dispatch_and_module, monkeypatch):
+    d, m = fresh_dispatch_and_module
+    monkeypatch.setattr(m, "handle_get_hostname", lambda h: {"hostname": "fox-host"})
+    from urllib.parse import urlparse
+    h = _FakeHandler()
+    assert d.handle_get(h, urlparse("/api/settings/hostname")) is True
+    assert h.responses[-1]["payload"] == {"hostname": "fox-host"}
+
+
+def test_get_unknown_subpath_falls_through(fresh_dispatch_and_module):
+    """GET on dismiss-prompt (POST-only) → False."""
+    d, _m = fresh_dispatch_and_module
+    from urllib.parse import urlparse
+    h = _FakeHandler()
+    assert d.handle_get(h, urlparse("/api/settings/hostname/dismiss-prompt")) is False
+    assert d.handle_get(h, urlparse("/api/settings/hostname/anything")) is False
+
+
+# ── POST routing ────────────────────────────────────────────────────────────
+
+def test_post_set_hostname_ok(fresh_dispatch_and_module, monkeypatch):
+    d, m = fresh_dispatch_and_module
+    monkeypatch.setattr(m, "handle_set_hostname", lambda h, body: {"ok": True, "hostname": body["hostname"]})
+    from urllib.parse import urlparse
+    h = _FakeHandler(body={"hostname": "fox-prod"})
+    assert d.handle_post(h, urlparse("/api/settings/hostname")) is True
+    assert h.responses[-1] == {"status": 200, "payload": {"ok": True, "hostname": "fox-prod"}}
+
+
+def test_post_set_hostname_failure_status_400(fresh_dispatch_and_module, monkeypatch):
+    d, m = fresh_dispatch_and_module
+    monkeypatch.setattr(m, "handle_set_hostname", lambda h, body: {"ok": False, "error": "invalid"})
+    from urllib.parse import urlparse
+    h = _FakeHandler(body={"hostname": "INVALID..."})
+    assert d.handle_post(h, urlparse("/api/settings/hostname")) is True
+    assert h.responses[-1]["status"] == 400
+
+
+def test_post_dismiss_prompt_ok(fresh_dispatch_and_module, monkeypatch):
+    d, m = fresh_dispatch_and_module
+    monkeypatch.setattr(m, "handle_dismiss_hostname_prompt", lambda h, body: {"ok": True, "prompted": True})
+    from urllib.parse import urlparse
+    h = _FakeHandler(body={})
+    assert d.handle_post(h, urlparse("/api/settings/hostname/dismiss-prompt")) is True
+    assert h.responses[-1]["status"] == 200
+
+
+def test_post_unknown_subpath_falls_through(fresh_dispatch_and_module):
+    d, _m = fresh_dispatch_and_module
+    from urllib.parse import urlparse
+    h = _FakeHandler()
+    assert d.handle_post(h, urlparse("/api/settings/hostname/wrong-thing")) is False
+
+
+# ── prefix-boundary safety (allow_bare requires explicit boundary check) ───
+
+def test_boundary_rejects_adjacent_paths(fresh_dispatch_and_module):
+    d, _m = fresh_dispatch_and_module
+    from urllib.parse import urlparse
+    h = _FakeHandler()
+    assert d.handle_get(h, urlparse("/api/settings/hostnameX")) is False
+    assert d.handle_get(h, urlparse("/api/settings/hostnameattack")) is False
+    assert d.handle_post(h, urlparse("/api/settings/hostname-other")) is False


### PR DESCRIPTION
Phase 5 module 5 of 6 — hostname is the smallest at 279 LOC.

## What this adds

| File | Purpose |
|------|---------|
| `fox_overlay/webui_modules/hostname.py` | 279 LOC migrated + ~55-line wrapper |
| `fox_overlay/webui_modules/__init__.py` | imports hostname |
| `tests/test_hostname_overlay.py` | 9 wrapper tests |
| `MANIFEST.toml` | `webui_modules.hostname` entry |

## Routes preserved

| Path | Method | Status |
|------|--------|--------|
| `/api/settings/hostname` | GET | 200 |
| `/api/settings/hostname` | POST | 200/400 |
| `/api/settings/hostname/dismiss-prompt` | POST | 200/400 |

Uses `dispatch.register_*(allow_bare=True)` — same pattern as models_download — to dispatch both the bare path AND the `/dismiss-prompt` sub-path.

## Pre-existing api.onboarding coupling

`hostname.py` imports `_write_env_key` from `api.onboarding` (Fox's wholesale-replaced setup wizard). Coupling preserved in overlay; runtime import still resolves to Fox's `api.onboarding`. Phase 7 will need to keep `_write_env_key` reachable or update this import — noted in comments.

## Verification

- 91 unit tests pass (83 prior + 9 new hostname)
- Container build with submodule@b72ddd1 (fork PR #24 merge):
  - Bootstrap log: `5 GET + 5 POST handlers registered`
  - GET /api/settings/hostname → 200
  - GET /api/settings/hostnameX (adjacency attack) → 404
  - All 4 prior modules' endpoints still return 200

## Submodule

`forks/hermes-webui` → `b72ddd1` (fork PR #24 merge commit). Auto-merge after CI green.