### PR TITLE
feat(check-overlay-basis): replace stub with real check + wire into build-container CI (#246)

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -54,6 +54,14 @@ jobs:
         with:
           submodules: recursive
 
+      # Phase 8 follow-up #246: fail fast if any overlay artefact is stale
+      # against the current submodule pin. Catches upstream rename/delete
+      # of .fox-removals entries + anchor drift in the webui/agent patch
+      # series BEFORE the Docker build wastes ~3 minutes per arch only to
+      # die at git apply --check inside the container.
+      - name: Overlay basis sanity check
+        run: ./packages/fox-overlay/scripts/check-overlay-basis.sh
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:

--- a/packages/fox-overlay/scripts/check-overlay-basis.sh
+++ b/packages/fox-overlay/scripts/check-overlay-basis.sh
@@ -1,10 +1,114 @@
-#!/bin/bash
-# Detect upstream rename/delete of any file referenced in .fox-removals.
+#!/usr/bin/env bash
 #
-# Runs as a CI gate before the Docker build (wired in Phase 8). Failure
-# means the submodule pin needs to be rolled back to the previous tag
-# and the overlay/migration plan updated for the upstream restructure.
+# check-overlay-basis.sh — overlay basis sanity check for v0.6.0+.
 #
-# Phase 1: no-op stub returning 0. Phase 8 makes it real.
+# Detect upstream rename/delete of any file the overlay depends on:
+#
+# 1. .fox-removals entries — each path MUST exist in the webui submodule
+#    (otherwise the manifest is stale; upstream renamed/removed it out
+#    from under us, and the next container build silently won't perform
+#    the intended removal).
+# 2. patches/webui/series + patches/agent/series — each .patch MUST apply
+#    --check cleanly against the current submodule pointer (otherwise
+#    upstream's churn invalidated the anchor).
+#
+# Runs as a CI gate BEFORE the Docker build. Failure means: either
+# (a) the submodule pin needs to be rolled back to the previous tag
+# the overlay tracked, or (b) the manifest/patches need refresh for
+# the new upstream tag.
+#
+# Made real in Phase 8 follow-up #246 (was an empty `exit 0` stub
+# from Phase 1).
+#
+# Exit codes:
+#   0 = overlay basis is clean against current submodule pointers
+#   1 = at least one mismatch — diagnostics printed to stderr; CI fails
 
-exit 0
+set -eu
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+OVERLAY="$REPO_ROOT/packages/fox-overlay"
+WEBUI="$REPO_ROOT/forks/hermes-webui"
+AGENT="$REPO_ROOT/forks/hermes-agent"
+
+failed=0
+
+note() { printf '[check-overlay-basis] %s\n' "$*"; }
+fail() { printf '[check-overlay-basis] FAIL: %s\n' "$*" >&2; failed=1; }
+
+# ── 1. .fox-removals entries must exist in the webui submodule ──────────────
+removals_file="$OVERLAY/.fox-removals"
+if [ ! -f "$removals_file" ]; then
+    fail "missing manifest: $removals_file"
+else
+    note "checking .fox-removals entries against $WEBUI"
+    while IFS= read -r entry; do
+        # Strip blanks + comments (same convention as the Dockerfile consumer).
+        entry="${entry%%#*}"
+        entry="$(printf '%s' "$entry" | tr -d '\r' | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+        [ -z "$entry" ] && continue
+        if [ ! -e "$WEBUI/$entry" ]; then
+            fail ".fox-removals entry missing in upstream: $entry"
+        fi
+    done < "$removals_file"
+fi
+
+# ── 2. webui patch series must apply --check against current submodule ──────
+webui_series="$OVERLAY/patches/webui/series"
+if [ -f "$webui_series" ]; then
+    note "checking webui patch series against $WEBUI ($(cd "$WEBUI" && git describe --tags --always 2>/dev/null || echo unknown))"
+    while IFS= read -r patch; do
+        patch="${patch%%#*}"
+        patch="$(printf '%s' "$patch" | tr -d '\r' | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+        [ -z "$patch" ] && continue
+        patch_path="$OVERLAY/patches/webui/$patch"
+        if [ ! -f "$patch_path" ]; then
+            fail "webui series references missing patch: $patch"
+            continue
+        fi
+        if ! (cd "$WEBUI" && git apply --check "$patch_path") 2>/dev/null; then
+            fail "webui patch fails --check: $patch"
+            (cd "$WEBUI" && git apply --check "$patch_path" 2>&1 | sed 's/^/    /') >&2 || true
+        fi
+    done < "$webui_series"
+fi
+
+# ── 3. agent patch series must apply --check against current submodule ──────
+agent_series="$OVERLAY/patches/agent/series"
+if [ -f "$agent_series" ]; then
+    note "checking agent patch series against $AGENT ($(cd "$AGENT" && git describe --tags --always 2>/dev/null || echo unknown))"
+    while IFS= read -r patch; do
+        patch="${patch%%#*}"
+        patch="$(printf '%s' "$patch" | tr -d '\r' | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+        [ -z "$patch" ] && continue
+        patch_path="$OVERLAY/patches/agent/$patch"
+        if [ ! -f "$patch_path" ]; then
+            fail "agent series references missing patch: $patch"
+            continue
+        fi
+        if ! (cd "$AGENT" && git apply --check "$patch_path") 2>/dev/null; then
+            fail "agent patch fails --check: $patch"
+            (cd "$AGENT" && git apply --check "$patch_path" 2>&1 | sed 's/^/    /') >&2 || true
+        fi
+    done < "$agent_series"
+fi
+
+if [ "$failed" -eq 0 ]; then
+    note "OK — overlay basis clean against current submodule pointers"
+    exit 0
+fi
+
+cat >&2 <<'BANNER'
+[check-overlay-basis] one or more overlay/submodule basis mismatches
+[check-overlay-basis] detected. Likely causes:
+[check-overlay-basis]   * Upstream churn since the last submodule bump
+[check-overlay-basis]     renamed/removed a file the overlay depends on.
+[check-overlay-basis]   * The submodule pointer was bumped without the
+[check-overlay-basis]     matching overlay refresh.
+[check-overlay-basis] Resolution:
+[check-overlay-basis]   * Revert the submodule pointer to the last clean tag
+[check-overlay-basis]     AND open an issue to refresh anchors/manifest, OR
+[check-overlay-basis]   * Refresh the failing anchor/manifest entry first,
+[check-overlay-basis]     then re-bump the submodule.
+BANNER
+exit 1


### PR DESCRIPTION
Closes #246. Last Phase 8 follow-up.

## What ships

| File | Change |
|------|--------|
| `packages/fox-overlay/scripts/check-overlay-basis.sh` | Phase 1 stub → real impl |
| `.github/workflows/build-container.yml` | New step: run the script after submodule checkout, before Docker build |

## The script checks 3 things

1. **`.fox-removals` entries exist in the webui submodule.** Catches upstream rename/delete that would silently turn the Dockerfile `rm -f` into a no-op.
2. **`patches/webui/series` patches apply --check.** Catches anchor drift before container build wastes ~3 minutes per arch.
3. **`patches/agent/series` patches apply --check.** Same against agent submodule.

Diagnostic output: prints failing entry + raw `git apply --check` stderr. Closing banner gives a resolution playbook.

## Verified against current state

```
[check-overlay-basis] OK — overlay basis clean against current submodule pointers
```

Exit 0.

## Future Phase 9 use

The nightly upstream-watch CI (#202) will run this script after temporarily checking out the proposed next upstream tag — `--check` failure tells us the next bump needs anchor refresh first.