### PR TITLE
fix(agent-patches): restore Phase 3 bootstrap shim as managed patch + refresh auxiliary_client anchor (#242)

### DIFF
--- a/packages/fox-overlay/fox_overlay/agent_plugins/fox_overlay_plugin/monkey_patches/auxiliary_client.py
+++ b/packages/fox-overlay/fox_overlay/agent_plugins/fox_overlay_plugin/monkey_patches/auxiliary_client.py
@@ -22,20 +22,24 @@ from ._helpers import substitute_function
 
 def apply() -> None:
     # 1) _resolve_task_provider_model: insert explicit-provider branch
+    # Refreshed for v2026.5.16 (Phase 8 #242): upstream now returns
+    # `cfg_base_url, cfg_api_key` instead of `None, None` in this branch.
+    # The Fox-added fallback below still uses `None, None` because the
+    # cfg_provider="auto" path doesn't have an explicit base_url/api_key.
     substitute_function(
         upstream_module=_u,
         function_name="_resolve_task_provider_model",
         substitutions=[
             (
                 '        if cfg_provider and cfg_provider != "auto":\n'
-                '            return cfg_provider, resolved_model, None, None, resolved_api_mode\n'
+                '            return cfg_provider, resolved_model, cfg_base_url, cfg_api_key, resolved_api_mode\n'
                 '\n'
                 '        return "auto", resolved_model, None, None, resolved_api_mode\n',
                 '        if cfg_provider and cfg_provider != "auto":\n'
-                '            return cfg_provider, resolved_model, None, None, resolved_api_mode\n'
+                '            return cfg_provider, resolved_model, cfg_base_url, cfg_api_key, resolved_api_mode\n'
                 '\n'
-                '        # provider is "auto" (or unset) but config specified an explicit model\n'
-                '        # (e.g. auxiliary.default.model = us.anthropic.claude-haiku-...).\n'
+                '        # Fox patch (#242): provider is "auto" (or unset) but config specified\n'
+                '        # an explicit model (e.g. auxiliary.default.model = us.anthropic.claude-...).\n'
                 '        # _resolve_auto ignores the model hint and always uses the main model,\n'
                 '        # so we must resolve the provider explicitly here to honour cfg_model.\n'
                 '        if resolved_model:\n'

--- a/packages/fox-overlay/patches/agent/001-gateway-bootstrap-shim.patch
+++ b/packages/fox-overlay/patches/agent/001-gateway-bootstrap-shim.patch
@@ -1,0 +1,38 @@
+diff --git a/gateway/run.py b/gateway/run.py
+index f9a282a41..aad5d58cb 100644
+--- a/gateway/run.py
++++ b/gateway/run.py
+@@ -3497,6 +3497,33 @@ class GatewayRunner:
+                 exc_info=True,
+             )
+ 
++        # === FITB ===
++        # Trigger fox-overlay's agent plugins so the monkey-patches and
++        # mem0_oss plugin actually fire at gateway boot. Upstream's
++        # PluginManager (which discovers hermes_agent.plugins entry-points)
++        # is invoked only from `hermes` CLI commands, not from this gateway
++        # startup path. Bootstrap shim restores the Phase 3 behavior on
++        # virgin upstream content (post-Phase-8 re-point).
++        #
++        # Set FITB_DISABLE_AGENT_OVERLAY=1 to disable in production without
++        # rebuilding the image.
++        if os.environ.get("FITB_DISABLE_AGENT_OVERLAY", "").lower() not in ("1", "true", "yes"):
++            try:
++                from fox_overlay.agent_plugins import register as _fitb_register
++                _fitb_register(None)
++            except ImportError:
++                logger.debug(
++                    "fox-overlay not installed; skipping agent-plugin bootstrap"
++                )
++            except Exception:
++                logger.warning(
++                    "fox-overlay agent-plugin bootstrap failed; gateway will "
++                    "boot without Fox monkey-patches (target_model fix, "
++                    "auxiliary.default fallback, cron failure diagnostics)",
++                    exc_info=True,
++                )
++        # === /FITB ===
++
+         # Discover and load event hooks
+         self.hooks.discover_and_load()
+ 

--- a/packages/fox-overlay/patches/agent/series
+++ b/packages/fox-overlay/patches/agent/series
@@ -1,2 +1,3 @@
 # Intentionally empty — hermes-agent customizations live as monkey-patches via
 # the hermes_agent.plugins entry-point (Phase 3), not as patch-series files.
+001-gateway-bootstrap-shim.patch

--- a/packages/integration/Dockerfile
+++ b/packages/integration/Dockerfile
@@ -190,6 +190,52 @@ RUN set -eu; \
     done; \
     rm -rf /tmp/fox-webui-patches
 
+# ── Fox agent patch series (Phase 8 of v0.6.0 migration) ─────────────────────
+# Mirrors the webui patch series above. First non-empty consumer of the
+# agent series at Phase 8: the gateway/run.py bootstrap shim that calls
+# fox_overlay.agent_plugins.register() — without this, hermes-agent's
+# PluginManager.discover_and_load() is only invoked from `hermes` CLI
+# commands (not from the gateway startup path), so Phase 3 monkey-patches
+# never fire when running as a daemon.
+#
+# FITB_DISABLE_AGENT_OVERLAY=1 short-circuits both the patch loop here
+# AND the patched shim's runtime path (gated by env var inside the shim).
+ARG FITB_DISABLE_AGENT_OVERLAY=0
+COPY packages/fox-overlay/patches/agent /tmp/fox-agent-patches
+RUN set -eu; \
+    if [ "${FITB_DISABLE_AGENT_OVERLAY}" = "1" ]; then \
+        echo "[fox-patch] FITB_DISABLE_AGENT_OVERLAY=1 — skipping agent patch series"; \
+        rm -rf /tmp/fox-agent-patches; \
+        exit 0; \
+    fi; \
+    cd /app/hermes-agent; \
+    rm -f .git; \
+    series_file=/tmp/fox-agent-patches/series; \
+    if [ ! -f "$series_file" ]; then \
+        echo "[fox-patch] no agent series — skipping"; \
+        rm -rf /tmp/fox-agent-patches; \
+        exit 0; \
+    fi; \
+    patches=$(tr -d '\r' < "$series_file" | grep -vE '^\s*$|^\s*#' || true); \
+    if [ -z "$patches" ]; then \
+        echo "[fox-patch] agent series file empty; nothing to apply"; \
+        rm -rf /tmp/fox-agent-patches; \
+        exit 0; \
+    fi; \
+    echo "$patches" | while IFS= read -r p; do \
+        [ -z "$p" ] && continue; \
+        echo "[fox-patch] applying agent/$p"; \
+        if ! err=$(git apply --check "/tmp/fox-agent-patches/$p" 2>&1); then \
+            echo "::error::patch agent/$p failed --check"; \
+            echo "----- git apply --check output -----"; \
+            echo "$err"; \
+            echo "------------------------------------"; \
+            exit 1; \
+        fi; \
+        git apply "/tmp/fox-agent-patches/$p"; \
+    done; \
+    rm -rf /tmp/fox-agent-patches
+
 # ── .fox-removals consumer (Phase 7 of v0.6.0 migration) ──────────────────────
 # Apply the .fox-removals manifest to /app/hermes-webui. Each line names a
 # fork-relative path Fox does NOT ship (e.g. upstream onboarding tests that


### PR DESCRIPTION
Closes #242.

## What was broken

Phase 3 added a gateway/run.py bootstrap shim that called `fox_overlay.agent_plugins.register(None)` so agent monkey-patches fire at gateway start. The shim was a FORK COMMIT — lost in Phase 8 ATOMIC re-point at virgin upstream.

Phase 3 commit body explicitly anticipated this would extract to a managed patch at Phase 8.

## What ships

| Change | File |
|--------|------|
| Bootstrap shim as managed patch | `packages/fox-overlay/patches/agent/001-gateway-bootstrap-shim.patch` (new) |
| Series entry | `packages/fox-overlay/patches/agent/series` |
| Dockerfile agent patch consumer | New RUN block mirroring webui patch series; `FITB_DISABLE_AGENT_OVERLAY=1` bypass |
| auxiliary_client anchor refresh | `_resolve_task_provider_model` — upstream changed `None, None` → `cfg_base_url, cfg_api_key` |

## What was already good

- runtime_provider anchor unchanged in v2026.5.16
- auxiliary_client._get_auxiliary_task_config anchors unchanged
- cron_diagnostics anchors unchanged (create_job + mark_job_run both)

## Verification

Container against v2026.5.16:
- Gateway log: NO `fox-overlay agent-plugin bootstrap failed` warning
- All 5 Phase 3 monkey-patch sentinels = True
- All Phase 5+7 dispatcher webui routes return 200