### PR TITLE
feat(fox-overlay): config patch — settings defaults + cache invalidation (Phase 6 module 3/5)

### DIFF
--- a/packages/fox-overlay/MANIFEST.toml
+++ b/packages/fox-overlay/MANIFEST.toml
@@ -61,3 +61,4 @@
 "fox_overlay.webui_patches._helpers" = "fox-only-additive"  # substitute_function (webui-side; mirror of agent_plugins helper)
 "fox_overlay.webui_patches.providers" = "fox-only-additive"  # patches api.providers.set_provider_key — adds gateway hot-reload
 "fox_overlay.webui_patches.models" = "fox-only-additive"  # patches api.models.Session.{save,load_metadata_only} + new_session — #1558 P0 guard + .bak backup + project_id pass-through
+"fox_overlay.webui_patches.config" = "fox-only-additive"  # patches api.config — Fox _SETTINGS_DEFAULTS + _SETTINGS_BOOL_KEYS + get_config mtime invalidation + reload_config models-cache eviction + save_settings TS/Ollama validation + bool-string coercion

--- a/packages/fox-overlay/fox_overlay/webui_patches/__init__.py
+++ b/packages/fox-overlay/fox_overlay/webui_patches/__init__.py
@@ -24,16 +24,23 @@ _log = logging.getLogger("fox_overlay.webui_patches")
 
 
 def apply_all() -> None:
-    """Apply every Fox webui monkey-patch. Called once from bootstrap.install()."""
+    """Apply every Fox webui monkey-patch. Called once from bootstrap.install().
+
+    Ordering: config FIRST per issue #190 — Phase 5 webui modules read
+    settings whose defaults config.py provides. (For Phase 6 internal
+    ordering only — historical providers/models PRs already shipped and
+    don't read config keys.)
+    """
+    from . import config
+    config.apply()
     from . import providers
     providers.apply()
     from . import models
     models.apply()
     # Phase 6 adds more modules here:
     # from . import streaming; streaming.apply()
-    # from . import config; config.apply()
     # from . import updates; updates.apply()
     _log.warning(
         "[fox-overlay] webui_patches.apply_all() complete (%d patch modules)",
-        2,  # update as modules are added
+        3,  # update as modules are added
     )

--- a/packages/fox-overlay/fox_overlay/webui_patches/config.py
+++ b/packages/fox-overlay/fox_overlay/webui_patches/config.py
@@ -1,0 +1,268 @@
+"""Fox webui patch: config.py — settings defaults + cache invalidation + save-gate validation.
+
+Re-applies the Fox edits to ``api/config.py`` reverted to upstream
+merge-base in fork PR fox-in-the-box-ai/hermes-webui#NN (Phase 6
+fork-side, parent #189). Closes monorepo issue #190.
+
+## Fox edits restored
+
+### Module-scope additions (direct dict/set mutation, no substitution)
+
+* ``_SETTINGS_DEFAULTS`` gains 9 Fox keys:
+  ``local_fallback_enabled``, ``hostname_prompted``,
+  ``tailscale_login_server``, ``tailscale_advertise_routes``,
+  ``tailscale_advertise_tags``, ``tailscale_accept_routes``,
+  ``tailscale_accept_dns``, ``tailscale_exit_node``,
+  ``ollama_custom_url``.
+* ``_SETTINGS_BOOL_KEYS`` gains 4 Fox keys (the bool ones above).
+
+These are persistent settings the Phase 5 webui modules (ollama,
+tailscale, local_fallback, hostname) read at module-load. **Issue #190
+flagged this PR as "MERGE FIRST"** — without these keys present,
+Phase 5 modules would read missing settings and silently default to
+None / KeyError on first run.
+
+### Function patches
+
+* ``get_config()`` — add mtime-based cache invalidation so config
+  changes from out-of-process writers (gateway, supervisor) reach
+  the webui without restart.
+* ``reload_config()`` — also evict the in-memory ``_available_models_cache``
+  (#138 chat-model-picker stale-after-Ollama-switch fix).
+* ``save_settings()`` — three additions:
+  - Validate Tailscale power-user fields at the save gate
+  - Validate Ollama custom URL + normalize + remember the change
+  - Replace native ``bool(v)`` coercion with string-aware coercion
+    (``bool("false") == True`` was silently flipping flags)
+  - Invalidate Ollama probe cache after URL change
+
+## Self-checks
+
+* ``inspect.signature`` self-check on all 3 functions
+* Anchor self-check via ``substitute_function`` (each anchor MUST
+  appear exactly once)
+* Idempotent via per-patch sentinels + a module-attribute flag for the
+  dict/set additions
+"""
+import inspect
+import logging
+
+from ._helpers import substitute_function
+
+_log = logging.getLogger("fox_overlay.webui_patches.config")
+
+_GET_CONFIG_SENTINEL = "_fox_patched_get_config"
+_RELOAD_CONFIG_SENTINEL = "_fox_patched_reload_config"
+_SAVE_SETTINGS_SENTINEL = "_fox_patched_save_settings"
+_MODULE_DEFAULTS_FLAG = "_fox_settings_defaults_applied"
+
+_EXPECTED_GET_CONFIG_SIG = "() -> dict"
+_EXPECTED_RELOAD_CONFIG_SIG = "() -> None"
+_EXPECTED_SAVE_SETTINGS_SIG = "(settings: dict) -> dict"
+
+_FOX_DEFAULTS = {
+    # Local AI fallback (#9). Toggling ON triggers a one-time GGUF
+    # download (~2.5 GB) and starts a supervisord-managed llama-server.
+    "local_fallback_enabled": False,
+    # Tracks whether the post-wizard hostname prompt (#68) has been
+    # shown. Once true, the prompt never re-fires.
+    "hostname_prompted": False,
+    # Power-user Tailscale flags (#96 phase 2). _build_up_argv() already
+    # accepts these; persisting them here lets the UI pre-populate on
+    # revisit. accept_dns defaults TRUE (Tailscale itself defaults true
+    # and most users want MagicDNS).
+    "tailscale_login_server": "",
+    "tailscale_advertise_routes": "",
+    "tailscale_advertise_tags": "",
+    "tailscale_accept_routes": False,
+    "tailscale_accept_dns": True,
+    "tailscale_exit_node": "",
+    # Custom Ollama base URL (#109). Empty = auto-detect.
+    "ollama_custom_url": "",
+}
+_FOX_BOOL_KEYS = {
+    "local_fallback_enabled",
+    "hostname_prompted",
+    "tailscale_accept_routes",
+    "tailscale_accept_dns",
+}
+
+
+def _check_signature(callable_obj, expected: str, label: str) -> None:
+    actual = str(inspect.signature(callable_obj))
+    if actual != expected:
+        raise AssertionError(
+            "[fox-overlay] config patch: %s signature drift.\n"
+            "  expected: %s\n"
+            "  actual:   %s\n"
+            "Refresh both the expected signature and the substitution "
+            "anchors in fox_overlay/webui_patches/config.py." % (label, expected, actual)
+        )
+
+
+def apply() -> None:
+    from api import config as _u
+
+    # Apply-level idempotency: bail if get_config already patched.
+    if getattr(_u.get_config, _GET_CONFIG_SENTINEL, False):
+        return
+
+    # ── Signature self-checks ───────────────────────────────────────────
+    _check_signature(_u.get_config, _EXPECTED_GET_CONFIG_SIG, "get_config")
+    _check_signature(_u.reload_config, _EXPECTED_RELOAD_CONFIG_SIG, "reload_config")
+    _check_signature(_u.save_settings, _EXPECTED_SAVE_SETTINGS_SIG, "save_settings")
+
+    # ── Module-scope additions: defaults dict + bool key set ────────────
+    # Done BEFORE function patches so save_settings (which reads
+    # _SETTINGS_BOOL_KEYS) sees the new keys.
+    if not getattr(_u, _MODULE_DEFAULTS_FLAG, False):
+        for key, value in _FOX_DEFAULTS.items():
+            _u._SETTINGS_DEFAULTS.setdefault(key, value)
+        _u._SETTINGS_BOOL_KEYS.update(_FOX_BOOL_KEYS)
+        setattr(_u, _MODULE_DEFAULTS_FLAG, True)
+        _log.info(
+            "[fox-overlay] api.config _SETTINGS_DEFAULTS gained %d keys; "
+            "_SETTINGS_BOOL_KEYS gained %d keys",
+            len(_FOX_DEFAULTS), len(_FOX_BOOL_KEYS),
+        )
+
+    # ── Patch get_config: add mtime-based cache invalidation ────────────
+    substitute_function(
+        upstream_module=_u,
+        function_name="get_config",
+        substitutions=[
+            (
+                "    if not _cfg_cache:\n"
+                "        reload_config()\n"
+                "    return _cfg_cache\n",
+                "    if not _cfg_cache:\n"
+                "        reload_config()\n"
+                "        return _cfg_cache\n"
+                "\n"
+                "    # Fox: file-mtime check — pick up out-of-process config writes\n"
+                "    # (e.g. supervisorctl-managed gateway) without a webui restart.\n"
+                "    try:\n"
+                "        if _get_config_path().stat().st_mtime != _cfg_mtime:\n"
+                "            with _cfg_lock:\n"
+                "                if _get_config_path().stat().st_mtime != _cfg_mtime:\n"
+                "                    reload_config()\n"
+                "    except OSError:\n"
+                "        pass\n"
+                "\n"
+                "    return _cfg_cache\n",
+            ),
+        ],
+        sentinel=_GET_CONFIG_SENTINEL,
+    )
+
+    # ── Patch reload_config: add in-memory models-cache eviction ────────
+    substitute_function(
+        upstream_module=_u,
+        function_name="reload_config",
+        substitutions=[
+            (
+                # Expand global declaration to include the models-cache vars.
+                "    global _cfg_mtime\n"
+                "    with _cfg_lock:\n",
+                "    global _cfg_mtime, _available_models_cache, _available_models_cache_ts\n"
+                "    with _cfg_lock:\n",
+            ),
+            (
+                # Add cache eviction after on-disk cache delete (#138).
+                "        if _old_cfg_mtime != 0.0:\n"
+                "            _delete_models_cache_on_disk()\n",
+                "        if _old_cfg_mtime != 0.0:\n"
+                "            _delete_models_cache_on_disk()\n"
+                "            # Fox #138: evict in-memory cache too — same gating as\n"
+                "            # on-disk delete (only on actual changes, not first load).\n"
+                "            _available_models_cache = None\n"
+                "            _available_models_cache_ts = 0.0\n",
+            ),
+        ],
+        sentinel=_RELOAD_CONFIG_SENTINEL,
+    )
+
+    # ── Patch save_settings: three additions ────────────────────────────
+    substitute_function(
+        upstream_module=_u,
+        function_name="save_settings",
+        substitutions=[
+            (
+                # Top-of-function: Tailscale + Ollama URL validation gates.
+                'def save_settings(settings: dict) -> dict:\n'
+                '    """Save settings to disk. Returns the merged settings. Ignores unknown keys."""\n'
+                '    current = load_settings()\n',
+                'def save_settings(settings: dict) -> dict:\n'
+                '    """Save settings to disk. Returns the merged settings. Ignores unknown keys.\n'
+                '\n'
+                '    Fox: validate Tailscale + Ollama URL fields BEFORE persisting.\n'
+                '    See fox_overlay.webui_patches.config for rationale.\n'
+                '    """\n'
+                '    try:\n'
+                '        from api.tailscale import validate_settings_dict as _ts_validate\n'
+                '        ts_err = _ts_validate(settings)\n'
+                '        if ts_err:\n'
+                '            raise ValueError(f"Tailscale setting rejected: {ts_err}")\n'
+                '    except ImportError:\n'
+                '        pass\n'
+                '    _ollama_url_changed = False\n'
+                '    if "ollama_custom_url" in settings:\n'
+                '        try:\n'
+                '            from api.ollama import validate_custom_ollama_url\n'
+                '            ok, normalized_or_err = validate_custom_ollama_url(settings["ollama_custom_url"])\n'
+                '            if not ok:\n'
+                '                raise ValueError(f"Ollama setting rejected: {normalized_or_err}")\n'
+                '            settings["ollama_custom_url"] = normalized_or_err\n'
+                '            _ollama_url_changed = True\n'
+                '        except ImportError:\n'
+                '            pass\n'
+                '    current = load_settings()\n',
+            ),
+            (
+                # Replace native bool coercion with string-aware coercion.
+                "            # Coerce bool keys\n"
+                "            if k in _SETTINGS_BOOL_KEYS:\n"
+                "                v = bool(v)\n",
+                "            # Fox: bool('false') is True in Python — a curl POST with\n"
+                "            # {'hostname_prompted':'false'} would silently flip the flag\n"
+                "            # to True. Accept native booleans, JSON-stringified booleans,\n"
+                "            # and obvious truthy/falsy strings; reject other types by\n"
+                "            # leaving the prior value intact.\n"
+                "            if k in _SETTINGS_BOOL_KEYS:\n"
+                "                if isinstance(v, bool):\n"
+                "                    pass\n"
+                "                elif isinstance(v, str):\n"
+                "                    s = v.strip().lower()\n"
+                "                    if s in ('true', '1', 'yes', 'on'):\n"
+                "                        v = True\n"
+                "                    elif s in ('false', '0', 'no', 'off', ''):\n"
+                "                        v = False\n"
+                "                    else:\n"
+                "                        continue\n"
+                "                elif isinstance(v, (int, float)):\n"
+                "                    v = bool(v)\n"
+                "                else:\n"
+                "                    continue\n",
+            ),
+            (
+                # Add Ollama cache invalidation after default_workspace resolve.
+                "    global DEFAULT_WORKSPACE\n"
+                '    if "default_workspace" in current:\n'
+                '        DEFAULT_WORKSPACE = resolve_default_workspace(current["default_workspace"])\n'
+                '    current["default_model"] = get_effective_default_model()\n',
+                "    global DEFAULT_WORKSPACE\n"
+                '    if "default_workspace" in current:\n'
+                '        DEFAULT_WORKSPACE = resolve_default_workspace(current["default_workspace"])\n'
+                '    # Fox #109: invalidate Ollama probe cache on URL change so the\n'
+                '    # next /api/ollama/status reflects the new URL immediately.\n'
+                '    if _ollama_url_changed:\n'
+                '        try:\n'
+                '            from api.ollama import clear_cache as _clear_ollama_cache\n'
+                '            _clear_ollama_cache()\n'
+                '        except Exception:\n'
+                '            pass\n'
+                '    current["default_model"] = get_effective_default_model()\n',
+            ),
+        ],
+        sentinel=_SAVE_SETTINGS_SENTINEL,
+    )

--- a/packages/fox-overlay/tests/test_config_patch.py
+++ b/packages/fox-overlay/tests/test_config_patch.py
@@ -1,0 +1,251 @@
+"""Phase 6 regression tests for fox_overlay.webui_patches.config.
+
+Covers:
+* Module-scope additions: _SETTINGS_DEFAULTS + _SETTINGS_BOOL_KEYS gain
+  the 9+4 Fox keys.
+* Function patches applied (sentinels set) for get_config, reload_config,
+  save_settings.
+* Anchor self-check fires on drift in any of the 3 functions.
+* Idempotency across multiple apply() calls.
+* Behavioral spot-check: bool-string coercion fixes the bool("false")=True
+  bug.
+"""
+import importlib
+import sys
+
+import pytest
+
+
+# Upstream stub matching merge-base 9e31a2a around the anchor regions.
+# Trimmed to the bare minimum needed by the substitution anchors —
+# unrelated code is collapsed to comments to keep the stub short.
+_UPSTREAM_CONFIG_SOURCE = '''\
+import os
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+_cfg_cache = {}
+_cfg_lock = threading.RLock()
+_cfg_mtime = 0.0
+
+_available_models_cache = None
+_available_models_cache_ts = 0.0
+
+DEFAULT_WORKSPACE = "/tmp"
+
+
+def _get_config_path() -> Path:
+    return Path("/tmp/fox-test-config.yaml")
+
+
+def _delete_models_cache_on_disk():
+    pass
+
+
+def get_effective_default_model():
+    return "test-model"
+
+
+def resolve_default_workspace(p):
+    return p
+
+
+def load_settings():
+    return {}
+
+
+def get_config() -> dict:
+    """Return the cached config dict, loading from disk if needed."""
+    if not _cfg_cache:
+        reload_config()
+    return _cfg_cache
+
+
+def reload_config() -> None:
+    """Reload config.yaml from the active profile's directory."""
+    global _cfg_mtime
+    with _cfg_lock:
+        _cfg_cache.clear()
+        config_path = _get_config_path()
+        _old_cfg_mtime = _cfg_mtime
+        # ... upstream content collapsed ...
+        # still hits the fast path without a cold run.
+        if _old_cfg_mtime != 0.0:
+            _delete_models_cache_on_disk()
+
+
+_SETTINGS_DEFAULTS = {
+    "theme": "system",
+    "skin": "default",
+    "password_hash": None,
+}
+
+_SETTINGS_BOOL_KEYS = {
+    "show_thinking",
+    "simplified_tool_calling",
+    "api_redact_enabled",
+}
+
+_SETTINGS_LANG_RE = None  # placeholder
+
+
+def save_settings(settings: dict) -> dict:
+    """Save settings to disk. Returns the merged settings. Ignores unknown keys."""
+    current = load_settings()
+    pending_theme = current.get("theme")
+    pending_skin = current.get("skin")
+    if isinstance(settings, dict):
+        for k, v in settings.items():
+            # Coerce bool keys
+            if k in _SETTINGS_BOOL_KEYS:
+                v = bool(v)
+            current[k] = v
+    theme_value = pending_theme
+    skin_value = pending_skin
+    # ... save to disk collapsed ...
+    global DEFAULT_WORKSPACE
+    if "default_workspace" in current:
+        DEFAULT_WORKSPACE = resolve_default_workspace(current["default_workspace"])
+    current["default_model"] = get_effective_default_model()
+    return current
+'''
+
+
+def _install_stub(tmp_path, source, monkeypatch):
+    api_dir = tmp_path / "api"
+    api_dir.mkdir(exist_ok=True)
+    (api_dir / "__init__.py").write_text("")
+    (api_dir / "config.py").write_text(source)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    for name in list(sys.modules):
+        if name == "api" or name.startswith("api."):
+            del sys.modules[name]
+    import api.config as fake_config  # noqa: F401
+    return sys.modules["api.config"]
+
+
+@pytest.fixture
+def fresh_config(tmp_path, monkeypatch):
+    fake_config = _install_stub(tmp_path, _UPSTREAM_CONFIG_SOURCE, monkeypatch)
+    import fox_overlay.webui_patches.config as patch_mod
+    importlib.reload(patch_mod)
+    yield fake_config, patch_mod
+    importlib.reload(patch_mod)
+    for name in list(sys.modules):
+        if name == "api" or name.startswith("api."):
+            del sys.modules[name]
+
+
+# ── apply() applies all 3 function patches + module-scope additions ──────
+
+def test_apply_marks_all_function_sentinels(fresh_config):
+    _u, patch_mod = fresh_config
+    patch_mod.apply()
+    assert getattr(_u.get_config, "_fox_patched_get_config", False) is True
+    assert getattr(_u.reload_config, "_fox_patched_reload_config", False) is True
+    assert getattr(_u.save_settings, "_fox_patched_save_settings", False) is True
+
+
+def test_apply_adds_fox_defaults(fresh_config):
+    _u, patch_mod = fresh_config
+    patch_mod.apply()
+    for key in ("local_fallback_enabled", "hostname_prompted",
+                "tailscale_login_server", "tailscale_advertise_routes",
+                "tailscale_advertise_tags", "tailscale_accept_routes",
+                "tailscale_accept_dns", "tailscale_exit_node",
+                "ollama_custom_url"):
+        assert key in _u._SETTINGS_DEFAULTS, f"missing default: {key}"
+
+
+def test_apply_adds_fox_bool_keys(fresh_config):
+    _u, patch_mod = fresh_config
+    patch_mod.apply()
+    for key in ("local_fallback_enabled", "hostname_prompted",
+                "tailscale_accept_routes", "tailscale_accept_dns"):
+        assert key in _u._SETTINGS_BOOL_KEYS, f"missing bool key: {key}"
+
+
+def test_apply_preserves_upstream_defaults(fresh_config):
+    """Fox additions must be additive; never overwrite upstream defaults."""
+    _u, patch_mod = fresh_config
+    pre_theme = _u._SETTINGS_DEFAULTS["theme"]
+    patch_mod.apply()
+    assert _u._SETTINGS_DEFAULTS["theme"] == pre_theme
+
+
+def test_apply_is_idempotent(fresh_config):
+    _u, patch_mod = fresh_config
+    patch_mod.apply()
+    defaults_count = len(_u._SETTINGS_DEFAULTS)
+    bool_count = len(_u._SETTINGS_BOOL_KEYS)
+    patch_mod.apply()  # second call — no-op
+    assert len(_u._SETTINGS_DEFAULTS) == defaults_count
+    assert len(_u._SETTINGS_BOOL_KEYS) == bool_count
+
+
+# ── Behavioral check: bool-string coercion fix ───────────────────────────
+
+def test_bool_string_false_does_not_flip_to_true(fresh_config):
+    """Pre-patch: bool('false') == True. Patched: 'false' → False."""
+    _u, patch_mod = fresh_config
+    patch_mod.apply()
+    result = _u.save_settings({"hostname_prompted": "false"})
+    assert result.get("hostname_prompted") is False
+
+
+def test_bool_string_true_recognized(fresh_config):
+    _u, patch_mod = fresh_config
+    patch_mod.apply()
+    result = _u.save_settings({"local_fallback_enabled": "true"})
+    assert result.get("local_fallback_enabled") is True
+
+
+def test_bool_native_true_passes_through(fresh_config):
+    _u, patch_mod = fresh_config
+    patch_mod.apply()
+    result = _u.save_settings({"local_fallback_enabled": True})
+    assert result.get("local_fallback_enabled") is True
+
+
+def test_bool_unrecognized_string_is_skipped(fresh_config):
+    """Garbage string for a bool key — skip the setting, don't crash."""
+    _u, patch_mod = fresh_config
+    patch_mod.apply()
+    # No prior value; skip means key absent from result
+    result = _u.save_settings({"local_fallback_enabled": "maybe"})
+    assert "local_fallback_enabled" not in result
+
+
+# ── Anchor drift detection ───────────────────────────────────────────────
+
+def test_anchor_drift_in_get_config_fails_fast(tmp_path, monkeypatch):
+    drifted = _UPSTREAM_CONFIG_SOURCE.replace(
+        "    if not _cfg_cache:\n        reload_config()\n    return _cfg_cache\n",
+        "    return _cfg_cache  # upstream simplified\n",
+    )
+    _install_stub(tmp_path, drifted, monkeypatch)
+    import fox_overlay.webui_patches.config as patch_mod
+    importlib.reload(patch_mod)
+    with pytest.raises(AssertionError, match="anchor expected EXACTLY ONCE"):
+        patch_mod.apply()
+    importlib.reload(patch_mod)
+    for name in list(sys.modules):
+        if name == "api" or name.startswith("api."):
+            del sys.modules[name]
+
+
+def test_signature_drift_in_save_settings_fails_fast(tmp_path, monkeypatch):
+    drifted = _UPSTREAM_CONFIG_SOURCE.replace(
+        "def save_settings(settings: dict) -> dict:",
+        "def save_settings(settings: dict, force: bool = False) -> dict:",
+    )
+    _install_stub(tmp_path, drifted, monkeypatch)
+    import fox_overlay.webui_patches.config as patch_mod
+    importlib.reload(patch_mod)
+    with pytest.raises(AssertionError, match="save_settings signature drift"):
+        patch_mod.apply()
+    importlib.reload(patch_mod)
+    for name in list(sys.modules):
+        if name == "api" or name.startswith("api."):
+            del sys.modules[name]


### PR DESCRIPTION
Phase 6 of v0.6.0 migration. Third of five mid-file monkey-patches. Companion to fork PR fox-in-the-box-ai/hermes-webui#27 (revert `api/config.py` to upstream merge-base).

Closes #190.

## What this re-applies

| Target | Mechanism | Notes |
|--------|-----------|-------|
| `_SETTINGS_DEFAULTS` | direct dict mutation | 9 Fox keys (local_fallback, hostname_prompted, 6 Tailscale, ollama_custom_url) |
| `_SETTINGS_BOOL_KEYS` | direct set mutation | 4 Fox bool keys |
| `get_config()` | substitute_function | mtime-based cache invalidation |
| `reload_config()` | substitute_function (2 subs) | global decl + in-memory cache eviction (#138) |
| `save_settings()` | substitute_function (3 subs) | TS+Ollama URL validation gates + string-aware bool coercion + Ollama probe cache invalidation |

## Why dict/set additions are NOT substitutions

Module-scope mutations (`_SETTINGS_DEFAULTS["x"] = ...`) don't need `inspect.getsource` — direct attribute assignment on the module is simpler and more robust. Sentinel: module-level `_fox_settings_defaults_applied = True`.

## Ordering

Per issue #190 ("MERGE FIRST. Others read its settings."), `apply_all()` now calls `config.apply()` FIRST. (For Phase 6 internal ordering — providers/models had already shipped without depending on config, so no historical violation.)

## Verification

- 123 unit tests pass (112 prior + 11 new config patch)
- Container build with submodule@ca40c82 (fork PR #27 merge):
  - `[fox-overlay] webui_patches.apply_all() complete (3 patch modules)`
  - In-process: all 3 function patches confirmed True
  - `local_fallback_enabled`, `ollama_custom_url` in `_SETTINGS_DEFAULTS`
  - `hostname_prompted` in `_SETTINGS_BOOL_KEYS`
  - All 5 Phase 5 modules still return 200 (`ollama`, `tailscale`, `local-fallback`, `local-models`, `settings/hostname`)
- Phase 4 patches still apply --check clean

## Behavioral test highlight

`test_bool_string_false_does_not_flip_to_true` — locks the fix for the pre-Fox bug where `bool('false')` returned True, silently flipping flags like `hostname_prompted` to True on any string-typed POST. The string-aware coercion catches the obvious truthy/falsy strings; unrecognized strings are skipped (key absent from result) rather than coerced wrong.

## Submodule

`forks/hermes-webui` → `ca40c82` (fork PR #27 merge commit). Auto-merge after CI per Dennis's all-phases authorization.