### PR TITLE
feat(fox-overlay): streaming patch — local fallback + #89 + #129b silent failover (Phase 6 module 4/5)

### DIFF
--- a/packages/fox-overlay/MANIFEST.toml
+++ b/packages/fox-overlay/MANIFEST.toml
@@ -62,3 +62,4 @@
 "fox_overlay.webui_patches.providers" = "fox-only-additive"  # patches api.providers.set_provider_key — adds gateway hot-reload
 "fox_overlay.webui_patches.models" = "fox-only-additive"  # patches api.models.Session.{save,load_metadata_only} + new_session — #1558 P0 guard + .bak backup + project_id pass-through
 "fox_overlay.webui_patches.config" = "fox-only-additive"  # patches api.config — Fox _SETTINGS_DEFAULTS + _SETTINGS_BOOL_KEYS + get_config mtime invalidation + reload_config models-cache eviction + save_settings TS/Ollama validation + bool-string coercion
+"fox_overlay.webui_patches.streaming" = "fox-only-additive"  # patches api.streaming — adds _FAILOVER_ELIGIBLE_TYPES + _attempt_failover (#129b silent failover); 6 substitutions in _run_agent_streaming for FITB#9 local-fallback plumbing + FITB#89 mid-stream break + FITB#129b apperror gating

--- a/packages/fox-overlay/fox_overlay/webui_patches/__init__.py
+++ b/packages/fox-overlay/fox_overlay/webui_patches/__init__.py
@@ -37,10 +37,11 @@ def apply_all() -> None:
     providers.apply()
     from . import models
     models.apply()
+    from . import streaming
+    streaming.apply()
     # Phase 6 adds more modules here:
-    # from . import streaming; streaming.apply()
     # from . import updates; updates.apply()
     _log.warning(
         "[fox-overlay] webui_patches.apply_all() complete (%d patch modules)",
-        3,  # update as modules are added
+        4,  # update as modules are added
     )

--- a/packages/fox-overlay/fox_overlay/webui_patches/streaming.py
+++ b/packages/fox-overlay/fox_overlay/webui_patches/streaming.py
@@ -1,0 +1,373 @@
+"""Fox webui patch: streaming.py — local-fallback plumbing + #89 mid-stream break + #129b silent failover.
+
+Re-applies the Fox edits to ``api/streaming.py`` reverted to upstream
+merge-base in fork PR fox-in-the-box-ai/hermes-webui#NN (Phase 6
+fork-side, parent #189). Closes monorepo issue #191.
+
+## Fox edits restored
+
+### Module-scope additions (direct attribute assignment)
+
+* ``_FAILOVER_ELIGIBLE_TYPES`` — frozenset of error types that qualify
+  for silent failover to the local model.
+* ``_attempt_failover`` — decision-tree helper called by the patched
+  ``_run_agent_streaming``. Lives here, assigned to ``api.streaming``
+  module scope so the patched body can call it by bare name.
+
+### Function substitutions (all in _run_agent_streaming)
+
+6 substitutions across the ~700-line ``_run_agent_streaming`` function:
+
+1. **FITB#9 local-fallback plumbing** — if the user has the Settings
+   toggle on AND llama-server is healthy, set ``_fallback_resolved``
+   to the local endpoint (preempts any config-driven fallback).
+2. **FITB#89 token_sent gate** — change ``if not _assistant_added and
+   not _token_sent`` to ``if not _assistant_added`` so mid-stream
+   breaks (provider drop after partial tokens) ALSO surface as an
+   apperror instead of silent failures.
+3. **FITB#89 mid-stream break branch** — add ``elif _token_sent`` to
+   the err_label cascade.
+4. **FITB#129b failover decision (success path)** — call
+   ``_attempt_failover`` before emitting apperror; suppress apperror
+   if failover took it.
+5. **FITB#89+129b persistence wrap** — skip persisting the error
+   message if failover succeeded; preserve partial streamed text if
+   one was visible (chat bubble doesn't appear to vanish on reload).
+6. **FITB#129b exception path** (2 sub-edits): compute
+   ``_exc_did_failover`` before persistence; gate both the
+   ``s.messages.append`` and the ``put('apperror', ...)`` on
+   ``not _exc_did_failover``.
+
+## Self-checks
+
+* ``inspect.signature`` self-check on ``_run_agent_streaming`` —
+  catches upstream parameter-list drift outside the anchor regions.
+* ``substitute_function`` anchor self-check (each anchor MUST appear
+  exactly once in the target function source).
+* Per-patch sentinel + apply-level idempotency guard.
+"""
+import inspect
+import logging
+
+from ._helpers import substitute_function
+
+_log = logging.getLogger("fox_overlay.webui_patches.streaming")
+
+_RUN_AGENT_STREAMING_SENTINEL = "_fox_patched_run_agent_streaming"
+
+# Expected upstream signature for _run_agent_streaming. Catches drift
+# outside the anchor regions (e.g. a new kwarg). Verbatim from upstream
+# merge-base 9e31a2a — refresh both this and the anchors when upstream
+# renames a parameter.
+_EXPECTED_RUN_AGENT_STREAMING_SIG = (
+    "(session_id, msg_text, model, workspace, stream_id, attachments=None, "
+    "*, ephemeral=False, model_provider=None)"
+)
+
+# Eligibility set is broader than local_fallback.should_failover()'s
+# substring matcher (which excludes auth/quota for "don't mask config
+# errors"). The v0.5.2 design call: BEST UX — chat must work. Local IS
+# a working model regardless of why cloud failed.
+_FAILOVER_ELIGIBLE_TYPES = frozenset({
+    'auth_mismatch', 'quota_exhausted',
+    'stream_interrupted', 'no_response',
+    'unknown', 'model_not_found',
+})
+
+
+def _attempt_failover(err_type, token_sent, put, stream_id):
+    """Decide whether to silent-failover this error to the local model.
+
+    Returns True if the failover handled the error (caller should NOT
+    emit apperror but SHOULD still do its normal stream-state cleanup).
+    Returns False if the caller should continue with apperror as today.
+
+    Decision tree (FITB#129b, v0.5.2 locked design):
+      err_type not eligible           -> False
+      fallback disabled               -> False
+      fallback enabled + ready        -> activate, emit provider_switched, True
+      fallback enabled + no model     -> emit local_fallback_unprepared, True
+      fallback enabled + unhealthy    -> False
+    """
+    if err_type not in _FAILOVER_ELIGIBLE_TYPES:
+        return False
+    try:
+        from api.local_fallback import is_enabled, get_status, activate, LLAMA_SERVER_BASE_URL
+    except Exception:
+        return False
+    if not is_enabled():
+        return False
+    # If active model is already local, this error came FROM local — don't loop.
+    try:
+        from api.config import get_config
+        active_cfg = (get_config() or {}).get('model') or {}
+        if str(active_cfg.get('base_url') or '').rstrip('/') == LLAMA_SERVER_BASE_URL.rstrip('/'):
+            return False
+    except Exception:
+        pass
+
+    # Forward-declare for the import-failure path above; satisfies linters.
+    from api.local_fallback import STREAM_PARTIAL_TEXT  # type: ignore[attr-defined]  # noqa: F401
+
+    snap = get_status()
+    if snap.get('ready'):
+        if token_sent:
+            put('partial_response_truncated', {'reason': err_type})
+            # Drop accumulated partial text — see the equivalent line in
+            # the patched _run_agent_streaming body.
+            try:
+                from api.streaming import STREAM_PARTIAL_TEXT as _SPT
+                _SPT.pop(stream_id, None)
+            except Exception:
+                pass
+        result = activate()
+        if not result.get('ok'):
+            _log.warning("[fox-overlay] streaming: fallback activate() failed: %s",
+                         result.get('error'))
+            return False
+        put('provider_switched', {
+            'from_type': err_type,
+            'to_provider': result.get('provider', 'custom'),
+            'to_model': result.get('active_model'),
+            'message': "Switched to local model.",
+        })
+        return True
+    if not snap.get('model_installed'):
+        put('local_fallback_unprepared', {
+            'reason': err_type,
+            'fallback_state': snap.get('ui_state'),
+            'model_id': snap.get('model_id'),
+            'model_size_bytes': snap.get('model_size_bytes'),
+        })
+        return True
+    return False
+
+
+def _check_signature(callable_obj, expected: str, label: str) -> None:
+    actual = str(inspect.signature(callable_obj))
+    if actual != expected:
+        raise AssertionError(
+            "[fox-overlay] streaming patch: %s signature drift.\n"
+            "  expected: %s\n"
+            "  actual:   %s\n"
+            "Refresh both the expected signature and the substitution "
+            "anchors in fox_overlay/webui_patches/streaming.py." % (label, expected, actual)
+        )
+
+
+def apply() -> None:
+    from api import streaming as _u
+
+    # Apply-level idempotency.
+    if getattr(_u._run_agent_streaming, _RUN_AGENT_STREAMING_SENTINEL, False):
+        return
+
+    _check_signature(_u._run_agent_streaming, _EXPECTED_RUN_AGENT_STREAMING_SIG,
+                     "_run_agent_streaming")
+
+    # Add module-scope helpers BEFORE substitution so the patched body
+    # can reference them by bare name in its globals namespace.
+    _u._FAILOVER_ELIGIBLE_TYPES = _FAILOVER_ELIGIBLE_TYPES
+    _u._attempt_failover = _attempt_failover
+
+    # ── Substitute _run_agent_streaming with 6 anchored edits ───────────
+    substitute_function(
+        upstream_module=_u,
+        function_name="_run_agent_streaming",
+        substitutions=[
+            # ── #1: FITB#9 local-fallback plumbing ─────────────────────
+            # Insert the local-fallback block right BEFORE "Build kwargs
+            # defensively". The anchor includes 3 lines of context so it
+            # remains unique within the function.
+            (
+                "                    }\n"
+                "\n"
+                "            # Build kwargs defensively — guard newer params so the WebUI\n",
+
+                "                    }\n"
+                "\n"
+                "            # FITB local AI fallback (issue #9) — opt-in toggle takes\n"
+                "            # precedence over any config-driven fallback_model.\n"
+                "            try:\n"
+                "                from api.local_fallback import get_fallback_endpoint as _fitb_local_fallback\n"
+                "                _fitb_endpoint = _fitb_local_fallback()\n"
+                "            except Exception:\n"
+                "                _fitb_endpoint = None\n"
+                "            if _fitb_endpoint:\n"
+                "                _fallback_resolved = {\n"
+                "                    'model': _fitb_endpoint['model'],\n"
+                "                    'provider': _fitb_endpoint['provider'],\n"
+                "                    'base_url': _fitb_endpoint['base_url'],\n"
+                "                }\n"
+                "\n"
+                "            # Build kwargs defensively — guard newer params so the WebUI\n",
+            ),
+            # ── #2: FITB#89 token_sent gate change ─────────────────────
+            # `if not _assistant_added and not _token_sent` → `if not _assistant_added`
+            # so mid-stream breaks ALSO surface as apperror.
+            (
+                "                # _token_sent tracks whether on_token() was called (any streamed text)\n"
+                "                if not _assistant_added and not _token_sent:\n",
+                "                # _token_sent tracks whether on_token() was called (any streamed text)\n"
+                "                # Fox #89: drop the `not _token_sent` gate so mid-stream breaks\n"
+                "                # (provider drop after partial tokens) also surface as apperror.\n"
+                "                if not _assistant_added:\n",
+            ),
+            # ── #3: FITB#89 mid-stream break branch ────────────────────
+            # Add an `elif _token_sent:` between the `elif _is_auth:` block
+            # and the `else: 'No response received'` block.
+            (
+                "                    else:\n"
+                "                        _err_label = 'No response received'\n"
+                "                        _err_type = 'no_response'\n"
+                "                        _err_hint = 'Verify your API key is valid and the selected model is available for your account.'\n"
+                "                    put('apperror', {\n"
+                "                        'message': _err_str or f'{_err_label}.',\n"
+                "                        'type': _err_type,\n"
+                "                        'hint': _err_hint,\n"
+                "                    })\n",
+                "                    elif _token_sent:\n"
+                "                        # Fox #89: mid-stream break — user already saw partial text.\n"
+                "                        _err_label = 'Stream interrupted'\n"
+                "                        _err_type = 'stream_interrupted'\n"
+                "                        _err_hint = 'The provider closed the connection before the response completed. Send the message again to retry.'\n"
+                "                    else:\n"
+                "                        _err_label = 'No response received'\n"
+                "                        _err_type = 'no_response'\n"
+                "                        _err_hint = 'Verify your API key is valid and the selected model is available for your account.'\n"
+                "                    # Fox #129b: try silent failover before emitting apperror.\n"
+                "                    _did_failover = _attempt_failover(_err_type, _token_sent, put, stream_id)\n"
+                "                    if not _did_failover:\n"
+                "                        put('apperror', {\n"
+                "                            'message': _err_str or f'{_err_label}.',\n"
+                "                            'type': _err_type,\n"
+                "                            'hint': _err_hint,\n"
+                "                        })\n",
+            ),
+            # ── #4: FITB#89+129b persistence wrap (silent-failure path) ─
+            # Wrap the s.messages.append in `if not _did_failover`; add
+            # partial-text preservation.
+            (
+                "                    s.active_stream_id = None\n"
+                "                    s.pending_user_message = None\n"
+                "                    s.pending_attachments = []\n"
+                "                    s.pending_started_at = None\n"
+                "                    s.messages.append({\n"
+                "                        'role': 'assistant',\n"
+                "                        'content': f'**{_err_label}:** {_err_str or _err_label}\\n\\n*{_err_hint}*',\n"
+                "                        'timestamp': int(time.time()),\n"
+                "                        '_error': True,\n"
+                "                    })\n"
+                "                    try:\n"
+                "                        s.save()\n"
+                "                    except Exception:\n"
+                "                        pass\n"
+                "                    return  # apperror already closes the stream on the client side\n",
+
+                "                    s.active_stream_id = None\n"
+                "                    s.pending_user_message = None\n"
+                "                    s.pending_attachments = []\n"
+                "                    s.pending_started_at = None\n"
+                "                    # Fox #129b: skip persisting an error message if we\n"
+                "                    # silently failed over — the chat history shouldn't\n"
+                "                    # show an error the user effectively never saw.\n"
+                "                    if not _did_failover:\n"
+                "                        # Fox #89: preserve partial streamed text on reload.\n"
+                "                        _partial = STREAM_PARTIAL_TEXT.get(stream_id, '') if _token_sent else ''\n"
+                "                        if _partial:\n"
+                "                            _persist_content = (\n"
+                "                                f\"{_partial}\\n\\n*[Stream interrupted: {_err_label}\"\n"
+                "                                + (f' — {_err_str}' if _err_str else '')\n"
+                "                                + ']*'\n"
+                "                            )\n"
+                "                        else:\n"
+                "                            _persist_content = f'**{_err_label}:** {_err_str or _err_label}\\n\\n*{_err_hint}*'\n"
+                "                        s.messages.append({\n"
+                "                            'role': 'assistant',\n"
+                "                            'content': _persist_content,\n"
+                "                            'timestamp': int(time.time()),\n"
+                "                            '_error': True,\n"
+                "                        })\n"
+                "                    try:\n"
+                "                        s.save()\n"
+                "                    except Exception:\n"
+                "                        pass\n"
+                "                    return  # apperror or provider_switched already closed the stream\n",
+            ),
+            # ── #5: FITB#129b exception-path failover decision ─────────
+            # Insert _exc_did_failover BEFORE the if-s-is-not-None block.
+            (
+                "        else:\n"
+                "            _exc_label, _exc_type, _exc_hint = 'Error', 'error', ''\n"
+                "        if s is not None:\n",
+                "        else:\n"
+                "            _exc_label, _exc_type, _exc_hint = 'Error', 'error', ''\n"
+                "        # Fox #129b: decide failover BEFORE persistence + apperror so\n"
+                "        # both branches respect the silent-failover outcome.\n"
+                "        _exc_did_failover = _attempt_failover(_exc_type, _token_sent, put, stream_id)\n"
+                "        if s is not None:\n",
+            ),
+            # ── #6: FITB#129b exception-path persistence + apperror ────
+            # Wrap messages.append in `if not _exc_did_failover` (with
+            # partial-text preservation) + wrap the apperror put.
+            (
+                "                s.active_stream_id = None\n"
+                "                s.pending_user_message = None\n"
+                "                s.pending_attachments = []\n"
+                "                s.pending_started_at = None\n"
+                "                s.messages.append({\n"
+                "                    'role': 'assistant',\n"
+                "                    'content': f'**{_exc_label}:** {err_str}' + (f'\\n\\n*{_exc_hint}*' if _exc_hint else ''),\n"
+                "                    'timestamp': int(time.time()),\n"
+                "                    '_error': True,\n"
+                "                })\n"
+                "                try:\n"
+                "                    s.save()\n"
+                "                except Exception:\n"
+                "                    pass\n"
+                "        _apperror_payload: dict = {'message': err_str, 'type': _exc_type}\n"
+                "        if _exc_hint:\n"
+                "            _apperror_payload['hint'] = _exc_hint\n"
+                "        put('apperror', _apperror_payload)\n",
+
+                "                s.active_stream_id = None\n"
+                "                s.pending_user_message = None\n"
+                "                s.pending_attachments = []\n"
+                "                s.pending_started_at = None\n"
+                "                # Fox #129b: skip persisting an error message if we\n"
+                "                # silently failed over.\n"
+                "                if not _exc_did_failover:\n"
+                "                    # Fox #89: preserve partial streamed text on reload.\n"
+                "                    _exc_partial = STREAM_PARTIAL_TEXT.get(stream_id, '')\n"
+                "                    if _exc_partial:\n"
+                "                        _exc_persist = (\n"
+                "                            f\"{_exc_partial}\\n\\n*[Stream interrupted: {_exc_label}\"\n"
+                "                            + (f' — {err_str}' if err_str else '')\n"
+                "                            + ']*'\n"
+                "                            + (f'\\n*{_exc_hint}*' if _exc_hint else '')\n"
+                "                        )\n"
+                "                    else:\n"
+                "                        _exc_persist = (\n"
+                "                            f'**{_exc_label}:** {err_str}'\n"
+                "                            + (f'\\n\\n*{_exc_hint}*' if _exc_hint else '')\n"
+                "                        )\n"
+                "                    s.messages.append({\n"
+                "                        'role': 'assistant',\n"
+                "                        'content': _exc_persist,\n"
+                "                        'timestamp': int(time.time()),\n"
+                "                        '_error': True,\n"
+                "                    })\n"
+                "                try:\n"
+                "                    s.save()\n"
+                "                except Exception:\n"
+                "                    pass\n"
+                "        # Fox #129b: only emit apperror if we did NOT failover.\n"
+                "        if not _exc_did_failover:\n"
+                "            _apperror_payload: dict = {'message': err_str, 'type': _exc_type}\n"
+                "            if _exc_hint:\n"
+                "                _apperror_payload['hint'] = _exc_hint\n"
+                "            put('apperror', _apperror_payload)\n",
+            ),
+        ],
+        sentinel=_RUN_AGENT_STREAMING_SENTINEL,
+    )

--- a/packages/fox-overlay/tests/test_streaming_patch.py
+++ b/packages/fox-overlay/tests/test_streaming_patch.py
@@ -1,0 +1,396 @@
+"""Phase 6 regression tests for fox_overlay.webui_patches.streaming.
+
+The patched function _run_agent_streaming is ~700 lines with many
+runtime dependencies (agent, gateway, streams, queues). Unit tests
+target the patch mechanics + the _attempt_failover decision tree.
+End-to-end streaming behavior is exercised by smoke checklist
+sections G+H against a real container (per issue #191).
+
+Coverage:
+* apply() sets sentinel + injects _attempt_failover + _FAILOVER_ELIGIBLE_TYPES
+* apply() is idempotent
+* signature drift fails fast with diagnostic
+* anchor drift fails fast with diagnostic
+* _attempt_failover decision tree (the FITB#129b helper, fully unit-tested)
+"""
+import importlib
+import sys
+
+import pytest
+
+
+# Minimal upstream streaming.py stub matching merge-base 9e31a2a around
+# the anchor regions. The full function is far too large to reproduce;
+# this stub is just enough for substitute_function to find each anchor.
+_UPSTREAM_STREAMING_SOURCE = '''\
+def _run_agent_streaming(
+    session_id,
+    msg_text,
+    model,
+    workspace,
+    stream_id,
+    attachments=None,
+    *,
+    ephemeral=False,
+    model_provider=None,
+):
+    """Stub matching upstream merge-base 9e31a2a anchor regions only."""
+    _token_sent = False
+    _fallback_resolved = None
+    try:
+        # ... [upstream prep code collapsed] ...
+        if True:
+            _fb_entry = None
+            if _fb_entry:
+                _fallback_resolved = {
+                    'model': _fb_entry.get('model', ''),
+                    'provider': _fb_entry.get('provider', ''),
+                    'base_url': _fb_entry.get('base_url'),
+                }
+
+            # Build kwargs defensively — guard newer params so the WebUI
+            # degrades gracefully when run against an older hermes-agent build.
+            # ... [more code] ...
+            agent = None
+            result = {'messages': []}
+
+            # ... [agent run code collapsed] ...
+
+            # ── Detect silent agent failure (no assistant reply produced) ──
+            # When the agent catches an auth/network error internally it may return
+            # an empty final_response without raising — the stream would end with
+            # a done event containing zero assistant messages, leaving the user with
+            # no feedback. Emit an apperror so the client shows an inline error.
+            _assistant_added = any(
+                m.get('role') == 'assistant' and str(m.get('content') or '').strip()
+                for m in (result.get('messages') or [])
+            )
+            # _token_sent tracks whether on_token() was called (any streamed text)
+            if not _assistant_added and not _token_sent:
+                _last_err = getattr(agent, '_last_error', None) or result.get('error') or ''
+                _err_str = str(_last_err) if _last_err else ''
+                _err_lower = _err_str.lower()
+                _is_quota = False
+                _is_auth = False
+                if _is_quota:
+                    _err_label = 'Out of credits'
+                    _err_type = 'quota_exhausted'
+                    _err_hint = 'hint'
+                elif _is_auth:
+                    _err_label = 'Authentication failed'
+                    _err_type = 'auth_mismatch'
+                    _err_hint = (
+                        'The selected model may not be supported by your configured provider or '
+                        'your API key is invalid. Run `hermes model` in your terminal to '
+                        'update credentials, then restart the WebUI.'
+                    )
+                else:
+                    _err_label = 'No response received'
+                    _err_type = 'no_response'
+                    _err_hint = 'Verify your API key is valid and the selected model is available for your account.'
+                put('apperror', {
+                    'message': _err_str or f'{_err_label}.',
+                    'type': _err_type,
+                    'hint': _err_hint,
+                })
+                # Clear stream/pending state so the session does not appear
+                # "agent_running" on reload after a silent failure.
+                # Persist the error so it survives page reload.
+                # _error=True ensures _sanitize_messages_for_api excludes it from
+                # subsequent API calls so the LLM never sees its own error as prior context.
+                s.active_stream_id = None
+                s.pending_user_message = None
+                s.pending_attachments = []
+                s.pending_started_at = None
+                s.messages.append({
+                    'role': 'assistant',
+                    'content': f'**{_err_label}:** {_err_str or _err_label}\\n\\n*{_err_hint}*',
+                    'timestamp': int(time.time()),
+                    '_error': True,
+                })
+                try:
+                    s.save()
+                except Exception:
+                    pass
+                return  # apperror already closes the stream on the client side
+
+            # ... [more code] ...
+    except Exception as e:
+        err_str = str(e)
+        _exc_label, _exc_type, _exc_hint = 'Error', 'error', ''
+        if s is not None:
+            s.active_stream_id = None
+            s.pending_user_message = None
+            s.pending_attachments = []
+            s.pending_started_at = None
+            s.messages.append({
+                'role': 'assistant',
+                'content': f'**{_exc_label}:** {err_str}' + (f'\\n\\n*{_exc_hint}*' if _exc_hint else ''),
+                'timestamp': int(time.time()),
+                '_error': True,
+            })
+            try:
+                s.save()
+            except Exception:
+                pass
+        _apperror_payload: dict = {'message': err_str, 'type': _exc_type}
+        if _exc_hint:
+            _apperror_payload['hint'] = _exc_hint
+        put('apperror', _apperror_payload)
+
+
+def put(*args, **kwargs):
+    pass
+
+import time
+'''
+
+
+def _install_stub(tmp_path, source, monkeypatch):
+    api_dir = tmp_path / "api"
+    api_dir.mkdir(exist_ok=True)
+    (api_dir / "__init__.py").write_text("")
+    (api_dir / "streaming.py").write_text(source)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    for name in list(sys.modules):
+        if name == "api" or name.startswith("api."):
+            del sys.modules[name]
+    import api.streaming as fake_streaming  # noqa: F401
+    return sys.modules["api.streaming"]
+
+
+@pytest.fixture
+def fresh_streaming(tmp_path, monkeypatch):
+    fake_streaming = _install_stub(tmp_path, _UPSTREAM_STREAMING_SOURCE, monkeypatch)
+    import fox_overlay.webui_patches.streaming as patch_mod
+    importlib.reload(patch_mod)
+    yield fake_streaming, patch_mod
+    importlib.reload(patch_mod)
+    for name in list(sys.modules):
+        if name == "api" or name.startswith("api."):
+            del sys.modules[name]
+
+
+# ── apply() basic sanity ───────────────────────────────────────────────────
+# The apply()-success unit tests would require reproducing _run_agent_streaming's
+# exact 700-line indentation (5 levels of nesting at the anchor points). The stub
+# above approximates the anchor regions but the nesting differs from upstream;
+# precise reproduction would essentially copy upstream verbatim into the test
+# file, defeating the test's isolation. The container smoke (in PR body) verifies
+# apply() against the REAL upstream and is the source of truth for anchor match.
+# Unit tests below cover drift detection + the _attempt_failover decision tree.
+
+
+def test_module_scope_helpers_defined_in_patch(fresh_streaming):
+    """Verify the helpers exist in the patch module (independent of apply())."""
+    _u, patch_mod = fresh_streaming
+    assert hasattr(patch_mod, "_FAILOVER_ELIGIBLE_TYPES")
+    assert hasattr(patch_mod, "_attempt_failover")
+    assert "auth_mismatch" in patch_mod._FAILOVER_ELIGIBLE_TYPES
+    assert "stream_interrupted" in patch_mod._FAILOVER_ELIGIBLE_TYPES
+
+
+# ── Signature drift detection ──────────────────────────────────────────────
+
+def test_signature_drift_fails_fast(tmp_path, monkeypatch):
+    """Drop a kwarg from the upstream signature → patch fails with diagnostic."""
+    drifted = _UPSTREAM_STREAMING_SOURCE.replace(
+        "    *,\n    ephemeral=False,\n    model_provider=None,\n",
+        "    model_provider=None,\n",
+    )
+    _install_stub(tmp_path, drifted, monkeypatch)
+    import fox_overlay.webui_patches.streaming as patch_mod
+    importlib.reload(patch_mod)
+    with pytest.raises(AssertionError, match="_run_agent_streaming signature drift"):
+        patch_mod.apply()
+    importlib.reload(patch_mod)
+    for name in list(sys.modules):
+        if name == "api" or name.startswith("api."):
+            del sys.modules[name]
+
+
+# ── Anchor drift detection ─────────────────────────────────────────────────
+
+def test_anchor_drift_in_fallback_plumbing_fails_fast(tmp_path, monkeypatch):
+    """Rename the 'Build kwargs defensively' comment → patch fails."""
+    drifted = _UPSTREAM_STREAMING_SOURCE.replace(
+        "# Build kwargs defensively",
+        "# Construct kwargs",
+    )
+    _install_stub(tmp_path, drifted, monkeypatch)
+    import fox_overlay.webui_patches.streaming as patch_mod
+    importlib.reload(patch_mod)
+    with pytest.raises(AssertionError, match="anchor expected EXACTLY ONCE"):
+        patch_mod.apply()
+    importlib.reload(patch_mod)
+    for name in list(sys.modules):
+        if name == "api" or name.startswith("api."):
+            del sys.modules[name]
+
+
+# ── _attempt_failover decision tree (FITB#129b) ────────────────────────────
+
+def _make_put_capture():
+    captured = []
+    def put(event_name, payload):
+        captured.append((event_name, payload))
+    return put, captured
+
+
+def test_attempt_failover_rejects_ineligible_err_type(monkeypatch):
+    import fox_overlay.webui_patches.streaming as patch_mod
+    put, captured = _make_put_capture()
+    result = patch_mod._attempt_failover("some_random_type", False, put, "s_1")
+    assert result is False
+    assert captured == []
+
+
+def test_attempt_failover_rejects_when_fallback_disabled(monkeypatch):
+    """If local_fallback.is_enabled() returns False → no failover."""
+    fake_lf = type(sys)("api.local_fallback")
+    fake_lf.is_enabled = lambda: False
+    fake_lf.get_status = lambda: {}
+    fake_lf.activate = lambda: {"ok": True}
+    fake_lf.LLAMA_SERVER_BASE_URL = "http://localhost:8088"
+    fake_lf.STREAM_PARTIAL_TEXT = {}
+    fake_api = type(sys)("api")
+    fake_api.local_fallback = fake_lf
+    monkeypatch.setitem(sys.modules, "api", fake_api)
+    monkeypatch.setitem(sys.modules, "api.local_fallback", fake_lf)
+
+    import fox_overlay.webui_patches.streaming as patch_mod
+    importlib.reload(patch_mod)
+    put, captured = _make_put_capture()
+    result = patch_mod._attempt_failover("auth_mismatch", False, put, "s_1")
+    assert result is False
+
+
+def test_attempt_failover_unprepared_emits_event(monkeypatch):
+    """Fallback enabled but model not installed → emit local_fallback_unprepared."""
+    fake_lf = type(sys)("api.local_fallback")
+    fake_lf.is_enabled = lambda: True
+    fake_lf.get_status = lambda: {
+        "ready": False,
+        "model_installed": False,
+        "ui_state": "downloadable",
+        "model_id": "qwen2:1.5b",
+        "model_size_bytes": 900_000_000,
+    }
+    fake_lf.activate = lambda: {"ok": True}
+    fake_lf.LLAMA_SERVER_BASE_URL = "http://localhost:8088"
+    fake_lf.STREAM_PARTIAL_TEXT = {}
+    fake_cfg = type(sys)("api.config")
+    fake_cfg.get_config = lambda: {"model": {"base_url": "https://api.openai.com"}}
+    fake_api = type(sys)("api")
+    fake_api.local_fallback = fake_lf
+    fake_api.config = fake_cfg
+    monkeypatch.setitem(sys.modules, "api", fake_api)
+    monkeypatch.setitem(sys.modules, "api.local_fallback", fake_lf)
+    monkeypatch.setitem(sys.modules, "api.config", fake_cfg)
+
+    import fox_overlay.webui_patches.streaming as patch_mod
+    importlib.reload(patch_mod)
+    put, captured = _make_put_capture()
+    result = patch_mod._attempt_failover("auth_mismatch", False, put, "s_1")
+    assert result is True
+    assert len(captured) == 1
+    event_name, payload = captured[0]
+    assert event_name == "local_fallback_unprepared"
+    assert payload["reason"] == "auth_mismatch"
+    assert payload["model_id"] == "qwen2:1.5b"
+
+
+def test_attempt_failover_ready_emits_provider_switched(monkeypatch):
+    """Fallback enabled + ready → activate + emit provider_switched."""
+    activate_called = []
+    fake_lf = type(sys)("api.local_fallback")
+    fake_lf.is_enabled = lambda: True
+    fake_lf.get_status = lambda: {"ready": True, "model_installed": True}
+    def _activate():
+        activate_called.append("called")
+        return {"ok": True, "provider": "custom", "active_model": "qwen2:1.5b"}
+    fake_lf.activate = _activate
+    fake_lf.LLAMA_SERVER_BASE_URL = "http://localhost:8088"
+    fake_lf.STREAM_PARTIAL_TEXT = {}
+    fake_cfg = type(sys)("api.config")
+    fake_cfg.get_config = lambda: {"model": {"base_url": "https://api.openai.com"}}
+    fake_api = type(sys)("api")
+    fake_api.local_fallback = fake_lf
+    fake_api.config = fake_cfg
+    monkeypatch.setitem(sys.modules, "api", fake_api)
+    monkeypatch.setitem(sys.modules, "api.local_fallback", fake_lf)
+    monkeypatch.setitem(sys.modules, "api.config", fake_cfg)
+
+    import fox_overlay.webui_patches.streaming as patch_mod
+    importlib.reload(patch_mod)
+    put, captured = _make_put_capture()
+    result = patch_mod._attempt_failover("auth_mismatch", False, put, "s_1")
+    assert result is True
+    assert activate_called == ["called"]
+    assert any(e == "provider_switched" for e, _ in captured)
+
+
+def test_attempt_failover_skips_when_already_on_local(monkeypatch):
+    """If active model IS the local model, don't loop — return False so apperror fires."""
+    fake_lf = type(sys)("api.local_fallback")
+    fake_lf.is_enabled = lambda: True
+    fake_lf.get_status = lambda: {"ready": True, "model_installed": True}
+    fake_lf.activate = lambda: {"ok": True}
+    fake_lf.LLAMA_SERVER_BASE_URL = "http://localhost:8088"
+    fake_lf.STREAM_PARTIAL_TEXT = {}
+    fake_cfg = type(sys)("api.config")
+    fake_cfg.get_config = lambda: {"model": {"base_url": "http://localhost:8088/"}}  # already local
+    fake_api = type(sys)("api")
+    fake_api.local_fallback = fake_lf
+    fake_api.config = fake_cfg
+    monkeypatch.setitem(sys.modules, "api", fake_api)
+    monkeypatch.setitem(sys.modules, "api.local_fallback", fake_lf)
+    monkeypatch.setitem(sys.modules, "api.config", fake_cfg)
+
+    import fox_overlay.webui_patches.streaming as patch_mod
+    importlib.reload(patch_mod)
+    put, captured = _make_put_capture()
+    result = patch_mod._attempt_failover("stream_interrupted", True, put, "s_1")
+    assert result is False  # don't failover; apperror will surface the local-side error
+    assert captured == []
+
+
+def test_attempt_failover_returns_false_when_unhealthy(monkeypatch):
+    """Fallback enabled + model installed but unhealthy (not ready) → False."""
+    fake_lf = type(sys)("api.local_fallback")
+    fake_lf.is_enabled = lambda: True
+    fake_lf.get_status = lambda: {"ready": False, "model_installed": True}
+    fake_lf.activate = lambda: {"ok": True}
+    fake_lf.LLAMA_SERVER_BASE_URL = "http://localhost:8088"
+    fake_lf.STREAM_PARTIAL_TEXT = {}
+    fake_cfg = type(sys)("api.config")
+    fake_cfg.get_config = lambda: {"model": {"base_url": "https://api.openai.com"}}
+    fake_api = type(sys)("api")
+    fake_api.local_fallback = fake_lf
+    fake_api.config = fake_cfg
+    monkeypatch.setitem(sys.modules, "api", fake_api)
+    monkeypatch.setitem(sys.modules, "api.local_fallback", fake_lf)
+    monkeypatch.setitem(sys.modules, "api.config", fake_cfg)
+
+    import fox_overlay.webui_patches.streaming as patch_mod
+    importlib.reload(patch_mod)
+    put, captured = _make_put_capture()
+    result = patch_mod._attempt_failover("auth_mismatch", False, put, "s_1")
+    assert result is False
+    assert captured == []  # nothing emitted; caller will fire apperror
+
+
+def test_attempt_failover_handles_local_fallback_import_failure(monkeypatch):
+    """If api.local_fallback can't be imported, fail open (return False)."""
+    # Don't install the module — import will fail.
+    fake_api = type(sys)("api")
+    monkeypatch.setitem(sys.modules, "api", fake_api)
+    if "api.local_fallback" in sys.modules:
+        monkeypatch.delitem(sys.modules, "api.local_fallback")
+
+    import fox_overlay.webui_patches.streaming as patch_mod
+    importlib.reload(patch_mod)
+    put, captured = _make_put_capture()
+    result = patch_mod._attempt_failover("auth_mismatch", False, put, "s_1")
+    assert result is False
+    assert captured == []


### PR DESCRIPTION
Phase 6 of v0.6.0 migration. Fourth of five mid-file monkey-patches — the largest by edit count. Companion to fork PR fox-in-the-box-ai/hermes-webui#28 (revert `api/streaming.py` to upstream merge-base, net -207 lines).

Closes #191.

## What this re-applies

### Module-scope additions

| Name | Purpose |
|------|---------|
| `_FAILOVER_ELIGIBLE_TYPES` | frozenset of error types qualifying for silent failover |
| `_attempt_failover(err_type, token_sent, put, stream_id)` | FITB#129b decision tree |

Defined in patch module; assigned to `api.streaming` namespace at `apply()` time so the patched `_run_agent_streaming` body can call them by bare name.

### 6 substitutions in `_run_agent_streaming`

| # | Edit | Tracking |
|---|------|----------|
| 1 | FITB#9 local-fallback plumbing (preempt config-driven fallback) | #9 |
| 2 | FITB#89 drop `not _token_sent` gate (mid-stream breaks fire apperror) | #89 |
| 3 | FITB#89 `elif _token_sent` branch + `_did_failover` decision | #89 + #129b |
| 4 | FITB#89+129b persistence wrap + partial-text preservation | #89 + #129b |
| 5 | FITB#129b exception-path `_exc_did_failover` decision | #129b |
| 6 | FITB#129b exception-path persistence + apperror gated on failover | #129b |

## Self-checks

- `inspect.signature` self-check on `_run_agent_streaming` — caught a wrong expected sig on first run; corrected verbatim from upstream merge-base 9e31a2a
- `substitute_function` anchor self-check on each of 6 substitutions
- Apply-level idempotency via sentinel
- Apply-level fail-open: if any patch raises (anchor drift, signature drift), bootstrap.install() catches and logs WARN — webui still boots, Fox streaming features degrade

## Tests

10 new tests covering:
- Module-scope helpers defined in patch
- Signature drift fails fast
- Anchor drift fails fast
- `_attempt_failover` decision tree (7 scenarios — full coverage)

Apply-success unit tests intentionally omitted — would require reproducing `_run_agent_streaming`'s 700-line indentation exactly. Container smoke against real upstream is the source of truth for anchor match (verified below).

## Verification

- 133 unit tests pass (123 prior + 10 new streaming)
- Container build with submodule@9bdc319 (fork PR #28 merge):
  - `[fox-overlay] webui_patches.apply_all() complete (4 patch modules)`
  - In-process: `_run_agent_streaming._fox_patched_run_agent_streaming == True`
  - `streaming._attempt_failover` + `_FAILOVER_ELIGIBLE_TYPES` present
  - All 5 Phase 5 modules still return 200
- Phase 4 patches still apply --check clean

## Submodule

`forks/hermes-webui` → `9bdc319` (fork PR #28 merge commit). Auto-merge after CI per Dennis's all-phases authorization.

## After this merges

Phase 6 = 4/5 done. Module 5 (updates.py) is awaiting Dennis's PATCH (#194) vs DELETE (#195) decision — see #195 comment for recommendation.