### PR TITLE
feat(fox-overlay): webui_patches framework + providers patch (Phase 6 module 1/5)

### DIFF
--- a/packages/fox-overlay/MANIFEST.toml
+++ b/packages/fox-overlay/MANIFEST.toml
@@ -52,3 +52,11 @@
 "fox_overlay.webui_modules.local_fallback" = "fox-only-additive"  # claims /api/local-fallback/ (was forks/hermes-webui/api/local_fallback.py)
 "fox_overlay.webui_modules.models_download" = "fox-only-additive"  # claims /api/local-models (bare + sub-paths) (was forks/hermes-webui/api/models_download.py)
 "fox_overlay.webui_modules.hostname" = "fox-only-additive"  # claims /api/settings/hostname (bare + /dismiss-prompt) (was forks/hermes-webui/api/hostname.py)
+
+# Phase 6 — webui mid-file monkey-patches. Fork files are restored to
+# virgin upstream content; these modules re-apply Fox behavior at runtime
+# via inspect.getsource + anchored textual substitution. Anchor drift
+# fails fast at boot — Phase 9 nightly upstream-watch catches it earlier.
+"fox_overlay.webui_patches" = "fox-only-additive"  # apply_all() called from bootstrap
+"fox_overlay.webui_patches._helpers" = "fox-only-additive"  # substitute_function (webui-side; mirror of agent_plugins helper)
+"fox_overlay.webui_patches.providers" = "fox-only-additive"  # patches api.providers.set_provider_key — adds gateway hot-reload

--- a/packages/fox-overlay/fox_overlay/bootstrap.py
+++ b/packages/fox-overlay/fox_overlay/bootstrap.py
@@ -32,15 +32,29 @@ def install() -> None:
     with _INSTALL_LOCK:
         if _INSTALLED:
             return
-        # Phase 5+: import webui_modules — each sub-module calls
+        # Phase 5: import webui_modules — each sub-module calls
         # dispatch.register_get/register_post() at module-load time. Wrap
         # in ImportError so a missing sub-module surfaces as a warning but
-        # doesn't kill webui boot (matches the pattern in server.py and
-        # api/routes.py for the dispatcher hook itself).
+        # doesn't kill webui boot.
         try:
             from fox_overlay import webui_modules  # noqa: F401
         except ImportError as e:
             _log.warning("[fox-overlay] webui_modules import failed (%s); Fox routes degraded", e)
+
+        # Phase 6: apply monkey-patches to upstream mid-file edits.
+        # Each patch is idempotent (sentinel attribute guard inside
+        # substitute_function). Wrap in Exception so a single patch
+        # failure (e.g. anchor drift) degrades that one patch but
+        # doesn't kill webui boot — the AssertionError detail still
+        # lands in webui stderr for ops to find.
+        try:
+            from fox_overlay import webui_patches
+            webui_patches.apply_all()
+        except ImportError as e:
+            _log.warning("[fox-overlay] webui_patches import failed (%s); Fox mid-file edits degraded", e)
+        except Exception as e:  # AssertionError on anchor drift, etc.
+            _log.warning("[fox-overlay] webui_patches.apply_all() failed (%s); some Fox mid-file edits degraded", e)
+
         from fox_overlay import dispatch
         dispatch.freeze()
         # WARNING level so the line surfaces in webui's default logging

--- a/packages/fox-overlay/fox_overlay/webui_patches/__init__.py
+++ b/packages/fox-overlay/fox_overlay/webui_patches/__init__.py
@@ -1,0 +1,38 @@
+"""Fox webui monkey-patches — Phase 6 of v0.6.0 upstream-separation.
+
+Each module here patches mid-file Fox edits into upstream hermes-webui
+files (api/streaming.py, api/models.py, api/config.py, api/providers.py,
+api/updates.py). Fork-side, those files are restored to virgin upstream
+content (Phase 6 per-module fork PRs); the Fox behavior is reinstated
+at runtime via these patches.
+
+Each patch module exports an ``apply()`` function that is idempotent —
+re-running it is a no-op once the per-target sentinel is set. The
+``apply_all()`` function below invokes each module's ``apply()`` in
+order; ``fox_overlay.bootstrap.install()`` calls ``apply_all()`` after
+``webui_modules`` are imported (so dispatcher entries register first).
+
+Substitution mechanics live in ``_helpers.substitute_function`` —
+``inspect.getsource`` + textual anchor substitution. Anchors MUST be
+unique within the target function; mismatched anchors fail at boot
+with a precise diagnostic so Phase 9 nightly upstream-watch CI catches
+upstream drift.
+"""
+import logging
+
+_log = logging.getLogger("fox_overlay.webui_patches")
+
+
+def apply_all() -> None:
+    """Apply every Fox webui monkey-patch. Called once from bootstrap.install()."""
+    from . import providers
+    providers.apply()
+    # Phase 6 adds more modules here:
+    # from . import streaming; streaming.apply()
+    # from . import models; models.apply()
+    # from . import config; config.apply()
+    # from . import updates; updates.apply()
+    _log.warning(
+        "[fox-overlay] webui_patches.apply_all() complete (%d patch modules)",
+        1,  # update as modules are added
+    )

--- a/packages/fox-overlay/fox_overlay/webui_patches/_helpers.py
+++ b/packages/fox-overlay/fox_overlay/webui_patches/_helpers.py
@@ -1,0 +1,99 @@
+"""Anchor-based source substitution helper for webui-side monkey-patches.
+
+Phase-6 sibling of the agent-side `fox_overlay.agent_plugins.fox_overlay_plugin.monkey_patches._helpers`.
+Logic is identical — kept duplicated to preserve clean package boundaries
+between agent_plugins (entry-point loaded by hermes-agent) and
+webui_patches (called from `fox_overlay.bootstrap`). A future cleanup
+PR could extract to a shared `fox_overlay._substitute` module if the
+duplication starts to drift.
+
+Pattern: each monkey-patch module defines its target upstream function
+and a list of ``(old, new)`` substitutions where ``old`` is an EXACT
+fragment of the upstream function source. ``substitute_function`` reads
+the upstream source via :func:`inspect.getsource`, applies the
+substitutions sequentially, and recompiles the result in the upstream
+module's namespace so it can be assigned back as the new function.
+
+If any ``old`` anchor is missing or appears more than once, an
+``AssertionError`` is raised at import time — the container fails to
+boot with a precise error pointing at the upstream drift. Phase 9's
+nightly upstream-watch CI catches this before users do.
+
+Idempotency: each patch sets a per-target sentinel attribute; re-running
+``apply()`` (test setup, reload, etc.) is a no-op once the sentinel is
+present.
+"""
+import inspect
+import logging
+from types import ModuleType
+from typing import Any, Dict, Optional, Sequence, Tuple
+
+_log = logging.getLogger("fox_overlay.webui_patches")
+
+
+def substitute_function(
+    upstream_module: ModuleType,
+    function_name: str,
+    substitutions: Sequence[Tuple[str, str]],
+    sentinel: str,
+    extra_globals: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Replace ``upstream_module.<function_name>`` with a patched version.
+
+    Each ``(old, new)`` substitution is applied to the upstream source
+    in sequence. Each ``old`` MUST appear exactly once or this raises
+    ``AssertionError``.
+
+    ``extra_globals`` injects additional names into the patched
+    function's ``__globals__`` so the patched body can reference modules
+    or symbols not imported in the upstream module (e.g., a helper
+    function the Fox patch wants to call but upstream doesn't define).
+    These names are scoped to the patched function only — they do not
+    pollute the upstream module's namespace.
+
+    Note: we deliberately do NOT call ``textwrap.dedent`` on the source —
+    ``dedent`` normalizes whitespace-only blank lines to a bare ``\\n``,
+    breaking anchors that match against the verbatim file content. For
+    top-level functions there is no common leading indent to remove
+    anyway. If a future caller needs to patch a class method (where the
+    body is indented under the class def), it must either dedent its
+    anchors itself or wrap this helper.
+    """
+    upstream_fn = getattr(upstream_module, function_name)
+    if getattr(upstream_fn, sentinel, False):
+        return
+
+    src = inspect.getsource(upstream_fn)
+
+    for idx, (old, new) in enumerate(substitutions):
+        count = src.count(old)
+        if count != 1:
+            raise AssertionError(
+                "[fox-overlay] monkey-patch %s.%s substitution #%d: "
+                "anchor expected EXACTLY ONCE, found %dx. Upstream may have "
+                "refactored this function — refresh the anchor in the "
+                "fox-overlay webui_patches module. Anchor:\n%s"
+                % (upstream_module.__name__, function_name, idx + 1, count, old)
+            )
+        src = src.replace(old, new)
+
+    namespace = dict(upstream_module.__dict__)
+    if extra_globals:
+        namespace.update(extra_globals)
+    code = compile(
+        src,
+        "<fox-overlay %s.%s>" % (upstream_module.__name__, function_name),
+        "exec",
+    )
+    exec(code, namespace)  # noqa: S102 — namespace is the upstream module's globals
+
+    patched_fn = namespace[function_name]
+    setattr(patched_fn, sentinel, True)
+    setattr(upstream_module, function_name, patched_fn)
+
+    _log.info(
+        "[fox-overlay] patched %s.%s (%d substitutions)",
+        upstream_module.__name__,
+        function_name,
+        len(substitutions),
+    )

--- a/packages/fox-overlay/fox_overlay/webui_patches/providers.py
+++ b/packages/fox-overlay/fox_overlay/webui_patches/providers.py
@@ -1,0 +1,87 @@
+"""Fox webui patch: gateway hot-reload after set_provider_key.
+
+Restores the two Fox edits to ``api/providers.py`` that were reverted
+to upstream merge-base in fork PR fox-in-the-box-ai/hermes-webui#25
+(Phase 6 fork-side revert).
+
+## What Fox needs
+
+When the user updates an API key via Settings → Providers, the gateway
+process must pick up the new key. Several runtime_provider paths read
+keys via ``os.getenv`` directly (OpenRouter, OpenAI), so
+``invalidate_models_cache()`` alone — which only refreshes the model
+dropdown — isn't enough; the gateway's process env must be refreshed.
+
+Fox's approach: shell out to ``supervisorctl restart hermes-gateway``
+after each key change. Best-effort — silently a no-op when
+``supervisorctl`` is unavailable (upstream Hermes / dev environments
+without supervisord).
+
+## How the patch works
+
+* Adds one line to ``set_provider_key`` — a call to
+  ``_reload_provider_runtime()`` immediately after the existing
+  ``invalidate_models_cache()`` call.
+* Injects ``_reload_provider_runtime`` into the patched function's
+  globals via ``extra_globals``. The helper is defined in THIS module
+  so the upstream namespace stays virgin.
+
+The original Fox patch added the helper as a module-level function in
+``api/providers.py`` (so other code could call it). No other code DOES
+call it — verified by grepping the fork. Defining it in the patch
+namespace is therefore behaviorally equivalent and keeps the upstream
+namespace untouched.
+"""
+import logging
+import shutil
+import subprocess
+
+from ._helpers import substitute_function
+
+_log = logging.getLogger("fox_overlay.webui_patches.providers")
+_SENTINEL = "_fox_patched_set_provider_key"
+
+
+def _reload_provider_runtime() -> None:
+    """Best-effort restart of the gateway so new env keys take effect.
+
+    Skipped silently outside FITB-style supervisor deployments.
+    """
+    if not shutil.which("supervisorctl"):
+        return
+    try:
+        subprocess.run(
+            ["supervisorctl", "-c", "/etc/supervisor/supervisord.conf",
+             "restart", "hermes-gateway"],
+            capture_output=True, timeout=10, check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        _log.warning("Gateway hot-reload failed: %s", exc)
+
+
+def apply() -> None:
+    """Patch api.providers.set_provider_key to call _reload_provider_runtime."""
+    from api import providers as _u
+
+    substitute_function(
+        upstream_module=_u,
+        function_name="set_provider_key",
+        substitutions=[
+            (
+                # Anchor: the existing invalidate_models_cache() call.
+                # Unique within set_provider_key per upstream merge-base 9e31a2a.
+                "    invalidate_models_cache()\n\n    return {",
+                # Insert the hot-reload call between cache invalidation and the
+                # return. Keeps Fox's pre-Phase-6 behavior identical — the
+                # original Fox edit added the same call in the same position.
+                "    invalidate_models_cache()\n\n"
+                "    # Fox: hot-reload the gateway so the new key takes effect\n"
+                "    # without a manual container restart. See\n"
+                "    # fox_overlay.webui_patches.providers for rationale.\n"
+                "    _reload_provider_runtime()\n\n"
+                "    return {",
+            ),
+        ],
+        sentinel=_SENTINEL,
+        extra_globals={"_reload_provider_runtime": _reload_provider_runtime},
+    )

--- a/packages/fox-overlay/tests/test_providers_patch.py
+++ b/packages/fox-overlay/tests/test_providers_patch.py
@@ -1,0 +1,201 @@
+"""Phase 6 regression tests for fox_overlay.webui_patches.providers.
+
+Verifies the substitute_function-based monkey-patch correctly inserts
+the gateway-hot-reload call into ``set_provider_key`` while leaving
+the rest of the upstream behavior intact.
+
+The patch uses ``inspect.getsource`` which needs a real file backing
+the function — so the test fixture writes a stub file to ``tmp_path``
+and imports it as ``api.providers``.
+"""
+import importlib
+import importlib.util
+import sys
+import types
+
+import pytest
+
+
+# Stub source matching upstream merge-base api/providers.py around the
+# anchor we patch (verified against 9e31a2a). Keeping the anchor area
+# verbatim catches anchor drift at the test level too.
+_UPSTREAM_PROVIDERS_SOURCE = '''\
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def invalidate_models_cache():
+    """Stub for tests."""
+    invalidate_models_cache.calls += 1
+invalidate_models_cache.calls = 0
+
+
+_PROVIDER_DISPLAY = {"openai": "OpenAI"}
+
+
+def set_provider_key(provider_id: str, api_key: str | None) -> dict[str, Any]:
+    """Persist an API key for a provider."""
+    if provider_id == "fail-write":
+        logger.exception("Failed to write env file for provider %s", provider_id)
+        return {"ok": False, "error": "Failed to save API key: simulated"}
+
+    # Invalidate the model cache so the dropdown refreshes on next request.
+    # Using invalidate_models_cache() instead of reload_config() to avoid
+    # disrupting active streaming sessions that may be reading config.cfg.
+    invalidate_models_cache()
+
+    return {
+        "ok": True,
+        "provider": provider_id,
+        "display_name": _PROVIDER_DISPLAY.get(provider_id, provider_id),
+        "action": "updated" if api_key else "removed",
+    }
+'''
+
+
+def _install_stub(tmp_path, source: str, monkeypatch):
+    """Write `source` to tmp_path/api/providers.py and import it as `api.providers`.
+
+    Using a real file (not exec) is required because the patch uses
+    inspect.getsource which needs a file backing.
+    """
+    api_dir = tmp_path / "api"
+    api_dir.mkdir(exist_ok=True)
+    (api_dir / "__init__.py").write_text("")
+    providers_path = api_dir / "providers.py"
+    providers_path.write_text(source)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    # Ensure clean re-import — drop any cached api/* modules
+    for name in list(sys.modules):
+        if name == "api" or name.startswith("api."):
+            del sys.modules[name]
+    import api.providers as fake_providers  # noqa: F401  (registers in sys.modules)
+    return sys.modules["api.providers"]
+
+
+@pytest.fixture
+def fake_providers_module(tmp_path, monkeypatch):
+    """Install upstream stub + reload patch module so apply() targets the stub."""
+    fake_providers = _install_stub(tmp_path, _UPSTREAM_PROVIDERS_SOURCE, monkeypatch)
+
+    import fox_overlay.webui_patches.providers as patch_mod
+    importlib.reload(patch_mod)
+
+    yield fake_providers, patch_mod
+
+    importlib.reload(patch_mod)
+    # Drop cached api/* so the next test gets a clean slate
+    for name in list(sys.modules):
+        if name == "api" or name.startswith("api."):
+            del sys.modules[name]
+
+
+# ── basic apply() smoke ────────────────────────────────────────────────────
+
+def test_apply_is_idempotent(fake_providers_module):
+    """apply() can be called multiple times safely (sentinel guard)."""
+    fake_providers, patch_mod = fake_providers_module
+    patch_mod.apply()
+    patch_mod.apply()
+    assert getattr(fake_providers.set_provider_key, "_fox_patched_set_provider_key", False) is True
+
+
+def test_apply_does_not_corrupt_unrelated_functions(fake_providers_module):
+    """invalidate_models_cache survives the patch unmodified."""
+    fake_providers, patch_mod = fake_providers_module
+    pre_count = fake_providers.invalidate_models_cache.calls
+    patch_mod.apply()
+    # invalidate_models_cache should still be callable + behave normally
+    fake_providers.invalidate_models_cache()
+    assert fake_providers.invalidate_models_cache.calls == pre_count + 1
+
+
+# ── patched behavior ───────────────────────────────────────────────────────
+
+def test_patched_set_provider_key_calls_reload_runtime(fake_providers_module, monkeypatch):
+    """After patch, set_provider_key calls _reload_provider_runtime exactly once."""
+    fake_providers, patch_mod = fake_providers_module
+    calls = []
+    monkeypatch.setattr(patch_mod, "_reload_provider_runtime", lambda: calls.append("called"))
+    patch_mod.apply()
+    # Pre-patch invocation count baseline
+    fake_providers.invalidate_models_cache.calls = 0
+    result = fake_providers.set_provider_key("openai", "sk-test")
+    assert result == {
+        "ok": True,
+        "provider": "openai",
+        "display_name": "OpenAI",
+        "action": "updated",
+    }
+    assert calls == ["called"]
+    # invalidate_models_cache should still fire BEFORE the reload
+    assert fake_providers.invalidate_models_cache.calls == 1
+
+
+def test_patched_failure_path_does_not_call_reload(fake_providers_module, monkeypatch):
+    """The early-return failure path skips the reload."""
+    fake_providers, patch_mod = fake_providers_module
+    calls = []
+    monkeypatch.setattr(patch_mod, "_reload_provider_runtime", lambda: calls.append("called"))
+    patch_mod.apply()
+    result = fake_providers.set_provider_key("fail-write", "sk-test")
+    assert result["ok"] is False
+    assert calls == []  # reload NOT called on the failure path
+
+
+def test_patched_remove_path_calls_reload(fake_providers_module, monkeypatch):
+    """api_key=None ('remove') is on the same success path — also reloads."""
+    fake_providers, patch_mod = fake_providers_module
+    calls = []
+    monkeypatch.setattr(patch_mod, "_reload_provider_runtime", lambda: calls.append("called"))
+    patch_mod.apply()
+    result = fake_providers.set_provider_key("openai", None)
+    assert result["action"] == "removed"
+    assert calls == ["called"]
+
+
+# ── anchor-drift detection ────────────────────────────────────────────────
+
+def test_apply_fails_loud_when_anchor_missing(tmp_path, monkeypatch):
+    """If upstream removes or renames invalidate_models_cache, the patch fails fast."""
+    drifted_source = '''\
+def set_provider_key(provider_id, api_key):
+    return {"ok": True, "provider": provider_id}
+'''
+    _install_stub(tmp_path, drifted_source, monkeypatch)
+    import fox_overlay.webui_patches.providers as patch_mod
+    importlib.reload(patch_mod)
+    with pytest.raises(AssertionError, match="anchor expected EXACTLY ONCE"):
+        patch_mod.apply()
+    importlib.reload(patch_mod)
+    for name in list(sys.modules):
+        if name == "api" or name.startswith("api."):
+            del sys.modules[name]
+
+
+# ── _reload_provider_runtime helper (Fox-side, defined in the patch module) ──
+
+def test_reload_runtime_noop_when_supervisorctl_missing(monkeypatch):
+    """Helper is a silent no-op outside FITB supervisor deployments."""
+    import fox_overlay.webui_patches.providers as patch_mod
+    monkeypatch.setattr(patch_mod.shutil, "which", lambda binary: None)
+    # Capture subprocess.run to ensure it's NOT called
+    calls = []
+    monkeypatch.setattr(patch_mod.subprocess, "run", lambda *a, **kw: calls.append(a))
+    patch_mod._reload_provider_runtime()
+    assert calls == []
+
+
+def test_reload_runtime_invokes_supervisorctl_when_present(monkeypatch):
+    """Helper shells out to supervisorctl restart when it's on PATH."""
+    import fox_overlay.webui_patches.providers as patch_mod
+    monkeypatch.setattr(patch_mod.shutil, "which", lambda binary: "/usr/bin/supervisorctl")
+    captured = []
+    monkeypatch.setattr(patch_mod.subprocess, "run", lambda *a, **kw: captured.append(a[0]))
+    patch_mod._reload_provider_runtime()
+    assert captured == [
+        ["supervisorctl", "-c", "/etc/supervisor/supervisord.conf",
+         "restart", "hermes-gateway"],
+    ]


### PR DESCRIPTION
Phase 6 of v0.6.0 migration. First of five mid-file monkey-patches. Companion to fork PR fox-in-the-box-ai/hermes-webui#25 which reverted `api/providers.py` to upstream merge-base; this PR re-applies the Fox edit at runtime via `inspect.getsource` + anchored substitution.

## Framework added

| File | Purpose |
|------|---------|
| `webui_patches/__init__.py` | `apply_all()` — called from `bootstrap.install()` |
| `webui_patches/_helpers.py` | `substitute_function` — webui-side mirror of the Phase 3 helper |
| `bootstrap.install()` | Calls `apply_all()` with Exception fallback (single-patch failure degrades, doesn't kill boot) |

## Providers patch (module 1/5)

| File | Purpose |
|------|---------|
| `webui_patches/providers.py` | Re-applies the gateway hot-reload `set_provider_key` edit |
| `tests/test_providers_patch.py` | 8 tests: idempotency, behavior parity, anchor-drift, helper noop/run paths |

The Fox helper `_reload_provider_runtime` lives in the patch module (not the `api` namespace) and is injected into the patched function's globals via `extra_globals`. No other code referenced it — verified by pre-Phase-6 grep.

## Verification

- 99 unit tests pass (91 prior + 8 new providers patch)
- Container build with submodule@d88ad66:
  - `[fox-overlay] webui_patches.apply_all() complete (1 patch modules)`
  - `[fox-overlay] bootstrap installed: dispatcher frozen, 5 GET + 5 POST handlers registered`
  - In-process: `set_provider_key._fox_patched_set_provider_key == True`
  - No regressions on Phase 5 endpoints
- Phase 4 patches still apply --check clean

## Submodule

`forks/hermes-webui` → `d88ad66` (fork PR #25 merge commit). Auto-merge after CI per Dennis's all-phases authorization.

Closes #193 (P6 monorepo: monkey-patch providers.py — Gateway hot-reload after key change).