### PR TITLE
feat(fox-overlay): Phase 7 — onboarding wholesale-replace + setup files + .fox-removals consumer

### DIFF
--- a/packages/fox-overlay/MANIFEST.toml
+++ b/packages/fox-overlay/MANIFEST.toml
@@ -20,6 +20,10 @@
 "onboarding-preview.js" = "fox-only"
 "fallback-polish.js" = "fox-only"
 "hostname-prompt.js" = "fox-only"
+# Phase 7 — Fox onboarding wizard static files (moved from fork's static/setup.* after Phase 7a removed them):
+"setup.html" = "fox-only"
+"setup.css" = "fox-only"
+"setup.js" = "fox-only"
 
 [python]
 # Phase 3 — agent-side overlay. Three monkey-patch modules applied via
@@ -52,6 +56,7 @@
 "fox_overlay.webui_modules.local_fallback" = "fox-only-additive"  # claims /api/local-fallback/ (was forks/hermes-webui/api/local_fallback.py)
 "fox_overlay.webui_modules.models_download" = "fox-only-additive"  # claims /api/local-models (bare + sub-paths) (was forks/hermes-webui/api/models_download.py)
 "fox_overlay.webui_modules.hostname" = "fox-only-additive"  # claims /api/settings/hostname (bare + /dismiss-prompt) (was forks/hermes-webui/api/hostname.py)
+"fox_overlay.webui_modules.onboarding" = "fox-only-additive"  # Phase 7: claims /setup (bare) + /api/setup/; exports _write_env_key for hostname (was forks/hermes-webui/api/onboarding.py)
 
 # Phase 6 — webui mid-file monkey-patches. Fork files are restored to
 # virgin upstream content; these modules re-apply Fox behavior at runtime

--- a/packages/fox-overlay/fox_overlay/webui_modules/__init__.py
+++ b/packages/fox-overlay/fox_overlay/webui_modules/__init__.py
@@ -12,8 +12,9 @@ session_recovery lands last (longest smoke + #129 failover-engine
 coupling). See `docs/architecture/v0.6.0-github-breakdown-v2.md` §item
 14.
 """
+from . import onboarding  # noqa: F401  -- registers /setup (bare) + /api/setup/; provides _write_env_key for hostname
 from . import ollama  # noqa: F401  -- registers /api/ollama/ at import
 from . import tailscale  # noqa: F401  -- registers /api/tailscale/ at import
 from . import local_fallback  # noqa: F401  -- registers /api/local-fallback/ at import
 from . import models_download  # noqa: F401  -- registers /api/local-models (bare) at import
-from . import hostname  # noqa: F401  -- registers /api/settings/hostname (bare) at import
+from . import hostname  # noqa: F401  -- registers /api/settings/hostname (bare); imports _write_env_key from onboarding

--- a/packages/fox-overlay/fox_overlay/webui_modules/hostname.py
+++ b/packages/fox-overlay/fox_overlay/webui_modules/hostname.py
@@ -20,7 +20,10 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
-from api.onboarding import _write_env_key
+# Phase 7 (v0.6.0): _write_env_key moved from api.onboarding (fork removed
+# the file) to fox_overlay.webui_modules.onboarding. Same function, same
+# behavior — just relocated to the overlay package.
+from fox_overlay.webui_modules.onboarding import _write_env_key
 
 logger = logging.getLogger(__name__)
 
@@ -285,10 +288,9 @@ def handle_dismiss_hostname_prompt(handler, body: dict) -> dict[str, Any]:
 # /api/settings/hostname (GET + POST) and the /dismiss-prompt sub-path
 # (POST). Wrapper does its own boundary check.
 #
-# Pre-existing coupling: `from api.onboarding import _write_env_key`
-# at module top stays intact. Phase 7 (wholesale-replace onboarding
-# via overlay) will need to keep _write_env_key reachable or update
-# this import.
+# Phase 7 update: `_write_env_key` now imported from
+# fox_overlay.webui_modules.onboarding (was: api.onboarding before
+# fork removed the file in Phase 7a). Same function, no behavior change.
 # ──────────────────────────────────────────────────────────────────────
 from fox_overlay import dispatch  # noqa: E402
 

--- a/packages/fox-overlay/fox_overlay/webui_modules/onboarding.py
+++ b/packages/fox-overlay/fox_overlay/webui_modules/onboarding.py
@@ -1,0 +1,359 @@
+"""Hermes Web UI -- Onboarding wizard backend.
+
+Provides the /setup page and /api/setup/* endpoints for first-run configuration.
+The redirect middleware sends users to /setup until onboarding is complete.
+
+Part of Fox in the Box (issue #28).
+"""
+
+import json
+import logging
+import os
+import subprocess
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# ── Onboarding state file ────────────────────────────────────────────────────
+
+ONBOARDING_PATH = Path(os.environ.get("ONBOARDING_PATH", "/data/config/onboarding.json"))
+
+# ── Paths exempt from redirect ───────────────────────────────────────────────
+
+# Wizard probes Ollama and the bundled local-fallback during boot to render
+# the local-model fast-paths on Step 1 (#69). Without these prefixes the
+# probes 302 to /setup, fetch follows, JSON.parse fails on HTML, the .catch
+# in setup.js silently zeros state.ollama / state.localFallback, and the
+# detection boxes never render — even when Ollama is running on the host.
+_SETUP_PREFIXES = (
+    "/setup",
+    "/api/setup/",
+    "/api/ollama/",
+    "/api/local-fallback/",
+    "/static/setup.",
+    "/health",
+    "/static/favicon",
+)
+
+
+def onboarding_complete() -> bool:
+    """Check whether onboarding has been completed.
+
+    Reads either of two state surfaces — historical FITB
+    `onboarding.json:completed` and Hermes WebUI's
+    `settings.json:onboarding_completed` — and returns True if either is
+    set. Issue #11 added the `settings.json` write so future code that
+    sets it directly (e.g. CLI bootstrappers) is honoured by the
+    redirect middleware. Either flag flipping unlocks the chat UI.
+    """
+    try:
+        with open(ONBOARDING_PATH) as f:
+            if json.load(f).get("completed", False) is True:
+                return True
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        pass
+    try:
+        from api.config import load_settings
+        if load_settings().get("onboarding_completed") is True:
+            return True
+    except Exception:  # broad on purpose — settings are auxiliary state
+        pass
+    return False
+
+
+def is_setup_path(path: str) -> bool:
+    """Return True if the request path is exempt from the onboarding redirect."""
+    return any(path.startswith(prefix) for prefix in _SETUP_PREFIXES)
+
+
+def should_redirect_to_setup(path: str) -> bool:
+    """Return True if the request should be redirected to /setup."""
+    if onboarding_complete():
+        return False
+    if is_setup_path(path):
+        return False
+    return True
+
+
+def redirect_to_setup(handler) -> None:
+    """Send a 302 redirect to /setup."""
+    handler.send_response(302)
+    handler.send_header("Location", "/setup")
+    handler.send_header("Content-Length", "0")
+    handler.end_headers()
+
+
+# ── ENV file helpers ─────────────────────────────────────────────────────────
+
+_ENV_PATH = Path(os.environ.get("HERMES_ENV_PATH", "/data/config/hermes.env"))
+
+
+def _write_env_key(key: str, value: str) -> None:
+    """Write or update a key=value pair in the env file.
+
+    Creates the file and parent directory if they do not exist.
+    Preserves existing lines. Updates in-place if key already present.
+    """
+    _ENV_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+    lines: list[str] = []
+    if _ENV_PATH.exists():
+        lines = _ENV_PATH.read_text(encoding="utf-8").splitlines()
+
+    found = False
+    for i, raw in enumerate(lines):
+        stripped = raw.strip()
+        if stripped and not stripped.startswith("#") and "=" in stripped:
+            existing_key = stripped.split("=", 1)[0].strip()
+            if existing_key == key:
+                lines[i] = f"{key}={value}"
+                found = True
+                break
+
+    if not found:
+        if lines and lines[-1].strip():
+            lines.append("")
+        lines.append(f"{key}={value}")
+
+    _ENV_PATH.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+# ── Setup route handlers ─────────────────────────────────────────────────────
+
+
+def handle_setup_page(handler) -> None:
+    """Serve the setup.html page from overlay's webui_static (post-Phase-7)."""
+    # Phase 7 (v0.6.0): setup.html moved from fork's static/ to overlay's
+    # webui_static/. Read from overlay-local path; do NOT depend on
+    # api.config.REPO_ROOT (fork-side concept).
+    from pathlib import Path as _Path
+    setup_path = _Path(__file__).resolve().parent.parent.parent / "webui_static" / "setup.html"
+    if not setup_path.exists():
+        handler.send_response(500)
+        handler.send_header("Content-Type", "text/plain")
+        body = b"Setup page not found"
+        handler.send_header("Content-Length", str(len(body)))
+        handler.end_headers()
+        handler.wfile.write(body)
+        return
+    html = setup_path.read_bytes()
+    handler.send_response(200)
+    handler.send_header("Content-Type", "text/html; charset=utf-8")
+    handler.send_header("Content-Length", str(len(html)))
+    handler.send_header("Cache-Control", "no-store")
+    handler.end_headers()
+    handler.wfile.write(html)
+
+
+def handle_setup_openrouter(handler, body: dict) -> dict:
+    """Validate and persist an OpenRouter API key.
+
+    Returns a result dict. Never logs the key value.
+    """
+    key = body.get("key", "")
+    if not isinstance(key, str):
+        return {"ok": False, "error": "Key must be a string."}
+    key = key.strip()
+    if not key:
+        return {"ok": False, "error": "API key is required."}
+    if not key.startswith("sk-"):
+        return {"ok": False, "error": "Key must start with sk-."}
+    if len(key) > 512:
+        return {"ok": False, "error": "Key is too long."}
+
+    try:
+        _write_env_key("OPENROUTER_API_KEY", key)
+    except OSError as exc:
+        logger.error("Failed to write env file: %s", exc)
+        return {"ok": False, "error": "Failed to save key."}
+
+    return {"ok": True}
+
+
+def handle_setup_complete(handler, body: dict) -> dict:
+    """Mark onboarding as complete and write the state files."""
+    tailscale_connected = bool(body.get("tailscale_connected", False))
+    return _mark_onboarding_complete(
+        skipped=False,
+        extra={"tailscale_connected": tailscale_connected},
+    )
+
+
+def handle_setup_skip(handler, body: dict) -> dict:
+    """Mark onboarding as skipped (no API key collected). Issue #11.
+
+    Provides an exit hatch for users who want to configure providers
+    later via Settings → Providers, or who'll rely on local Ollama
+    (#66). Sets the same completion flags as a normal finish — the
+    redirect middleware unlocks the main UI immediately.
+    """
+    return _mark_onboarding_complete(skipped=True)
+
+
+def _mark_onboarding_complete(*, skipped: bool, extra: dict | None = None) -> dict:
+    """Write both `onboarding.json` and `settings.json:onboarding_completed`.
+
+    Two state surfaces are kept in sync (issue #11) so the redirect
+    middleware and the WebUI settings panel agree. Failure to write
+    settings.json is non-fatal — onboarding.json is the authoritative
+    flag for the redirect.
+    """
+    ONBOARDING_PATH.parent.mkdir(parents=True, exist_ok=True)
+    state = {
+        "completed": True,
+        "completed_at": datetime.now(timezone.utc).isoformat(),
+        "skipped": bool(skipped),
+    }
+    if extra:
+        state.update(extra)
+    ONBOARDING_PATH.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+
+    # Mirror to settings.json:onboarding_completed so any code path that
+    # consults settings (e.g. future CLI bootstrappers) sees the same truth.
+    try:
+        from api.config import load_settings, save_settings
+        s = load_settings()
+        s["onboarding_completed"] = True
+        save_settings(s)
+    except Exception as exc:
+        logger.debug("Could not mirror onboarding flag to settings.json: %s", exc)
+
+    return {"ok": True, "skipped": bool(skipped)}
+
+
+# ── Welcome content ─────────────────────────────────────────────────────────
+
+# Externalized so the welcome message can be edited per install without a
+# code change (issue #11 AC: "Script is externalised — editable without
+# code change"). Plain text, paragraphs separated by blank lines. The
+# default below ships in packages/integration/default-configs/onboarding.md
+# and is copied into /data/config on first container run by entrypoint.sh.
+
+_ONBOARDING_MD_PATH = Path(os.environ.get(
+    "ONBOARDING_MD_PATH", "/data/config/onboarding.md"
+))
+
+_DEFAULT_WELCOME = (
+    "Let's get you set up. This will only take a minute.\n\n"
+    "Bring an OpenRouter API key for cloud models, or skip this wizard "
+    "if you're running a local AI on your computer (Ollama, LM Studio, "
+    "etc.) — you can configure providers any time from Settings."
+)
+
+
+def read_welcome_text() -> str:
+    """Return the welcome paragraph(s) for the wizard's first step.
+    Reads /data/config/onboarding.md if present, falls back to the
+    bundled default."""
+    try:
+        if _ONBOARDING_MD_PATH.exists():
+            text = _ONBOARDING_MD_PATH.read_text(encoding="utf-8").strip()
+            if text:
+                return text
+    except OSError as exc:
+        logger.debug("Could not read %s: %s", _ONBOARDING_MD_PATH, exc)
+    return _DEFAULT_WELCOME
+
+
+def handle_setup_welcome(handler) -> dict:
+    """GET /api/setup/welcome — returns the (editable) welcome text."""
+    return {"text": read_welcome_text()}
+
+
+def handle_setup_restart(handler) -> dict:
+    """Restart hermes-gateway and hermes-webui via supervisorctl."""
+    try:
+        result = subprocess.run(
+            [
+                "supervisorctl",
+                "-c", "/etc/supervisor/supervisord.conf",
+                "restart", "hermes-gateway", "hermes-webui",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode == 0:
+            return {"ok": True}
+        return {"ok": False, "error": result.stderr.strip() or "Restart failed."}
+    except FileNotFoundError:
+        return {"ok": False, "error": "supervisorctl not found."}
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "error": "Restart timed out."}
+    except OSError as exc:
+        return {"ok": False, "error": str(exc)}
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Fox dispatcher integration — Phase 7 of v0.6.0 migration.
+# Three dispatcher registrations:
+#   * GET  /setup            (allow_bare=True) — handle_setup_page
+#   * GET  /api/setup/       — handle_setup_welcome
+#   * POST /api/setup/       — handle_setup_{openrouter,complete,skip,restart}
+# api.helpers lazy-imported inside each wrapper (see ollama.py rationale).
+#
+# `_write_env_key` (defined above at line ~93) is also exported by name so
+# fox_overlay.webui_modules.hostname can import it from here (pre-Phase-7
+# hostname read it from api.onboarding — fork's api/onboarding.py removed
+# in fork PR #30 so the import had to move).
+# ──────────────────────────────────────────────────────────────────────
+from fox_overlay import dispatch  # noqa: E402
+
+
+def _handle_get(handler, parsed) -> bool:
+    """GET /setup — returns True if handled, False to fall through.
+
+    allow_bare=True boundary: must reject /setupX adjacency. The single
+    exact-match check below does this naturally (any /setupX path fails
+    the == check and returns False).
+    """
+    if parsed.path == "/setup":
+        handle_setup_page(handler)
+        return True
+    return False
+
+
+def _handle_api_setup_get(handler, parsed) -> bool:
+    """GET /api/setup/* — returns True if handled, False to fall through."""
+    from api.helpers import j
+
+    if parsed.path == "/api/setup/welcome":
+        j(handler, handle_setup_welcome(handler))
+        return True
+    return False
+
+
+def _handle_api_setup_post(handler, parsed) -> bool:
+    """POST /api/setup/* — returns True if handled, False to fall through."""
+    from api.helpers import j, read_body
+
+    body = read_body(handler)
+
+    if parsed.path == "/api/setup/openrouter":
+        result = handle_setup_openrouter(handler, body)
+        j(handler, result)  # pre-migration: j(handler, result) no ok-check
+        return True
+
+    if parsed.path == "/api/setup/complete":
+        result = handle_setup_complete(handler, body)
+        j(handler, result)
+        return True
+
+    if parsed.path == "/api/setup/restart":
+        result = handle_setup_restart(handler)
+        j(handler, result)
+        return True
+
+    if parsed.path == "/api/setup/skip":
+        result = handle_setup_skip(handler, body)
+        j(handler, result)
+        return True
+
+    return False
+
+
+dispatch.register_get("/setup", _handle_get, allow_bare=True)
+dispatch.register_get("/api/setup/", _handle_api_setup_get)
+dispatch.register_post("/api/setup/", _handle_api_setup_post)

--- a/packages/fox-overlay/tests/test_onboarding_overlay.py
+++ b/packages/fox-overlay/tests/test_onboarding_overlay.py
@@ -1,0 +1,194 @@
+"""Phase 7 regression tests for fox_overlay.webui_modules.onboarding.
+
+Covers:
+* 3 dispatcher registrations: GET /setup (allow_bare), GET /api/setup/, POST /api/setup/
+* /setup wrapper boundary check (allow_bare)
+* /api/setup/welcome routes to handle_setup_welcome
+* POST /api/setup/{openrouter,complete,skip,restart} dispatch
+* _write_env_key still importable (hostname coupling)
+
+Behavioral parity for setup wizard is exercised by smoke checklist
+Section B (full first-run wizard against real container).
+"""
+import importlib
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def fresh_dispatch_and_module(monkeypatch, tmp_path):
+    """Reload dispatch + onboarding module so register_* fires fresh."""
+    fake_helpers = type(sys)("api.helpers")
+    def _j(handler, payload, status=200, extra_headers=None):
+        handler.responses.append({"status": status, "payload": payload})
+    def _read_body(handler):
+        return getattr(handler, "_body", {})
+    fake_helpers.j = _j
+    fake_helpers.read_body = _read_body
+
+    # onboarding.py imports `from api.config import load_settings` inside
+    # onboarding_complete; stub that so the module loads.
+    fake_config = type(sys)("api.config")
+    fake_config.load_settings = lambda: {}
+
+    fake_api = type(sys)("api")
+    fake_api.helpers = fake_helpers
+    fake_api.config = fake_config
+
+    monkeypatch.setitem(sys.modules, "api", fake_api)
+    monkeypatch.setitem(sys.modules, "api.helpers", fake_helpers)
+    monkeypatch.setitem(sys.modules, "api.config", fake_config)
+
+    # Redirect ONBOARDING_PATH + HERMES_ENV_PATH to tmp so tests don't write to /data
+    monkeypatch.setenv("ONBOARDING_PATH", str(tmp_path / "onboarding.json"))
+    monkeypatch.setenv("HERMES_ENV_PATH", str(tmp_path / "hermes.env"))
+
+    import fox_overlay.dispatch as d
+    importlib.reload(d)
+    import fox_overlay.webui_modules.onboarding as m
+    importlib.reload(m)
+    yield d, m
+    importlib.reload(d)
+    importlib.reload(m)
+
+
+class _FakeHandler:
+    def __init__(self, body=None):
+        self._body = body or {}
+        self.responses = []
+        # For handle_setup_page (sends raw bytes)
+        self._written = []
+        self._response_code = None
+        self._headers = []
+    def send_response(self, code):
+        self._response_code = code
+    def send_header(self, key, val):
+        self._headers.append((key, val))
+    def end_headers(self):
+        pass
+    @property
+    def wfile(self):
+        class _W:
+            def write(_self, b):
+                self._written.append(b)
+        return _W()
+
+
+# ── registration ────────────────────────────────────────────────────────────
+
+def test_module_registers_setup_bare_get(fresh_dispatch_and_module):
+    """/setup is registered with allow_bare=True."""
+    d, _m = fresh_dispatch_and_module
+    assert "/setup" in d.GET_TABLE
+
+
+def test_module_registers_api_setup_get_and_post(fresh_dispatch_and_module):
+    d, _m = fresh_dispatch_and_module
+    assert "/api/setup/" in d.GET_TABLE
+    assert "/api/setup/" in d.POST_TABLE
+
+
+# ── /setup (GET, allow_bare) ───────────────────────────────────────────────
+
+def test_get_setup_serves_html_when_file_exists(fresh_dispatch_and_module, monkeypatch):
+    """handle_setup_page reads setup.html from overlay's webui_static."""
+    d, m = fresh_dispatch_and_module
+    # Stub handle_setup_page to just record the call (real one reads from disk)
+    called = []
+    def _stub(handler):
+        called.append("page")
+        handler.send_response(200)
+    monkeypatch.setattr(m, "handle_setup_page", _stub)
+    from urllib.parse import urlparse
+    h = _FakeHandler()
+    assert d.handle_get(h, urlparse("/setup")) is True
+    assert called == ["page"]
+
+
+def test_get_setup_boundary_rejects_adjacent(fresh_dispatch_and_module):
+    """allow_bare contract: /setupX must NOT match (wrapper rejects)."""
+    d, _m = fresh_dispatch_and_module
+    from urllib.parse import urlparse
+    h = _FakeHandler()
+    assert d.handle_get(h, urlparse("/setupX")) is False
+    assert d.handle_get(h, urlparse("/setup-other")) is False
+
+
+# ── /api/setup/* (GET) ─────────────────────────────────────────────────────
+
+def test_get_api_setup_welcome(fresh_dispatch_and_module, monkeypatch):
+    d, m = fresh_dispatch_and_module
+    monkeypatch.setattr(m, "handle_setup_welcome", lambda h: {"welcome": True})
+    from urllib.parse import urlparse
+    h = _FakeHandler()
+    assert d.handle_get(h, urlparse("/api/setup/welcome")) is True
+    assert h.responses[-1]["payload"] == {"welcome": True}
+
+
+def test_get_api_setup_unknown_falls_through(fresh_dispatch_and_module):
+    d, _m = fresh_dispatch_and_module
+    from urllib.parse import urlparse
+    h = _FakeHandler()
+    assert d.handle_get(h, urlparse("/api/setup/nonexistent")) is False
+
+
+# ── /api/setup/* (POST) ────────────────────────────────────────────────────
+
+def test_post_api_setup_openrouter(fresh_dispatch_and_module, monkeypatch):
+    d, m = fresh_dispatch_and_module
+    captured = []
+    monkeypatch.setattr(m, "handle_setup_openrouter", lambda h, body: captured.append(body) or {"ok": True})
+    from urllib.parse import urlparse
+    h = _FakeHandler(body={"key": "sk-test"})
+    assert d.handle_post(h, urlparse("/api/setup/openrouter")) is True
+    assert captured == [{"key": "sk-test"}]
+
+
+def test_post_api_setup_complete(fresh_dispatch_and_module, monkeypatch):
+    d, m = fresh_dispatch_and_module
+    monkeypatch.setattr(m, "handle_setup_complete", lambda h, body: {"ok": True})
+    from urllib.parse import urlparse
+    h = _FakeHandler(body={})
+    assert d.handle_post(h, urlparse("/api/setup/complete")) is True
+
+
+def test_post_api_setup_skip(fresh_dispatch_and_module, monkeypatch):
+    d, m = fresh_dispatch_and_module
+    monkeypatch.setattr(m, "handle_setup_skip", lambda h, body: {"ok": True, "skipped": True})
+    from urllib.parse import urlparse
+    h = _FakeHandler(body={})
+    assert d.handle_post(h, urlparse("/api/setup/skip")) is True
+
+
+def test_post_api_setup_restart(fresh_dispatch_and_module, monkeypatch):
+    d, m = fresh_dispatch_and_module
+    monkeypatch.setattr(m, "handle_setup_restart", lambda h: {"ok": True})
+    from urllib.parse import urlparse
+    h = _FakeHandler(body={})
+    assert d.handle_post(h, urlparse("/api/setup/restart")) is True
+
+
+def test_post_api_setup_unknown_falls_through(fresh_dispatch_and_module):
+    d, _m = fresh_dispatch_and_module
+    from urllib.parse import urlparse
+    h = _FakeHandler(body={})
+    assert d.handle_post(h, urlparse("/api/setup/nonexistent")) is False
+
+
+# ── _write_env_key re-export (hostname coupling) ───────────────────────────
+
+def test_write_env_key_importable_from_overlay(fresh_dispatch_and_module):
+    """hostname.py imports _write_env_key from this module — must be exposed."""
+    _d, m = fresh_dispatch_and_module
+    assert callable(getattr(m, "_write_env_key", None))
+
+
+def test_write_env_key_writes_file(fresh_dispatch_and_module, tmp_path, monkeypatch):
+    """Quick smoke that _write_env_key still functions."""
+    _d, m = fresh_dispatch_and_module
+    # Override module-level _ENV_PATH via attribute assignment (it's a module-level
+    # Path at import — re-bind it for this test)
+    m._ENV_PATH = tmp_path / "test.env"
+    m._write_env_key("FOO", "bar")
+    assert m._ENV_PATH.read_text().strip() == "FOO=bar"

--- a/packages/fox-overlay/webui_static/setup.css
+++ b/packages/fox-overlay/webui_static/setup.css
@@ -1,0 +1,353 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: #0e0e10;
+  color: #e4e4e7;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+}
+
+#wizard {
+  width: 100%;
+  max-width: 480px;
+}
+
+/* ── Progress bar ───────────────────────────────────────────────────────── */
+
+#progress-bar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0;
+  margin-bottom: 32px;
+}
+
+.step-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #3f3f46;
+  flex-shrink: 0;
+  transition: background 0.2s;
+}
+
+.step-dot.active,
+.step-dot.done {
+  background: #f97316;
+}
+
+.step-line {
+  height: 2px;
+  width: 40px;
+  background: #3f3f46;
+  flex-shrink: 0;
+  transition: background 0.2s;
+}
+
+.step-line.done {
+  background: #f97316;
+}
+
+.progress-label {
+  display: block;
+  text-align: center;
+  font-size: 0.8rem;
+  color: #a1a1aa;
+  margin-top: 8px;
+}
+
+/* ── Steps ──────────────────────────────────────────────────────────────── */
+
+.step {
+  background: #18181b;
+  border: 1px solid #27272a;
+  border-radius: 12px;
+  padding: 32px 24px;
+}
+
+.step h1 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.step p {
+  color: #a1a1aa;
+  line-height: 1.5;
+  margin-bottom: 20px;
+}
+
+.step a {
+  color: #f97316;
+  text-decoration: none;
+}
+
+.step a:hover {
+  text-decoration: underline;
+}
+
+/* ── Form elements ──────────────────────────────────────────────────────── */
+
+label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 500;
+  margin-bottom: 6px;
+  color: #d4d4d8;
+}
+
+.input-wrapper {
+  position: relative;
+  margin-bottom: 4px;
+}
+
+.input-wrapper input {
+  width: 100%;
+  padding: 10px 44px 10px 12px;
+  background: #09090b;
+  border: 1px solid #3f3f46;
+  border-radius: 8px;
+  color: #e4e4e7;
+  font-size: 0.95rem;
+  font-family: inherit;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.input-wrapper input:focus {
+  border-color: #f97316;
+  box-shadow: 0 0 0 2px rgba(249, 115, 22, 0.15);
+}
+
+.input-wrapper input.has-error {
+  border-color: #ef4444;
+}
+
+.toggle-vis {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  color: #71717a;
+  cursor: pointer;
+  font-size: 0.8rem;
+  padding: 4px 6px;
+}
+
+.toggle-vis:hover {
+  color: #a1a1aa;
+}
+
+.hint {
+  font-size: 0.8rem;
+  color: #71717a;
+  margin-top: 6px;
+  margin-bottom: 20px;
+}
+
+.error-msg {
+  color: #ef4444;
+  font-size: 0.875rem;
+  margin-top: 4px;
+  margin-bottom: 16px;
+  min-height: 1.25em;
+}
+
+.success-msg {
+  color: #22c55e;
+  font-size: 0.875rem;
+  margin-top: 4px;
+  margin-bottom: 16px;
+}
+
+/* ── Buttons ────────────────────────────────────────────────────────────── */
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 24px;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.15s, opacity 0.15s;
+  min-height: 44px;
+}
+
+.btn:focus-visible {
+  outline: 2px solid #f97316;
+  outline-offset: 2px;
+}
+
+.btn-primary {
+  background: #f97316;
+  color: #fff;
+  width: 100%;
+}
+
+.btn-primary:hover {
+  background: #ea580c;
+}
+
+.btn-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  background: rgba(249, 115, 22, 0.12);
+  color: #f97316;
+  width: 100%;
+  border: 1px solid rgba(249, 115, 22, 0.4);
+}
+
+.btn-secondary:hover {
+  background: rgba(249, 115, 22, 0.2);
+}
+
+.btn-link {
+  background: transparent;
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 12px;
+  padding: 6px 12px;
+  border: none;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.btn-link:hover {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.skip-row {
+  margin-top: 14px;
+  text-align: center;
+}
+
+.ollama-detected {
+  margin-top: 18px;
+  padding: 14px;
+  border: 1px solid rgba(45, 212, 191, 0.4);
+  border-radius: 8px;
+  background: rgba(45, 212, 191, 0.08);
+}
+
+.ollama-detected-title {
+  font-weight: 600;
+  font-size: 13px;
+  color: #2dd4bf;
+  margin-bottom: 6px;
+}
+
+.ollama-detected p {
+  margin: 0 0 12px;
+  font-size: 13px;
+}
+
+.ollama-detected code {
+  background: rgba(0, 0, 0, 0.25);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+}
+
+.btn-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 24px;
+}
+
+/* ── Download progress bar (issue #69) ──────────────────────────────────── */
+
+.dl-bar {
+  width: 100%;
+  height: 8px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 4px;
+  overflow: hidden;
+  margin: 14px 0;
+}
+
+.dl-bar-fill {
+  height: 100%;
+  background: #2dd4bf;
+  transition: width 0.4s ease;
+}
+
+/* Indeterminate variant when bytes_total is unknown — animated stripe
+   so the user knows something is happening (QA fix). */
+.dl-bar-indeterminate {
+  position: relative;
+  overflow: hidden;
+}
+.dl-bar-indeterminate .dl-bar-fill {
+  position: absolute;
+  width: 30%;
+  left: -30%;
+  background: #2dd4bf;
+  animation: dl-bar-slide 1.4s linear infinite;
+}
+@keyframes dl-bar-slide {
+  0%   { left: -30%; }
+  100% { left: 100%; }
+}
+
+/* ── Spinner ────────────────────────────────────────────────────────────── */
+
+.spinner {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ── URLs list (done step) ──────────────────────────────────────────────── */
+
+.url-list {
+  list-style: none;
+  margin: 16px 0;
+}
+
+.url-list li {
+  padding: 8px 0;
+}
+
+.url-list code {
+  background: #09090b;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.9rem;
+}
+
+/* ── Responsive ─────────────────────────────────────────────────────────── */
+
+@media (max-width: 480px) {
+  .step {
+    padding: 24px 16px;
+  }
+}

--- a/packages/fox-overlay/webui_static/setup.html
+++ b/packages/fox-overlay/webui_static/setup.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fox in the Box -- Setup</title>
+  <link rel="stylesheet" href="/extensions/setup.css">
+</head>
+<body>
+  <div id="wizard">
+    <div id="progress-bar"></div>
+    <div id="step-container"></div>
+  </div>
+  <script src="/extensions/setup.js"></script>
+</body>
+</html>

--- a/packages/fox-overlay/webui_static/setup.js
+++ b/packages/fox-overlay/webui_static/setup.js
@@ -1,0 +1,570 @@
+/* Fox in the Box -- Onboarding setup wizard */
+
+const STEPS = ['Welcome', 'API Key', 'Done'];
+
+const state = {
+  currentStep: 1,
+  totalSteps: STEPS.length,
+  apiKey: '',
+  welcomeText: null,        // populated on boot from /api/setup/welcome
+  ollama: null,             // {running, host, version, models[]} populated on Welcome
+  localFallback: null,      // {ui_state, model_installed, model_size_bytes, ...} from /api/local-fallback/status
+  localModel: null,         // {provider: 'ollama'|'llama-cpp', name} once user picks a local path
+};
+
+// ── API helpers ──────────────────────────────────────────────────────────────
+
+async function post(path, body) {
+  const res = await fetch(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body || {}),
+  });
+  return { status: res.status, data: await res.json() };
+}
+
+async function getJson(path) {
+  const res = await fetch(path);
+  if (!res.ok) throw new Error('HTTP ' + res.status);
+  return res.json();
+}
+
+// ── Progress bar ─────────────────────────────────────────────────────────────
+
+function updateProgress(step) {
+  const bar = document.getElementById('progress-bar');
+  let html = '';
+  for (let i = 1; i <= state.totalSteps; i++) {
+    const cls = i < step ? 'done' : i === step ? 'active' : '';
+    html += `<div class="step-dot ${cls}"></div>`;
+    if (i < state.totalSteps) {
+      html += `<div class="step-line ${i < step ? 'done' : ''}"></div>`;
+    }
+  }
+  html += `<div class="progress-label">${step} / ${state.totalSteps} &mdash; ${STEPS[step - 1]}</div>`;
+  bar.innerHTML = html;
+}
+
+// ── Render helpers ───────────────────────────────────────────────────────────
+
+function escapeHtml(s) {
+  return String(s || '')
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+
+// Render plain-text welcome content (paragraph-split). Keeps the wizard
+// dependency-free — no markdown library — while still letting users edit
+// onboarding.md to customize the message. Issue #11.
+function renderWelcomeBody(text) {
+  if (!text) return '';
+  const paragraphs = String(text).trim().split(/\n\s*\n/);
+  return paragraphs.map(p => `<p>${escapeHtml(p).replace(/\n/g, '<br>')}</p>`).join('');
+}
+
+// Skip CTA inserted on every step. Bypasses API-key collection and marks
+// onboarding complete; user can configure providers later via Settings.
+function skipFooter() {
+  return `
+    <div class="skip-row">
+      <button class="btn-link" type="button" onclick="skipOnboarding()">Skip for now — I'll configure later</button>
+    </div>
+  `;
+}
+
+// ── Step renderers ───────────────────────────────────────────────────────────
+
+function renderStep1() {
+  const body = renderWelcomeBody(state.welcomeText)
+    || '<p>Let&apos;s get you set up. This will only take a minute.</p>';
+
+  // Local-model branch priority (issue #69):
+  //   1. Ollama detected with a model installed → use it (fastest, user already
+  //      configured something locally)
+  //   2. Bundled llama.cpp model already on disk → use it (instant, no download)
+  //   3. Bundled llama.cpp installable (in-container, supervisord present) →
+  //      offer download CTA (~2.5 GB)
+  //   4. None → only the OpenRouter path (Next button) and skip footer.
+  let localBlock = '';
+  if (state.ollama && state.ollama.running && Array.isArray(state.ollama.models) && state.ollama.models.length > 0) {
+    const first = state.ollama.models[0];
+    const modelName = escapeHtml(first.name || '');
+    // SECURITY (#XSS-1): never interpolate model names into a JS string
+    // context inside an `onclick` attribute. escapeHtml() is HTML-attribute-
+    // safe but does not safely escape JS string literals (a model name with
+    // backslash + apostrophe could break out). Use a data attribute and a
+    // delegated click handler — a tampered Ollama daemon could otherwise
+    // trigger code injection in the wizard.
+    localBlock = `
+      <div class="ollama-detected">
+        <div class="ollama-detected-title">Local model detected</div>
+        <p>You have <code>${modelName}</code> running on your computer via Ollama. Skip the API key step and chat with it locally — your data never leaves your machine.</p>
+        <button class="btn btn-secondary" data-action="use-ollama" data-model="${modelName}">Use ${modelName}</button>
+      </div>
+    `;
+  } else if (state.localFallback
+             && state.localFallback.ui_state !== 'no-supervisor'
+             && state.localFallback.ui_state !== 'missing-model-registry') {
+    if (state.localFallback.model_installed) {
+      localBlock = `
+        <div class="ollama-detected">
+          <div class="ollama-detected-title">Bundled local model ready</div>
+          <p>Phi-4-mini is already on disk. Skip the API key step and chat with it locally — your data never leaves your machine.</p>
+          <button class="btn btn-secondary" onclick="useLlamaCppFallback()">Use bundled local model</button>
+        </div>
+      `;
+    } else {
+      const bytes = state.localFallback.model_size_bytes || 0;
+      const sizeText = bytes > 0 ? ` (~${(bytes / 1073741824).toFixed(1)} GB)` : '';
+      localBlock = `
+        <div class="ollama-detected">
+          <div class="ollama-detected-title">Run a local model — no API key needed</div>
+          <p>Download Phi-4-mini${sizeText} and chat without an internet connection. Your data never leaves your machine.</p>
+          <button class="btn btn-secondary" onclick="useLlamaCppFallback()">Download &amp; use local model</button>
+        </div>
+      `;
+    }
+  }
+
+  // QA fix: disable Next while probes are in flight (state.ollama and
+  // state.localFallback are still null). Otherwise a fast user can skip
+  // past Step 1 before the local-model fast-paths render, missing them
+  // entirely. Once any probe resolves we re-render with the button enabled.
+  const probesPending = state.ollama === null && state.localFallback === null;
+  const nextBtn = probesPending
+    ? `<button class="btn btn-primary" disabled><span class="spinner"></span> Detecting local options…</button>`
+    : `<button class="btn btn-primary" onclick="advance(2)">Next</button>`;
+
+  return `
+    <div class="step">
+      <h1>Fox in the Box</h1>
+      ${body}
+      ${localBlock}
+      <div class="btn-actions">
+        ${nextBtn}
+      </div>
+      ${skipFooter()}
+    </div>
+  `;
+}
+
+function renderStep2() {
+  // When the user picked a local model on Step 1, OpenRouter becomes
+  // optional — they already have a working model. Show a clear "continue
+  // local-only" path so they don't have to dig through the wizard skip
+  // footer (which carries an "are you sure?" confirm aimed at users who
+  // haven't configured anything). Onboarding still completes at Step 3.
+  if (state.localModel) {
+    const localLabel = state.localModel.provider === 'ollama'
+      ? `${escapeHtml(state.localModel.name)} via Ollama`
+      : `${escapeHtml(state.localModel.name)} (bundled local model)`;
+    return `
+      <div class="step">
+        <h1>Add OpenRouter (optional)</h1>
+        <p>You're set up with <strong>${localLabel}</strong>. Add an OpenRouter API key for cloud models too, or continue with local-only.</p>
+        <label for="api-key">OpenRouter API Key</label>
+        <div class="input-wrapper">
+          <input id="api-key" type="password" placeholder="sk-or-..." autocomplete="off" spellcheck="false">
+          <button class="toggle-vis" type="button" onclick="toggleKeyVisibility()" aria-label="Toggle key visibility">show</button>
+        </div>
+        <div class="hint">
+          Get a free key at <a href="https://openrouter.ai/keys" target="_blank" rel="noopener">openrouter.ai</a>
+        </div>
+        <div id="key-error" class="error-msg"></div>
+        <div class="btn-actions">
+          <button id="submit-key" class="btn btn-primary" onclick="submitApiKey()">Add &amp; continue</button>
+          <button class="btn btn-secondary" type="button" onclick="advance(3)">Continue with local only</button>
+        </div>
+      </div>
+    `;
+  }
+  return `
+    <div class="step">
+      <h1>OpenRouter API Key</h1>
+      <p>Fox uses OpenRouter to access AI models. You'll need an API key to continue.</p>
+      <label for="api-key">API Key</label>
+      <div class="input-wrapper">
+        <input id="api-key" type="password" placeholder="sk-or-..." autocomplete="off" spellcheck="false">
+        <button class="toggle-vis" type="button" onclick="toggleKeyVisibility()" aria-label="Toggle key visibility">show</button>
+      </div>
+      <div class="hint">
+        Get your free key at <a href="https://openrouter.ai/keys" target="_blank" rel="noopener">openrouter.ai</a>
+      </div>
+      <div id="key-error" class="error-msg"></div>
+      <div class="btn-actions">
+        <button id="submit-key" class="btn btn-primary" onclick="submitApiKey()">Next</button>
+      </div>
+      ${skipFooter()}
+    </div>
+  `;
+}
+
+function renderStep3() {
+  // Echo back what's configured so the user knows what they're committing
+  // to before clicking Open Fox. Either or both can be set; one of them is
+  // guaranteed by the time we reach Step 3 (Step 2 either submits an
+  // OpenRouter key or routes "Continue with local only" past it).
+  let summary = '';
+  if (state.localModel) {
+    const localLabel = state.localModel.provider === 'ollama'
+      ? `${escapeHtml(state.localModel.name)} (Ollama, local)`
+      : `${escapeHtml(state.localModel.name)} (bundled local model)`;
+    summary += `<li>Local model: <code>${localLabel}</code></li>`;
+  }
+  if (state.apiKey) {
+    summary += `<li>OpenRouter: configured (cloud models available)</li>`;
+  }
+  return `
+    <div class="step">
+      <h1>Fox is ready!</h1>
+      <p>Your assistant is configured and ready to go.</p>
+      ${summary ? `<ul class="url-list">${summary}</ul>` : ''}
+      <ul class="url-list">
+        <li>Local: <code>http://localhost:8787</code></li>
+      </ul>
+      <div class="btn-actions">
+        <button id="open-fox" class="btn btn-primary" onclick="completeSetup()">Open Fox</button>
+      </div>
+    </div>
+  `;
+}
+
+// ── Navigation ───────────────────────────────────────────────────────────────
+
+function advance(n) {
+  state.currentStep = n;
+  renderStep(n);
+  updateProgress(n);
+}
+
+function renderStep(n) {
+  const container = document.getElementById('step-container');
+  switch (n) {
+    case 1: container.innerHTML = renderStep1(); break;
+    case 2: container.innerHTML = renderStep2(); break;
+    case 3: container.innerHTML = renderStep3(); break;
+  }
+}
+
+// ── Key input helpers ────────────────────────────────────────────────────────
+
+function toggleKeyVisibility() {
+  const input = document.getElementById('api-key');
+  const btn = input.parentElement.querySelector('.toggle-vis');
+  if (input.type === 'password') {
+    input.type = 'text';
+    btn.textContent = 'hide';
+  } else {
+    input.type = 'password';
+    btn.textContent = 'show';
+  }
+}
+
+function setKeyError(msg) {
+  const el = document.getElementById('key-error');
+  if (el) el.textContent = msg;
+  const input = document.getElementById('api-key');
+  if (input) {
+    if (msg) input.classList.add('has-error');
+    else input.classList.remove('has-error');
+  }
+}
+
+function setSubmitting(busy) {
+  const btn = document.getElementById('submit-key');
+  if (!btn) return;
+  btn.disabled = busy;
+  btn.innerHTML = busy ? '<span class="spinner"></span> Saving...' : 'Next';
+}
+
+// ── Submit API key ───────────────────────────────────────────────────────────
+
+async function submitApiKey() {
+  const input = document.getElementById('api-key');
+  const key = (input ? input.value : '').trim();
+
+  setKeyError('');
+
+  if (!key) {
+    setKeyError('API key is required.');
+    return;
+  }
+  if (!key.startsWith('sk-')) {
+    setKeyError('Key must start with sk-.');
+    return;
+  }
+
+  setSubmitting(true);
+  try {
+    const { data } = await post('/api/setup/openrouter', { key });
+    if (data.ok) {
+      state.apiKey = key;
+      advance(3);
+    } else {
+      setKeyError(data.error || 'Failed to save key.');
+    }
+  } catch (e) {
+    setKeyError('Network error. Please try again.');
+  } finally {
+    setSubmitting(false);
+  }
+}
+
+// ── Skip and local-Ollama paths (issue #11) ─────────────────────────────────
+
+async function skipOnboarding() {
+  if (!confirm("Skip the wizard? You can configure providers any time from Settings.")) return;
+  try {
+    await post('/api/setup/skip', {});
+  } catch (e) {
+    // Non-fatal — backend may have already marked complete.
+  }
+  // No supervisord restart needed — no env was written. Redirect immediately.
+  window.location.href = '/';
+}
+
+async function useLocalOllama(modelName) {
+  if (!modelName) return;
+
+  // Replace wizard contents synchronously so the user can't click Next /
+  // Skip during the use-model API call. Without this, advance(2) could be
+  // triggered mid-async, leaving the user on a stale step (FITB#122 race).
+  const container = document.getElementById('step-container');
+  if (container) {
+    container.innerHTML = `
+      <div class="step">
+        <h1>Setting up ${escapeHtml(modelName)}</h1>
+        <p>Switching to your local model. This will only take a moment.</p>
+        <div class="btn-actions">
+          <button class="btn btn-primary" disabled><span class="spinner"></span> Setting up…</button>
+        </div>
+      </div>
+    `;
+  }
+
+  try {
+    const r = await post('/api/ollama/use-model', { model: modelName });
+    if (!r.data.ok) {
+      alert('Could not switch to local model: ' + (r.data.error || 'unknown error'));
+      renderStep(1);
+      return;
+    }
+  } catch (e) {
+    alert('Network error while switching to local model.');
+    renderStep(1);
+    return;
+  }
+
+  // Local model is now active on the gateway. Continue through Step 2
+  // (OpenRouter, optional) so the user explicitly completes the wizard at
+  // Step 3. Onboarding is NOT marked complete here — that happens in
+  // completeSetup() when the user clicks Open Fox on Step 3.
+  state.localModel = { provider: 'ollama', name: modelName };
+  advance(2);
+}
+
+// Issue #69: bundled llama.cpp fast-path. Toggles on local fallback (kicks
+// download via #10's manager if needed), polls status, shows progress in
+// place of the welcome step, and finishes onboarding when llama-server is
+// ready.
+function _renderLocalFallbackProgress(snapshot) {
+  const container = document.getElementById('step-container');
+  if (!container) return;
+
+  const ui = (snapshot && snapshot.ui_state) || 'starting';
+  const ms = snapshot && snapshot.model_state;
+  const downloaded = ms && typeof ms.bytes_downloaded === 'number' ? ms.bytes_downloaded : 0;
+  const total = ms && typeof ms.bytes_total === 'number' && ms.bytes_total > 0
+    ? ms.bytes_total
+    : (snapshot && snapshot.model_size_bytes) || 0;
+  const pct = total > 0 ? Math.min(100, Math.floor((downloaded / total) * 100)) : 0;
+  const mb = (n) => (n / 1048576).toFixed(0);
+
+  let title, detail, showBar;
+  switch (ui) {
+    case 'needs-download':
+      title = 'Preparing download…';
+      detail = 'Queueing the model download.';
+      showBar = false;
+      break;
+    case 'downloading':
+      title = 'Downloading local model';
+      detail = total > 0
+        ? `${mb(downloaded)} / ${mb(total)} MB (${pct}%)`
+        : `${mb(downloaded)} MB downloaded`;
+      showBar = true;
+      break;
+    case 'starting':
+      title = 'Starting local model server…';
+      detail = 'Almost there.';
+      showBar = false;
+      break;
+    case 'warming':
+      title = 'Warming up the model…';
+      detail = 'Loading weights into memory.';
+      showBar = false;
+      break;
+    case 'ready':
+      title = 'Local model is ready';
+      detail = 'Opening Fox…';
+      showBar = false;
+      break;
+    default:
+      title = 'Setting up local model…';
+      detail = '';
+      showBar = false;
+  }
+
+  // QA fix: when bytes_total is unknown, the bar previously rendered
+  // as a 0%-fill and looked frozen. Use an indeterminate animated
+  // stripe instead so the user knows progress is happening.
+  let bar = '';
+  if (showBar) {
+    if (total > 0) {
+      bar = `<div class="dl-bar"><div class="dl-bar-fill" style="width:${pct}%"></div></div>`;
+    } else {
+      bar = `<div class="dl-bar dl-bar-indeterminate"><div class="dl-bar-fill"></div></div>`;
+    }
+  }
+
+  container.innerHTML = `
+    <div class="step">
+      <h1>${escapeHtml(title)}</h1>
+      <p>${escapeHtml(detail)}</p>
+      ${bar}
+      <div class="hint">You can close this window — the download keeps going in the background.</div>
+    </div>
+  `;
+}
+
+async function useLlamaCppFallback() {
+  // Kick the toggle. enable() returns immediately with the current snapshot;
+  // download (if needed) and llama-server start happen in background threads.
+  let snapshot;
+  try {
+    const r = await post('/api/local-fallback/enable', {});
+    if (!r.data || r.data.enabled === false) {
+      alert('Could not enable local fallback: ' + ((r.data && r.data.error) || 'unknown error'));
+      return;
+    }
+    snapshot = r.data;
+  } catch (e) {
+    alert('Network error while enabling local fallback.');
+    return;
+  }
+
+  _renderLocalFallbackProgress(snapshot);
+
+  // Poll until ui_state === 'ready'. Phi-4-mini is ~2.5 GB; on a typical
+  // residential connection this can take several minutes, so we poll
+  // patiently rather than time out.
+  const startedAt = Date.now();
+  const maxMs = 30 * 60 * 1000;  // 30 minutes — generous for slow links
+  const tick = async () => {
+    if (Date.now() - startedAt > maxMs) {
+      alert('Local model setup is taking longer than expected. Check Settings → Providers later.');
+      return;
+    }
+    let s;
+    try {
+      s = await getJson('/api/local-fallback/status');
+    } catch (e) {
+      setTimeout(tick, 3000);
+      return;
+    }
+    _renderLocalFallbackProgress(s);
+    if (s.ui_state === 'ready') {
+      // Bundled local model is now active. Continue through Step 2 so the
+      // user explicitly completes the wizard at Step 3 — onboarding gets
+      // marked complete in completeSetup() when they click Open Fox.
+      state.localModel = { provider: 'llama-cpp', name: 'Phi-4-mini' };
+      advance(2);
+      return;
+    }
+    setTimeout(tick, 2000);
+  };
+  setTimeout(tick, 1500);
+}
+
+// ── Complete setup ───────────────────────────────────────────────────────────
+
+async function completeSetup() {
+  const btn = document.getElementById('open-fox');
+  if (btn) {
+    btn.disabled = true;
+    btn.innerHTML = '<span class="spinner"></span> Starting...';
+  }
+
+  try {
+    await post('/api/setup/complete', { tailscale_connected: false });
+  } catch (e) {
+    // Non-fatal -- config is written, proceed anyway
+  }
+
+  try {
+    await post('/api/setup/restart', {});
+  } catch (e) {
+    // Non-fatal -- redirect anyway
+  }
+
+  // Wait for services to restart, then redirect
+  setTimeout(() => { window.location.href = '/'; }, 3000);
+}
+
+// ── Boot ─────────────────────────────────────────────────────────────────────
+
+async function loadOnboardingState() {
+  // Welcome content (externalized), Ollama detection, and bundled-llama.cpp
+  // status all run in parallel — the wizard renders with sensible fallbacks
+  // if any probe fails. (#69 added local-fallback to the probe set.)
+  const tasks = [
+    getJson('/api/setup/welcome').then(d => { state.welcomeText = d.text || null; }).catch(() => {}),
+    getJson('/api/ollama/status').then(async (s) => {
+      if (s && s.running) {
+        try {
+          const m = await getJson('/api/ollama/models');
+          state.ollama = Object.assign({}, s, { models: (m && m.models) || [] });
+        } catch (e) {
+          state.ollama = Object.assign({}, s, { models: [] });
+        }
+      } else {
+        state.ollama = { running: false, models: [] };
+      }
+    }).catch(() => { state.ollama = { running: false, models: [] }; }),
+    getJson('/api/local-fallback/status').then(s => {
+      // s.ui_state ∈ {disabled, needs-download, downloading, starting,
+      //   warming, ready, no-supervisor, missing-model-registry}.
+      // We care about: "ready" (instant fast-path) and supervisor-available
+      // states (offer the download CTA). "no-supervisor" hides the CTA.
+      state.localFallback = s || null;
+    }).catch(() => { state.localFallback = null; }),
+  ];
+  await Promise.all(tasks);
+}
+
+// Delegated click handler for data-action buttons. Avoids inline onclick=
+// strings that interpolate user-controlled values (model names from a
+// remote Ollama daemon, etc.). Bound once at module init.
+document.addEventListener('click', (ev) => {
+  const t = ev.target;
+  if (!t || t.nodeType !== 1) return;
+  const btn = t.closest('[data-action]');
+  if (!btn) return;
+  const action = btn.getAttribute('data-action');
+  if (action === 'use-ollama') {
+    useLocalOllama(btn.getAttribute('data-model') || '');
+  }
+});
+
+document.addEventListener('DOMContentLoaded', async () => {
+  // Show the welcome step immediately with hardcoded fallback content,
+  // then re-render once the probes return so the user never sees a
+  // blank screen if the API is slow.
+  renderStep(1);
+  updateProgress(1);
+  // QA fix: disable Next while probes are in flight so a fast user can't
+  // skip past Step 1 with no `state.ollama` / `state.localFallback`
+  // populated and miss the local-model fast-paths.
+  await loadOnboardingState();
+  if (state.currentStep === 1) renderStep(1);
+});

--- a/packages/integration/Dockerfile
+++ b/packages/integration/Dockerfile
@@ -190,6 +190,41 @@ RUN set -eu; \
     done; \
     rm -rf /tmp/fox-webui-patches
 
+# ── .fox-removals consumer (Phase 7 of v0.6.0 migration) ──────────────────────
+# Apply the .fox-removals manifest to /app/hermes-webui. Each line names a
+# fork-relative path Fox does NOT ship (e.g. upstream onboarding tests that
+# Fox replaced with its own wizard). xargs invokes rm -f so missing files
+# are silent (the file's load-bearing only at Phase 8 when the submodule
+# re-points at virgin upstream; pre-Phase-8 the entries are no-ops because
+# Fox already removed those files from the fork in past commits).
+#
+# Same parse convention as the webui patch series above: strip blanks +
+# comments via `grep -vE '^\s*$|^\s*#'`, strip CRLF, pass through xargs.
+COPY packages/fox-overlay/.fox-removals /tmp/fox-removals
+RUN set -eu; \
+    if [ "${FITB_DISABLE_WEBUI_OVERLAY}" = "1" ]; then \
+        echo "[fox-removals] FITB_DISABLE_WEBUI_OVERLAY=1 — skipping removals"; \
+        rm -f /tmp/fox-removals; \
+        exit 0; \
+    fi; \
+    cd /app/hermes-webui; \
+    removals=$(tr -d '\r' < /tmp/fox-removals | grep -vE '^\s*$|^\s*#' || true); \
+    if [ -z "$removals" ]; then \
+        echo "[fox-removals] manifest empty; nothing to remove"; \
+        rm -f /tmp/fox-removals; \
+        exit 0; \
+    fi; \
+    echo "$removals" | while IFS= read -r p; do \
+        [ -z "$p" ] && continue; \
+        if [ -e "$p" ]; then \
+            echo "[fox-removals] rm $p"; \
+            rm -f -- "$p"; \
+        else \
+            echo "[fox-removals] (absent — no-op) $p"; \
+        fi; \
+    done; \
+    rm -f /tmp/fox-removals
+
 RUN set -eux; \
     pip install -e /app/hermes-agent --quiet --no-cache-dir; \
     if [ -f /app/hermes-webui/pyproject.toml ] || [ -f /app/hermes-webui/setup.py ]; then \


### PR DESCRIPTION
Phase 7 of v0.6.0 upstream-separation migration. Companion to fork PR fox-in-the-box-ai/hermes-webui#30 (P7a — rm api/onboarding.py + setup files + restore 6 upstream onboarding tests with FOX_OVERLAY skipif).

Closes #198.

## What ships

| Subsystem | File | Notes |
|-----------|------|-------|
| Overlay module | `webui_modules/onboarding.py` (~360 LOC) | Fox setup wizard + dispatcher wrapper |
| Overlay statics | `webui_static/setup.{html,css,js}` | Moved from fork (Phase 2 deferral unblocked) |
| Hostname re-coupling | `webui_modules/hostname.py` | Import `_write_env_key` from overlay onboarding |
| Dockerfile | new `.fox-removals` consumer RUN block | First load-bearing user is Phase 8 |
| Tests | `tests/test_onboarding_overlay.py` (13 tests) | Wrapper shape, boundary, _write_env_key |

## Dispatcher registrations (+2 GET, +1 POST)

- `register_get("/setup", _handle_get, allow_bare=True)` — serves overlay's setup.html
- `register_get("/api/setup/", _handle_api_setup_get)` — handle_setup_welcome
- `register_post("/api/setup/", _handle_api_setup_post)` — openrouter, complete, skip, restart

`/setup` boundary check rejects `/setupX` adjacency (allow_bare contract honored).

## Hostname coupling resolved (CRITICAL)

`webui_modules/hostname.py` line 23 import changed atomic with this PR:
```diff
- from api.onboarding import _write_env_key
+ from fox_overlay.webui_modules.onboarding import _write_env_key
```

Without this, hostname module-load fails at `bootstrap.install()` after P7a removes fork's `api/onboarding.py`. Test `test_write_env_key_importable_from_overlay` locks this.

## Setup asset URLs

`setup.html` references updated from `/static/setup.{css,js}` (would 404 post-fork-removal) to `/extensions/setup.{css,js}` (served by upstream's extension-dir mechanism via existing `HERMES_WEBUI_EXTENSION_DIR=/app/fox-overlay/webui_static` env).

## `.fox-removals` consumer (NEW Dockerfile infrastructure)

New RUN block applies the `.fox-removals` manifest to `/app/hermes-webui` between the patch series RUN and pip install. Same `FITB_DISABLE_WEBUI_OVERLAY=1` bypass; missing files log as no-ops. The manifest is currently no-op against the Fox fork (Fox already removed those upstream files in past commits) — becomes load-bearing at Phase 8 when the submodule re-points at virgin upstream.

## Verification

- 146 unit tests pass (133 prior + 13 new onboarding)
- Container build with submodule@3060d76:
  - `[fox-overlay] bootstrap installed: dispatcher frozen, 7 GET + 6 POST handlers registered` (was 5+5)
  - `GET /setup` → 200 (overlay-served HTML)
  - `GET /extensions/setup.{css,js}` → 200
  - `GET /api/setup/welcome` → 200
  - `GET /setupX` → 404 (boundary check)
  - `GET /api/settings/hostname` → 200 (_write_env_key import survived)
  - All Phase 5 + Phase 6 endpoints still 200
  - Fork files confirmed gone: `api/onboarding.py` + `static/setup.html`
- Phase 4 patches still apply --check clean

## Submodule

`forks/hermes-webui` → `3060d76` (fork PR #30 merge commit). Auto-merge after CI per Dennis's all-phases authorization.