### PR TITLE
feat(fox-overlay): models patch + substitute_method helper (Phase 6 module 2/5)

### DIFF
--- a/packages/fox-overlay/MANIFEST.toml
+++ b/packages/fox-overlay/MANIFEST.toml
@@ -60,3 +60,4 @@
 "fox_overlay.webui_patches" = "fox-only-additive"  # apply_all() called from bootstrap
 "fox_overlay.webui_patches._helpers" = "fox-only-additive"  # substitute_function (webui-side; mirror of agent_plugins helper)
 "fox_overlay.webui_patches.providers" = "fox-only-additive"  # patches api.providers.set_provider_key — adds gateway hot-reload
+"fox_overlay.webui_patches.models" = "fox-only-additive"  # patches api.models.Session.{save,load_metadata_only} + new_session — #1558 P0 guard + .bak backup + project_id pass-through

--- a/packages/fox-overlay/fox_overlay/webui_patches/__init__.py
+++ b/packages/fox-overlay/fox_overlay/webui_patches/__init__.py
@@ -27,12 +27,13 @@ def apply_all() -> None:
     """Apply every Fox webui monkey-patch. Called once from bootstrap.install()."""
     from . import providers
     providers.apply()
+    from . import models
+    models.apply()
     # Phase 6 adds more modules here:
     # from . import streaming; streaming.apply()
-    # from . import models; models.apply()
     # from . import config; config.apply()
     # from . import updates; updates.apply()
     _log.warning(
         "[fox-overlay] webui_patches.apply_all() complete (%d patch modules)",
-        1,  # update as modules are added
+        2,  # update as modules are added
     )

--- a/packages/fox-overlay/fox_overlay/webui_patches/_helpers.py
+++ b/packages/fox-overlay/fox_overlay/webui_patches/_helpers.py
@@ -25,6 +25,7 @@ present.
 """
 import inspect
 import logging
+import textwrap
 from types import ModuleType
 from typing import Any, Dict, Optional, Sequence, Tuple
 
@@ -95,5 +96,91 @@ def substitute_function(
         "[fox-overlay] patched %s.%s (%d substitutions)",
         upstream_module.__name__,
         function_name,
+        len(substitutions),
+    )
+
+
+def substitute_method(
+    upstream_module: ModuleType,
+    class_name: str,
+    method_name: str,
+    substitutions: Sequence[Tuple[str, str]],
+    sentinel: str,
+    extra_globals: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Replace ``upstream_module.<class_name>.<method_name>`` with a patched version.
+
+    Class-method counterpart to :func:`substitute_function`.
+    ``inspect.getsource(SomeClass.method)`` returns the method body with
+    the surrounding class indentation (4 spaces); raw substitution
+    anchors must match that indentation. After all substitutions are
+    applied, the source is uniformly dedented (via :func:`textwrap.dedent`)
+    so :func:`compile` accepts it at module scope.
+
+    The Phase 3 ``dedent normalizes blank lines, breaking anchors``
+    warning does NOT apply here — dedent runs AFTER anchor matching is
+    complete, so any whitespace normalization can't break anchors.
+
+    The patched method is assigned to the class (not the module) via
+    :func:`setattr` on ``getattr(upstream_module, class_name)``.
+    Idempotency sentinel and ``extra_globals`` semantics match
+    ``substitute_function``.
+    """
+    cls = getattr(upstream_module, class_name)
+    # Read the raw descriptor (classmethod/staticmethod/function) rather
+    # than the resolved attribute — the resolved attribute strips the
+    # classmethod wrapper and we'd lose our sentinel after re-assignment.
+    raw_descriptor = vars(cls).get(method_name)
+    upstream_method = raw_descriptor if raw_descriptor is not None else getattr(cls, method_name)
+    # Sentinel may live on the descriptor OR on its underlying __func__.
+    if getattr(upstream_method, sentinel, False) or getattr(
+        getattr(upstream_method, "__func__", upstream_method), sentinel, False
+    ):
+        return
+
+    # inspect.getsource works on either the descriptor or the bound resolution.
+    src = inspect.getsource(getattr(cls, method_name))
+
+    for idx, (old, new) in enumerate(substitutions):
+        count = src.count(old)
+        if count != 1:
+            raise AssertionError(
+                "[fox-overlay] monkey-patch %s.%s.%s substitution #%d: "
+                "anchor expected EXACTLY ONCE, found %dx. Upstream may have "
+                "refactored this method — refresh the anchor in the "
+                "fox-overlay webui_patches module. Anchor:\n%s"
+                % (upstream_module.__name__, class_name, method_name, idx + 1, count, old)
+            )
+        src = src.replace(old, new)
+
+    # Dedent so compile() accepts the method source at module scope.
+    # Safe to dedent here — anchor matching is already complete above.
+    src = textwrap.dedent(src)
+
+    namespace = dict(upstream_module.__dict__)
+    if extra_globals:
+        namespace.update(extra_globals)
+    code = compile(
+        src,
+        "<fox-overlay %s.%s.%s>" % (upstream_module.__name__, class_name, method_name),
+        "exec",
+    )
+    exec(code, namespace)  # noqa: S102
+
+    patched_method = namespace[method_name]
+    # If the patched result is a descriptor (e.g. classmethod), set the
+    # sentinel on its underlying function so the next apply() can detect
+    # the already-patched state — descriptor lookup via cls.method
+    # returns the underlying function, not the descriptor, so a sentinel
+    # set on the descriptor alone is invisible.
+    sentinel_target = getattr(patched_method, "__func__", patched_method)
+    setattr(sentinel_target, sentinel, True)
+    setattr(cls, method_name, patched_method)
+
+    _log.info(
+        "[fox-overlay] patched %s.%s.%s (%d substitutions)",
+        upstream_module.__name__,
+        class_name,
+        method_name,
         len(substitutions),
     )

--- a/packages/fox-overlay/fox_overlay/webui_patches/models.py
+++ b/packages/fox-overlay/fox_overlay/webui_patches/models.py
@@ -1,0 +1,182 @@
+"""Fox webui patch: models.py — #1558 metadata-only save guard, .bak backup, project_id pass-through.
+
+Re-applies 4 Fox edits to ``api/models.py`` reverted to upstream
+merge-base in fork PR fox-in-the-box-ai/hermes-webui#NN (Phase 6
+fork-side, parent #189). Closes monorepo issue #192.
+
+## Fox edits restored
+
+1. ``Session.save`` — top-of-method ``RuntimeError`` if the session
+   was loaded with ``metadata_only=True``. Prevents the #1558 P0
+   data-loss regression (saving a metadata-only stub atomically
+   wipes on-disk messages).
+2. ``Session.save`` — mid-method ``.bak`` backup of the previous JSON
+   before overwriting, IFF the incoming messages array is shorter.
+   Powers the recovery path in ``api/session_recovery.py``.
+3. ``Session.load_metadata_only`` — set ``_loaded_metadata_only=True``
+   so the guard in #1 can detect metadata-only sessions.
+4. ``new_session`` — add ``project_id`` keyword to the factory
+   signature + pass through to ``Session(...)``. Upstream
+   ``Session.__init__`` already accepts ``project_id``; the Fox edit
+   bridges the factory API.
+
+## Self-checks
+
+* ``inspect.signature`` self-check on ``Session.save`` and
+  ``new_session`` — catches upstream signature drift not in the
+  substitution anchor regions.
+* ``substitute_function`` / ``substitute_method`` anchor self-checks
+  (each anchor MUST appear exactly once) catch any local drift.
+* Idempotent via per-patch sentinel attributes.
+"""
+import inspect
+import logging
+
+from ._helpers import substitute_function, substitute_method
+
+_log = logging.getLogger("fox_overlay.webui_patches.models")
+
+_SAVE_SENTINEL = "_fox_patched_session_save"
+_LOAD_META_SENTINEL = "_fox_patched_load_metadata_only"
+_NEW_SESSION_SENTINEL = "_fox_patched_new_session"
+
+# Expected upstream signatures — see _check_signature() docstring.
+_EXPECTED_SAVE_SIG = "(self, touch_updated_at: bool = True, skip_index: bool = False) -> None"
+# load_metadata_only is @classmethod; bound signature shown.
+_EXPECTED_LOAD_META_SIG = "(sid)"
+_EXPECTED_NEW_SESSION_SIG = "(workspace=None, model=None, profile=None, model_provider=None)"
+
+
+def _check_signature(callable_obj, expected: str, label: str) -> None:
+    """Fail fast if upstream signature drifts outside the anchor region.
+
+    Anchor checks in substitute_function catch local drift (the lines we
+    rewrite). Signature check catches drift elsewhere — e.g. a kwarg
+    added/removed/renamed in upstream that doesn't touch our anchor but
+    would break the patched body's references.
+    """
+    actual = str(inspect.signature(callable_obj))
+    if actual != expected:
+        raise AssertionError(
+            "[fox-overlay] models patch: %s signature drift.\n"
+            "  expected: %s\n"
+            "  actual:   %s\n"
+            "Refresh both the expected signature and the substitution "
+            "anchors in fox_overlay/webui_patches/models.py." % (label, expected, actual)
+        )
+
+
+def apply() -> None:
+    from api import models as _u
+
+    # Idempotency at the apply() level — the 4 substitutions are
+    # interdependent (save guard depends on load_metadata_only setting
+    # the flag; new_session needs project_id pass-through to match the
+    # Session.__init__ surface). Either all run or none.
+    if getattr(_u.Session.save, _SAVE_SENTINEL, False):
+        return
+
+    # ── Signature self-checks (only on first apply — sentinel-guarded above) ──
+    _check_signature(_u.Session.save, _EXPECTED_SAVE_SIG, "Session.save")
+    _check_signature(_u.Session.load_metadata_only, _EXPECTED_LOAD_META_SIG,
+                     "Session.load_metadata_only")
+    _check_signature(_u.new_session, _EXPECTED_NEW_SESSION_SIG, "new_session")
+
+    # ── Patch Session.save: 2 substitutions ─────────────────────────────
+    substitute_method(
+        upstream_module=_u,
+        class_name="Session",
+        method_name="save",
+        substitutions=[
+            (
+                # #1558 P0 guard — insert at top of method body.
+                "    def save(self, touch_updated_at: bool = True, skip_index: bool = False) -> None:\n"
+                "        if touch_updated_at:\n",
+                "    def save(self, touch_updated_at: bool = True, skip_index: bool = False) -> None:\n"
+                "        # Fox #1558 P0 guard — refuse to save metadata-only sessions.\n"
+                "        # See fox_overlay.webui_patches.models for rationale.\n"
+                "        if getattr(self, '_loaded_metadata_only', False):\n"
+                "            raise RuntimeError(\n"
+                "                f\"Refusing to save metadata-only session {self.session_id!r}: \"\n"
+                "                f\"would atomically overwrite on-disk messages with []. \"\n"
+                "                f\"Reload with metadata_only=False before mutating state. \"\n"
+                "                f\"See #1558.\"\n"
+                "            )\n"
+                "        if touch_updated_at:\n",
+            ),
+            (
+                # #1558 .bak backup — insert between payload= and tmp=.
+                "        payload = json.dumps({**meta, **extra}, ensure_ascii=False, indent=2)\n"
+                "        tmp = self.path.with_suffix(",
+                "        payload = json.dumps({**meta, **extra}, ensure_ascii=False, indent=2)\n"
+                "\n"
+                "        # Fox #1558 backup safeguard — copy existing JSON to .bak\n"
+                "        # if the incoming messages array shrinks. See\n"
+                "        # fox_overlay.webui_patches.models for rationale.\n"
+                "        try:\n"
+                "            if self.path.exists():\n"
+                "                existing_text = self.path.read_text(encoding='utf-8')\n"
+                "                try:\n"
+                "                    existing = json.loads(existing_text)\n"
+                "                    existing_msg_count = len(existing.get('messages') or [])\n"
+                "                except (json.JSONDecodeError, ValueError):\n"
+                "                    existing_msg_count = -1  # corrupt → always back up\n"
+                "                incoming_msg_count = len(self.messages or [])\n"
+                "                if existing_msg_count > incoming_msg_count:\n"
+                "                    bak_path = self.path.with_suffix('.json.bak')\n"
+                "                    try:\n"
+                "                        bak_path.write_text(existing_text, encoding='utf-8')\n"
+                "                    except OSError:\n"
+                "                        pass\n"
+                "        except OSError:\n"
+                "            pass\n"
+                "\n"
+                "        tmp = self.path.with_suffix(",
+            ),
+        ],
+        sentinel=_SAVE_SENTINEL,
+    )
+
+    # ── Patch Session.load_metadata_only: 1 substitution ────────────────
+    substitute_method(
+        upstream_module=_u,
+        class_name="Session",
+        method_name="load_metadata_only",
+        substitutions=[
+            (
+                # Set _loaded_metadata_only=True before return so save() guard fires.
+                "            session._metadata_message_count = _lookup_index_message_count(sid)\n"
+                "            return session\n",
+                "            session._metadata_message_count = _lookup_index_message_count(sid)\n"
+                "            # Fox #1558 — flag this session as metadata-only stub.\n"
+                "            # Save guard above (Session.save) refuses to write metadata-only sessions.\n"
+                "            session._loaded_metadata_only = True\n"
+                "            return session\n",
+            ),
+        ],
+        sentinel=_LOAD_META_SENTINEL,
+    )
+
+    # ── Patch new_session: 2 substitutions (signature + body) ───────────
+    substitute_function(
+        upstream_module=_u,
+        function_name="new_session",
+        substitutions=[
+            (
+                "def new_session(workspace=None, model=None, profile=None, model_provider=None):\n",
+                "def new_session(workspace=None, model=None, profile=None, model_provider=None, project_id=None):\n",
+            ),
+            (
+                "        model=effective_model,\n"
+                "        model_provider=model_provider,\n"
+                "        profile=profile,\n"
+                "    )\n",
+                "        model=effective_model,\n"
+                "        model_provider=model_provider,\n"
+                "        profile=profile,\n"
+                "        project_id=project_id,\n"
+                "    )\n",
+            ),
+        ],
+        sentinel=_NEW_SESSION_SENTINEL,
+    )

--- a/packages/fox-overlay/tests/test_models_patch.py
+++ b/packages/fox-overlay/tests/test_models_patch.py
@@ -1,0 +1,381 @@
+"""Phase 6 regression tests for fox_overlay.webui_patches.models.
+
+Covers:
+* substitute_method handles class-method indentation correctly
+* All 4 Fox edits applied: 2 on Session.save, 1 on Session.load_metadata_only,
+  1 on new_session
+* Signature self-check fires when upstream signature drifts
+* Anchor drift fails fast
+* Idempotency
+* Behavioral parity with pre-Phase-6 Fox: metadata-only save raises,
+  .bak written on shrink, _loaded_metadata_only set by load_metadata_only,
+  new_session passes project_id through to Session()
+"""
+import importlib
+import json
+import sys
+import textwrap
+
+import pytest
+
+
+# Minimal upstream models.py stub matching merge-base 9e31a2a around the
+# anchor regions. Includes the bare-minimum machinery so save() can write,
+# load_metadata_only() can return, and new_session() can construct a Session.
+_UPSTREAM_MODELS_SOURCE = '''\
+import json
+import logging
+import os
+import threading
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+SESSION_DIR = None  # patched per test
+SESSIONS = {}
+SESSIONS_MAX = 1000
+LOCK = threading.Lock()
+DEFAULT_WORKSPACE = "/tmp"
+DEFAULT_MODEL = "test-model"
+METADATA_FIELDS = ['session_id', 'title', 'model']
+
+
+def get_last_workspace():
+    return str(DEFAULT_WORKSPACE)
+
+
+def get_effective_default_model():
+    return DEFAULT_MODEL
+
+
+def _read_metadata_json_prefix(p):
+    return p.read_text(encoding='utf-8')
+
+
+def _lookup_index_message_count(sid):
+    return 0
+
+
+class Session:
+    def __init__(self, session_id=None, title='Untitled', workspace=None,
+                 model=None, model_provider=None, messages=None,
+                 created_at=None, updated_at=None, tool_calls=None,
+                 project_id=None, profile=None, **kwargs):
+        self.session_id = session_id or "s_test"
+        self.title = title
+        self.workspace = workspace
+        self.model = model
+        self.model_provider = model_provider
+        self.messages = messages or []
+        self.created_at = created_at or time.time()
+        self.updated_at = updated_at or time.time()
+        self.tool_calls = tool_calls or []
+        self.project_id = project_id
+        self.profile = profile
+        self._metadata_message_count = None
+
+    @property
+    def path(self):
+        return SESSION_DIR / f'{self.session_id}.json'
+
+    def save(self, touch_updated_at: bool = True, skip_index: bool = False) -> None:
+        if touch_updated_at:
+            self.updated_at = time.time()
+        # Write metadata fields first so load_metadata_only() can read them
+        # without parsing the full messages array (which may be 400KB+).
+        # Fields are listed in the order they should appear in the JSON file.
+        meta = {k: getattr(self, k, None) for k in METADATA_FIELDS}
+        meta['messages'] = self.messages
+        meta['tool_calls'] = self.tool_calls
+        # Fields not in METADATA_FIELDS (e.g. last_usage, message_count) go at the end
+        extra = {k: v for k, v in self.__dict__.items()
+                 if k not in METADATA_FIELDS and k not in ('messages', 'tool_calls')
+                 and not k.startswith('_')}
+        payload = json.dumps({**meta, **extra}, ensure_ascii=False, indent=2)
+        tmp = self.path.with_suffix(f'.tmp.{os.getpid()}.{threading.current_thread().ident}')
+        try:
+            with open(tmp, 'w', encoding='utf-8') as f:
+                f.write(payload)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp, self.path)
+        except Exception:
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+            raise
+
+    @classmethod
+    def load_metadata_only(cls, sid):
+        if not sid or not all(c in '0123456789abcdefghijklmnopqrstuvwxyz_' for c in sid):
+            return None
+        p = SESSION_DIR / f'{sid}.json'
+        if not p.exists():
+            return None
+        try:
+            prefix = _read_metadata_json_prefix(p)
+            if not prefix:
+                return None
+            parsed = json.loads(prefix)
+            needed = {'session_id'}
+            if not needed.issubset(parsed.keys()):
+                return None
+            parsed['messages'] = []
+            parsed['tool_calls'] = []
+            session = cls(**parsed)
+            session._metadata_message_count = _lookup_index_message_count(sid)
+            return session
+        except Exception:
+            return None
+
+
+def new_session(workspace=None, model=None, profile=None, model_provider=None):
+    """Create a new in-memory session."""
+    effective_model = model or get_effective_default_model()
+    s = Session(
+        workspace=workspace or get_last_workspace(),
+        model=effective_model,
+        model_provider=model_provider,
+        profile=profile,
+    )
+    with LOCK:
+        SESSIONS[s.session_id] = s
+    return s
+'''
+
+
+def _install_stub(tmp_path, source, monkeypatch, session_dir=None):
+    """Write `source` to tmp_path/api/models.py and import it as `api.models`."""
+    api_dir = tmp_path / "api"
+    api_dir.mkdir(exist_ok=True)
+    (api_dir / "__init__.py").write_text("")
+    (api_dir / "models.py").write_text(source)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    for name in list(sys.modules):
+        if name == "api" or name.startswith("api."):
+            del sys.modules[name]
+    import api.models as fake_models  # noqa: F401
+    if session_dir is not None:
+        fake_models.SESSION_DIR = session_dir
+    return sys.modules["api.models"]
+
+
+@pytest.fixture
+def fresh_models(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    fake_models = _install_stub(tmp_path, _UPSTREAM_MODELS_SOURCE, monkeypatch, session_dir)
+    import fox_overlay.webui_patches.models as patch_mod
+    importlib.reload(patch_mod)
+    yield fake_models, patch_mod, session_dir
+    importlib.reload(patch_mod)
+    for name in list(sys.modules):
+        if name == "api" or name.startswith("api."):
+            del sys.modules[name]
+
+
+# ── apply() idempotency + signature checks ─────────────────────────────────
+
+def test_apply_is_idempotent(fresh_models):
+    _u, patch_mod, _ = fresh_models
+    patch_mod.apply()
+    patch_mod.apply()
+    assert getattr(_u.Session.save, "_fox_patched_session_save", False) is True
+    assert getattr(_u.Session.load_metadata_only, "_fox_patched_load_metadata_only", False) is True
+    assert getattr(_u.new_session, "_fox_patched_new_session", False) is True
+
+
+def test_signature_self_check_catches_drift(tmp_path, monkeypatch):
+    """If upstream Session.save signature changes, patch fails fast with diagnostic."""
+    drifted = _UPSTREAM_MODELS_SOURCE.replace(
+        "def save(self, touch_updated_at: bool = True, skip_index: bool = False) -> None:",
+        "def save(self, touch_updated_at=True) -> None:",  # dropped skip_index
+    )
+    _install_stub(tmp_path, drifted, monkeypatch)
+    import fox_overlay.webui_patches.models as patch_mod
+    importlib.reload(patch_mod)
+    with pytest.raises(AssertionError, match="Session.save signature drift"):
+        patch_mod.apply()
+    importlib.reload(patch_mod)
+    for name in list(sys.modules):
+        if name == "api" or name.startswith("api."):
+            del sys.modules[name]
+
+
+def test_anchor_drift_fails_fast(tmp_path, monkeypatch):
+    """If upstream removes the anchor, substitute_method raises AssertionError."""
+    drifted = _UPSTREAM_MODELS_SOURCE.replace(
+        "        payload = json.dumps({**meta, **extra}, ensure_ascii=False, indent=2)\n"
+        "        tmp = self.path.with_suffix(",
+        "        # upstream restructured\n"
+        "        json_data = json.dumps({**meta, **extra})\n"
+        "        target_tmp = self.path.with_suffix(",
+    )
+    _install_stub(tmp_path, drifted, monkeypatch)
+    import fox_overlay.webui_patches.models as patch_mod
+    importlib.reload(patch_mod)
+    with pytest.raises(AssertionError, match="anchor expected EXACTLY ONCE"):
+        patch_mod.apply()
+    importlib.reload(patch_mod)
+    for name in list(sys.modules):
+        if name == "api" or name.startswith("api."):
+            del sys.modules[name]
+
+
+# ── Session.save metadata-only guard ───────────────────────────────────────
+
+def test_save_raises_when_loaded_metadata_only(fresh_models):
+    _u, patch_mod, session_dir = fresh_models
+    patch_mod.apply()
+    s = _u.Session(session_id="s_abc123def", title="T")
+    s._loaded_metadata_only = True
+    with pytest.raises(RuntimeError, match="Refusing to save metadata-only session"):
+        s.save()
+
+
+def test_save_works_normally_when_not_metadata_only(fresh_models):
+    _u, patch_mod, session_dir = fresh_models
+    patch_mod.apply()
+    s = _u.Session(session_id="s_abc123def", title="T", messages=[{"role": "user", "content": "hi"}])
+    s.save()
+    assert (session_dir / "s_abc123def.json").exists()
+
+
+# ── Session.save .bak backup ───────────────────────────────────────────────
+
+def test_save_writes_bak_when_messages_shrink(fresh_models):
+    _u, patch_mod, session_dir = fresh_models
+    patch_mod.apply()
+    # First save with 3 messages
+    s = _u.Session(session_id="s_grow", title="T", messages=[{"r": i} for i in range(3)])
+    s.save()
+    # Second save with 1 message — should trigger .bak
+    s2 = _u.Session(session_id="s_grow", title="T", messages=[{"r": 0}])
+    s2.save()
+    bak = session_dir / "s_grow.json.bak"
+    assert bak.exists()
+    saved_bak = json.loads(bak.read_text())
+    # Note: stub Session doesn't store messages in metadata-only fields,
+    # so saved_bak structure mirrors what got written previously.
+    # Sanity check: it should contain something.
+    assert saved_bak is not None
+
+
+def test_save_does_not_write_bak_when_messages_grow(fresh_models):
+    _u, patch_mod, session_dir = fresh_models
+    patch_mod.apply()
+    s = _u.Session(session_id="s_grow2", title="T", messages=[{"r": 0}])
+    s.save()
+    s2 = _u.Session(session_id="s_grow2", title="T", messages=[{"r": i} for i in range(3)])
+    s2.save()
+    bak = session_dir / "s_grow2.json.bak"
+    assert not bak.exists()
+
+
+# ── Session.load_metadata_only flag ────────────────────────────────────────
+
+def test_load_metadata_only_sets_flag(fresh_models):
+    _u, patch_mod, session_dir = fresh_models
+    patch_mod.apply()
+    # Write a session file directly
+    (session_dir / "s_load1.json").write_text(json.dumps({
+        "session_id": "s_load1", "title": "T", "messages": [],
+    }))
+    loaded = _u.Session.load_metadata_only("s_load1")
+    assert loaded is not None
+    assert getattr(loaded, "_loaded_metadata_only", False) is True
+
+
+def test_loaded_metadata_only_session_cannot_save(fresh_models):
+    _u, patch_mod, session_dir = fresh_models
+    patch_mod.apply()
+    (session_dir / "s_load2.json").write_text(json.dumps({
+        "session_id": "s_load2", "title": "T", "messages": [],
+    }))
+    loaded = _u.Session.load_metadata_only("s_load2")
+    with pytest.raises(RuntimeError, match="Refusing to save metadata-only session"):
+        loaded.save()
+
+
+# ── new_session project_id pass-through ────────────────────────────────────
+
+def test_new_session_accepts_project_id(fresh_models):
+    _u, patch_mod, _ = fresh_models
+    patch_mod.apply()
+    s = _u.new_session(project_id="proj_abc")
+    assert s.project_id == "proj_abc"
+
+
+def test_new_session_project_id_defaults_to_none(fresh_models):
+    """Backward-compat: callers not passing project_id still work."""
+    _u, patch_mod, _ = fresh_models
+    patch_mod.apply()
+    s = _u.new_session()
+    assert s.project_id is None
+
+
+# ── substitute_method helper itself (since this is its first user) ─────────
+
+def test_substitute_method_handles_class_indentation():
+    """End-to-end: a class method substitution actually compiles + replaces."""
+    import types
+    from fox_overlay.webui_patches._helpers import substitute_method
+
+    mod = types.ModuleType("test_indent_mod")
+    # Real file needed for inspect.getsource
+    import tempfile, pathlib
+    src = textwrap.dedent('''\
+        class Foo:
+            def bar(self, x):
+                return x + 1
+    ''')
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f:
+        f.write(src)
+        path = f.name
+    spec = importlib.util.spec_from_file_location("test_indent_mod", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    substitute_method(
+        upstream_module=mod,
+        class_name="Foo",
+        method_name="bar",
+        substitutions=[
+            ("return x + 1", "return x * 2"),
+        ],
+        sentinel="_test_patched",
+    )
+    assert mod.Foo().bar(5) == 10  # was 6, now 10
+
+
+def test_substitute_method_idempotent():
+    """Second apply on the same target is a no-op."""
+    import types, tempfile
+    from fox_overlay.webui_patches._helpers import substitute_method
+
+    src = textwrap.dedent('''\
+        class Foo:
+            def bar(self, x):
+                return x + 1
+    ''')
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f:
+        f.write(src)
+        path = f.name
+    spec = importlib.util.spec_from_file_location("test_indent_mod_2", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    substitute_method(
+        upstream_module=mod, class_name="Foo", method_name="bar",
+        substitutions=[("return x + 1", "return x * 2")],
+        sentinel="_idem_patched",
+    )
+    # Second apply must not re-substitute (would fail anchor count)
+    substitute_method(
+        upstream_module=mod, class_name="Foo", method_name="bar",
+        substitutions=[("return x + 1", "return x * 2")],
+        sentinel="_idem_patched",
+    )
+    assert mod.Foo().bar(5) == 10


### PR DESCRIPTION
Phase 6 of v0.6.0 migration. Second of five mid-file monkey-patches. Companion to fork PR fox-in-the-box-ai/hermes-webui#26 (revert `api/models.py` to upstream merge-base).

Closes #192.

## Framework: `substitute_method` (NEW helper)

Class-method sibling to `substitute_function` (Phase 3). Key design decisions:
- **Indentation**: `inspect.getsource` on a class method returns 4-space-indented source. Anchors match the indented source as-is; the helper runs `textwrap.dedent` AFTER substitution (anchor matching already complete) so `compile()` accepts the source at module scope.
- **Classmethod descriptor sentinel**: descriptor lookup via `cls.method` strips the wrapper. Sentinel is set on `__func__` so re-apply detection survives descriptor resolution.
- **`inspect.signature` self-check** (per #192 comment): catches upstream drift outside the anchor regions (e.g. a kwarg added/removed that doesn't touch the anchor but would break the patched body).

## Models patch (module 2/5)

Re-applies 4 Fox edits:

| Target | Edit | Type |
|--------|------|------|
| `Session.save` | `RuntimeError` if `_loaded_metadata_only=True` (#1558 P0) | substitute_method |
| `Session.save` | `.bak` backup before write if messages shrink (#1558 recovery) | substitute_method |
| `Session.load_metadata_only` | Set `_loaded_metadata_only=True` on returned session | substitute_method |
| `new_session` | Add `project_id` kwarg + pass-through | substitute_function |

Idempotent via per-patch sentinels; `apply()` bails early after first run via the `Session.save` sentinel (the 4 patches are interdependent — all-or-nothing).

## Verification

- 112 tests pass (99 prior + 13 new models patch)
- Container build with submodule@1b1d29a (fork PR #26 merge):
  - `[fox-overlay] webui_patches.apply_all() complete (2 patch modules)`
  - In-process: all 3 patches confirmed True
  - `new_session` signature now includes `project_id=None`
  - No regressions on Phase 5 endpoints
- Phase 4 patches still apply --check clean

## Submodule

`forks/hermes-webui` → `1b1d29a` (fork PR #26 merge commit). Auto-merge after CI per Dennis's all-phases authorization.