### PR TITLE
feat(ci): install 10 upstream-monitoring tripwires (#206)

### DIFF
--- a/.github/scripts/tripwire-branch-watch.sh
+++ b/.github/scripts/tripwire-branch-watch.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Tripwire #209 — branch-creation watch.
+#
+# Lists upstream branches; fires on any branch name matching the rewrite-
+# regex. Stateless — dedupe is by branch name in the issue title, so once
+# fired for "react", the issue gets re-fired (comment) not re-created.
+
+set -eu
+source "$(dirname "$0")/tripwire-common.sh"
+
+REWRITE_REGEX='react|vue|svelte|preact|rewrite|^v[0-9]+$|^next$|major'
+
+check_repo() {
+    local repo="$1"
+    local matches
+    matches=$(git ls-remote --heads "https://github.com/$repo.git" 2>/dev/null \
+              | awk '{sub("refs/heads/", "", $2); print $2}' \
+              | grep -iE "$REWRITE_REGEX" \
+              | grep -vE '^(master|main)$' \
+              || true)
+
+    if [ -z "$matches" ]; then
+        echo "[tripwire/branch] $repo: no rewrite-regex branches"
+        return 0
+    fi
+
+    while IFS= read -r branch; do
+        [ -z "$branch" ] && continue
+        body=$(cat <<EOF
+## Upstream \`$repo\` has a branch matching rewrite-regex
+
+Branch: **\`$branch\`**
+
+The regex \`$REWRITE_REGEX\` flags branches that historically signal:
+- A framework rewrite (\`react\`, \`vue\`, \`svelte\`, \`preact\`)
+- A major version bump (\`v2\`, \`v3\`, etc.)
+- A long-running rewrite (\`rewrite\`, \`major\`)
+- An upstream "next-gen" branch (\`next\`)
+
+**Why this matters:** if upstream merges a rewrite branch to default, the Fox overlay's anchors will catastrophically fail — most or all monkey-patch substitutions will miss. Plan a strategic re-evaluation before that merge lands.
+
+## Actions
+
+- [ ] Inspect the branch: https://github.com/$repo/tree/$branch
+- [ ] Read the latest commits to understand intent
+- [ ] If serious, file a Fox strategic-review issue and notify Dennis
+- [ ] If false positive (e.g. unrelated feature name happens to match \`major\`), close this issue — dedupe will not re-fire unless a different matching branch appears
+
+EOF
+)
+        tripwire_fire \
+            "[tripwire/branch] $repo has rewrite-regex branch: $branch" \
+            "$body" \
+            "tripwire-fire,tripwire/branch,P1"
+    done <<<"$matches"
+}
+
+check_repo "$WEBUI_REPO"
+check_repo "$AGENT_REPO"

--- a/.github/scripts/tripwire-commit-digest.sh
+++ b/.github/scripts/tripwire-commit-digest.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Tripwire #207 — daily upstream-commit digest.
+#
+# Fires once per day with the previous 24h of commits on each upstream,
+# highlighting commits matching keyword regex AND commits touching the
+# "always-conflict" file set. If both upstreams had zero commits AND no
+# keyword matches, no-op (don't open a noise issue).
+
+set -eu
+source "$(dirname "$0")/tripwire-common.sh"
+
+KEYWORDS='breaking|deprecat|migration|rewrite|schema|password|auth|csrf|xss|injection'
+CONFLICT_FILES='api/routes.py|api/onboarding.py|api/streaming.py|api/config.py|static/index.html|static/panels.js'
+
+since=$(date -u -v-1d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)
+
+# Returns markdown list of commits since $since for the given repo+branch.
+# Each line: "- {sha} {author}: {message-first-line}"
+list_commits() {
+    local repo="$1" branch="$2"
+    gh api -X GET "repos/$repo/commits" \
+        -f sha="$branch" -f since="$since" --paginate 2>/dev/null \
+        | jq -r '.[] | "- `\(.sha[0:7])` \(.commit.author.name): \(.commit.message | split("\n")[0])"' \
+        || true
+}
+
+# Returns repo's commit count touching any of $CONFLICT_FILES since $since.
+list_conflict_commits() {
+    local repo="$1" branch="$2"
+    local count=0
+    local out=""
+    IFS='|' read -ra paths <<<"$CONFLICT_FILES"
+    for p in "${paths[@]}"; do
+        local shas
+        shas=$(gh api -X GET "repos/$repo/commits" \
+                 -f sha="$branch" -f path="$p" -f since="$since" --paginate 2>/dev/null \
+                 | jq -r '.[] | "\(.sha[0:7]) \(.commit.author.name): \(.commit.message | split("\n")[0])"' \
+                 || true)
+        if [ -n "$shas" ]; then
+            out="$out\n\n**Touched \`$p\`**:\n$(echo "$shas" | sed 's/^/- `/' | sed 's/ /` /')"
+            count=$((count + $(echo "$shas" | grep -c '^' || true)))
+        fi
+    done
+    echo "$count"
+    printf '%s' "$out"
+}
+
+webui=$(list_commits "$WEBUI_REPO" "$WEBUI_BRANCH")
+agent=$(list_commits "$AGENT_REPO" "$AGENT_BRANCH")
+
+# Filter to keyword hits.
+webui_kw=$(echo "$webui" | grep -iE "$KEYWORDS" || true)
+agent_kw=$(echo "$agent" | grep -iE "$KEYWORDS" || true)
+
+# Conflict-file fires (returns: count\nmarkdown)
+webui_conf_full=$(list_conflict_commits "$WEBUI_REPO" "$WEBUI_BRANCH")
+webui_conf_count=$(echo "$webui_conf_full" | head -1)
+webui_conf_md=$(echo "$webui_conf_full" | tail -n +2)
+
+webui_count=$(echo "$webui" | grep -c '^-' || true)
+agent_count=$(echo "$agent" | grep -c '^-' || true)
+
+# No-op if zero activity AND zero keyword hits AND zero conflict-file fires.
+if [ "$webui_count" = "0" ] && [ "$agent_count" = "0" ] \
+   && [ -z "$webui_kw" ] && [ -z "$agent_kw" ] \
+   && [ "$webui_conf_count" = "0" ]; then
+    echo "[tripwire/digest] no upstream activity in last 24h; no-op"
+    exit 0
+fi
+
+# Only fire issue if there's something noteworthy (keyword OR conflict file).
+# Plain commit counts go to log only, not an issue.
+if [ -z "$webui_kw" ] && [ -z "$agent_kw" ] && [ "$webui_conf_count" = "0" ]; then
+    echo "[tripwire/digest] $webui_count webui + $agent_count agent commits in last 24h; nothing noteworthy"
+    exit 0
+fi
+
+today=$(tripwire_today)
+body=$(cat <<EOF
+## Upstream activity digest (24h ending $today)
+
+| Upstream | Total commits | Keyword-flagged | Touched always-conflict file |
+|----------|--------------|------------------|------------------------------|
+| ${WEBUI_REPO}@${WEBUI_BRANCH} | $webui_count | $(echo "$webui_kw" | grep -c '^-' || echo 0) | $webui_conf_count |
+| ${AGENT_REPO}@${AGENT_BRANCH} | $agent_count | $(echo "$agent_kw" | grep -c '^-' || echo 0) | n/a |
+
+### Keyword matches (regex: \`$KEYWORDS\`)
+
+**${WEBUI_REPO}:**
+${webui_kw:-_(none)_}
+
+**${AGENT_REPO}:**
+${agent_kw:-_(none)_}
+
+### Always-conflict file touches (regex: \`$CONFLICT_FILES\`)
+
+${webui_conf_md:-_(none)_}
+
+---
+
+**Action:** review listed commits; if any will conflict with the Fox overlay anchors, plan a pre-emptive anchor refresh before the next \`upstream-watch.yml\` auto-PR opens.
+EOF
+)
+
+tripwire_fire \
+    "[tripwire/digest] upstream-commit digest (rolling)" \
+    "$body" \
+    "tripwire-fire,tripwire/digest"

--- a/.github/scripts/tripwire-common.sh
+++ b/.github/scripts/tripwire-common.sh
@@ -1,0 +1,66 @@
+# .github/scripts/tripwire-common.sh
+#
+# Shared helpers sourced by every tripwire script. Keep this thin —
+# anything that diverges per-tripwire stays in the per-tripwire script.
+
+set -eu
+
+REPO="${GITHUB_REPOSITORY:-fox-in-the-box-ai/fox-in-the-box}"
+RUN_URL="${GITHUB_SERVER_URL:-https://github.com}/${REPO}/actions/runs/${GITHUB_RUN_ID:-local}"
+
+# Open or re-fire an issue. De-dupe by exact title match.
+#
+# Usage:
+#   tripwire_fire "<exact-title>" "<body markdown>" "<comma,sep,labels>"
+#
+# If an open issue with the same title exists, comment "Re-fired on
+# <RUN_URL>" + the new body on it. Otherwise create.
+tripwire_fire() {
+    local title="$1"
+    local body="$2"
+    local labels="$3"
+
+    local existing
+    existing=$(gh issue list --repo "$REPO" --state open \
+                 --search "in:title \"$title\"" \
+                 --json number,title \
+                 -q ".[] | select(.title == \"$title\") | .number" \
+                 2>/dev/null | head -1)
+
+    if [ -n "$existing" ]; then
+        gh issue comment "$existing" --repo "$REPO" --body "$(printf '%s\n\n_Re-fired on %s_' "$body" "$RUN_URL")"
+        echo "[tripwire] re-fired existing issue #$existing"
+        return 0
+    fi
+
+    # Build --label args from comma-separated list.
+    local label_args=()
+    IFS=',' read -ra parts <<<"$labels"
+    for l in "${parts[@]}"; do
+        l="$(echo "$l" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+        [ -z "$l" ] && continue
+        label_args+=("--label" "$l")
+    done
+
+    gh issue create --repo "$REPO" \
+        --title "$title" \
+        --body "$(printf '%s\n\n_Fired by upstream-tripwires.yml run %s_' "$body" "$RUN_URL")" \
+        "${label_args[@]}"
+}
+
+# Read JSON state file (one shared file per category), defaulting to "{}"
+# if missing. Used by license_watch + branch_watch for diff baselines.
+tripwire_state_read() {
+    local path="$1"
+    if [ -f "$path" ]; then
+        cat "$path"
+    else
+        echo "{}"
+    fi
+}
+
+# Pretty-print the date used in titles so dedupe works across days. Keep
+# titles STABLE across days — only the body/comment date changes.
+tripwire_today() {
+    date -u +%Y-%m-%d
+}

--- a/.github/scripts/tripwire-cve-feed.sh
+++ b/.github/scripts/tripwire-cve-feed.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Tripwire #212 — CVE feed subscription (GHSA polling).
+#
+# Polls GitHub Security Advisories for both upstreams. Any open or recent
+# advisory opens (or re-fires) an issue with severity in the title.
+
+set -eu
+source "$(dirname "$0")/tripwire-common.sh"
+
+check_repo_advisories() {
+    local repo="$1"
+    local advisories
+    advisories=$(gh api -X GET "repos/$repo/security-advisories" --paginate 2>/dev/null \
+                   | jq -c '.[] | select(.state=="published" or .state=="draft")' \
+                   2>/dev/null || true)
+
+    if [ -z "$advisories" ]; then
+        echo "[tripwire/cve] $repo: no advisories"
+        return 0
+    fi
+
+    echo "$advisories" | while IFS= read -r adv; do
+        local ghsa_id severity summary description html_url
+        ghsa_id=$(echo "$adv" | jq -r '.ghsa_id // ""')
+        severity=$(echo "$adv" | jq -r '.severity // "unknown"')
+        summary=$(echo "$adv" | jq -r '.summary // .description // ""' | head -c 200)
+        html_url=$(echo "$adv" | jq -r '.html_url // ""')
+
+        body=$(cat <<EOF
+## Security advisory on \`$repo\`
+
+| Field | Value |
+|-------|-------|
+| GHSA  | \`$ghsa_id\` |
+| Severity | $severity |
+| Summary | $summary |
+| Link  | $html_url |
+
+## Actions
+
+- [ ] Read the full advisory at $html_url
+- [ ] Determine if Fox's pinned tag in \`packages/fox-overlay/versions.toml\` is affected
+- [ ] If affected: emergency bump to the patched upstream tag (do NOT wait for nightly upstream-watch)
+- [ ] If not affected (e.g. advisory predates pinned tag): close this issue
+
+EOF
+)
+        tripwire_fire \
+            "[tripwire/cve] $repo — $ghsa_id ($severity)" \
+            "$body" \
+            "tripwire-fire,tripwire/cve,security,P0"
+    done
+}
+
+check_repo_advisories "$WEBUI_REPO"
+check_repo_advisories "$AGENT_REPO"

--- a/.github/scripts/tripwire-e2e-pair-verify.sh
+++ b/.github/scripts/tripwire-e2e-pair-verify.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Tripwire #214 — end-to-end pair test in Fox CI.
+#
+# ALREADY SHIPPED via `.github/workflows/build-container.yml`:
+#   - assembles the container from the pinned webui + pinned agent + overlay
+#   - runs Smoke (amd64) and Smoke (arm64) against the assembled image
+# That IS the pair test.
+#
+# This tripwire's job is to (a) sanity-check that build-container.yml still
+# does what it claims and (b) keep the tripwire accounted for in the daily
+# matrix.
+
+set -eu
+source "$(dirname "$0")/tripwire-common.sh"
+
+failures=()
+
+# 1. build-container.yml exists.
+if [ ! -f .github/workflows/build-container.yml ]; then
+    failures+=("missing: .github/workflows/build-container.yml")
+fi
+
+# 2. It still references both Smoke jobs.
+for arch in amd64 arm64; do
+    if ! grep -qE "Smoke.*$arch|smoke.*$arch" .github/workflows/build-container.yml; then
+        failures+=("build-container.yml no longer references Smoke ($arch)")
+    fi
+done
+
+# 3. It still includes the check-overlay-basis gate (proves it's exercising the overlay).
+if ! grep -q 'check-overlay-basis.sh' .github/workflows/build-container.yml; then
+    failures+=("build-container.yml no longer runs check-overlay-basis.sh — pair test may not be exercising overlay properly")
+fi
+
+if [ ${#failures[@]} -eq 0 ]; then
+    echo "[tripwire/e2e-pair] verified: build-container.yml exercises pinned webui + pinned agent + overlay end-to-end"
+    exit 0
+fi
+
+body=$(cat <<EOF
+## E2E pair-test invariants broken
+
+The \`build-container.yml\` workflow is meant to be the end-to-end pair test — assembling the pinned webui + pinned agent + fox-overlay and running smoke jobs against the resulting container. The following invariants have been violated:
+
+$(printf -- '- %s\n' "${failures[@]}")
+
+## Actions
+
+- [ ] Inspect \`.github/workflows/build-container.yml\` and restore the missing piece, OR
+- [ ] Update this tripwire's expected invariants in \`.github/scripts/tripwire-e2e-pair-verify.sh\` if the build pipeline intentionally moved
+
+EOF
+)
+
+tripwire_fire \
+    "[tripwire/e2e-pair] build-container.yml pair-test invariants broken" \
+    "$body" \
+    "tripwire-fire,tripwire/e2e-pair,P1"

--- a/.github/scripts/tripwire-issue-age.sh
+++ b/.github/scripts/tripwire-issue-age.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Tripwire #216 — open-issue-age sentry.
+#
+# Fires when the oldest open issue on either upstream is > $THRESHOLD_DAYS
+# old AND the upstream itself is < $UPSTREAM_AGE_MAX_MONTHS months old (so
+# this catches "active project, neglected issues" rather than misfiring on
+# mature projects with naturally old backlog).
+
+set -eu
+source "$(dirname "$0")/tripwire-common.sh"
+
+THRESHOLD_DAYS=90
+UPSTREAM_AGE_MAX_MONTHS=12
+
+check_repo() {
+    local repo="$1"
+
+    # Upstream age (in months).
+    local created
+    created=$(gh api "repos/$repo" -q .created_at 2>/dev/null || echo "")
+    [ -z "$created" ] && { echo "[tripwire/issue-age] $repo: cannot read created_at; skip"; return 0; }
+
+    local created_epoch now_epoch upstream_age_months
+    created_epoch=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$created" +%s 2>/dev/null \
+                    || date -u -d "$created" +%s)
+    now_epoch=$(date -u +%s)
+    upstream_age_months=$(( (now_epoch - created_epoch) / 2592000 ))  # ~30d/mo
+
+    if [ "$upstream_age_months" -gt "$UPSTREAM_AGE_MAX_MONTHS" ]; then
+        echo "[tripwire/issue-age] $repo: upstream age $upstream_age_months mo > cap $UPSTREAM_AGE_MAX_MONTHS mo; skip (mature project)"
+        return 0
+    fi
+
+    # Oldest open issue (`gh api` sorts asc by created with `-f sort=created -f direction=asc`).
+    local oldest
+    oldest=$(gh api -X GET "repos/$repo/issues" \
+              -f state=open -f sort=created -f direction=asc -f per_page=1 2>/dev/null \
+              | jq -c '.[0] // empty' \
+              2>/dev/null || true)
+
+    if [ -z "$oldest" ]; then
+        echo "[tripwire/issue-age] $repo: no open issues; no-op"
+        return 0
+    fi
+
+    local oldest_iso oldest_num oldest_title oldest_url
+    oldest_iso=$(echo "$oldest" | jq -r .created_at)
+    oldest_num=$(echo "$oldest" | jq -r .number)
+    oldest_title=$(echo "$oldest" | jq -r .title)
+    oldest_url=$(echo "$oldest" | jq -r .html_url)
+
+    local oldest_epoch age_days
+    oldest_epoch=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$oldest_iso" +%s 2>/dev/null \
+                   || date -u -d "$oldest_iso" +%s)
+    age_days=$(( (now_epoch - oldest_epoch) / 86400 ))
+
+    if [ "$age_days" -le "$THRESHOLD_DAYS" ]; then
+        echo "[tripwire/issue-age] $repo: oldest open issue is $age_days days old (≤ $THRESHOLD_DAYS); no-op"
+        return 0
+    fi
+
+    local body
+    body=$(cat <<EOF
+## Oldest open issue on \`$repo\` exceeds $THRESHOLD_DAYS days
+
+| Field | Value |
+|-------|-------|
+| Oldest issue | [\`#$oldest_num\` $oldest_title]($oldest_url) |
+| Created | $oldest_iso ($age_days days ago) |
+| Upstream age | $upstream_age_months months (within $UPSTREAM_AGE_MAX_MONTHS-month freshness window) |
+
+## Why this matters
+
+Issue accretion in young projects signals maintainer triage capacity is below intake rate. Per Architect 3 §10, persistent issue-age growth on a young upstream is a leading indicator that Scenario A (maintainer overload → eventual abandonment) is in play.
+
+## Actions
+
+- [ ] Inspect $oldest_url — is it truly neglected or just a low-priority enhancement?
+- [ ] Skim the upstream's recent issue activity — is overall response time degrading?
+- [ ] If yes: re-evaluate dependence on this upstream in v0.7.x planning
+- [ ] If no (one-off neglected enhancement): close this issue; tripwire will re-fire if the new oldest issue also exceeds threshold
+
+EOF
+)
+
+    tripwire_fire \
+        "[tripwire/issue-age] $repo oldest open issue >${THRESHOLD_DAYS}d (#$oldest_num)" \
+        "$body" \
+        "tripwire-fire,tripwire/issue-age,P2"
+}
+
+check_repo "$WEBUI_REPO"
+check_repo "$AGENT_REPO"

--- a/.github/scripts/tripwire-license-watch.sh
+++ b/.github/scripts/tripwire-license-watch.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Tripwire #208 — license watch.
+#
+# Compares the SHA-1 (git blob OID) of LICENSE on each upstream's default
+# branch to the baseline SHA recorded in .github/state/upstream-licenses.json.
+# Fires on any mismatch.
+#
+# Resolve by:
+#   1. Reviewing the new LICENSE text on the upstream
+#   2. If acceptable, editing .github/state/upstream-licenses.json with the
+#      new SHA and merging — workflow will go quiet
+#   3. If unacceptable (license change!), strategic decision required
+#      before bumping the submodule pin
+
+set -eu
+source "$(dirname "$0")/tripwire-common.sh"
+
+STATE_FILE=".github/state/upstream-licenses.json"
+
+# Fetch current LICENSE SHA from each upstream.
+current_webui_sha=$(gh api "repos/$WEBUI_REPO/contents/LICENSE?ref=$WEBUI_BRANCH" -q .sha 2>/dev/null || echo "MISSING")
+current_agent_sha=$(gh api "repos/$AGENT_REPO/contents/LICENSE?ref=$AGENT_BRANCH" -q .sha 2>/dev/null || echo "MISSING")
+
+state=$(tripwire_state_read "$STATE_FILE")
+baseline_webui_sha=$(echo "$state" | jq -r '.webui // ""')
+baseline_agent_sha=$(echo "$state" | jq -r '.agent // ""')
+
+fires=()
+if [ -n "$baseline_webui_sha" ] && [ "$baseline_webui_sha" != "$current_webui_sha" ]; then
+    fires+=("$WEBUI_REPO: $baseline_webui_sha → $current_webui_sha")
+fi
+if [ -n "$baseline_agent_sha" ] && [ "$baseline_agent_sha" != "$current_agent_sha" ]; then
+    fires+=("$AGENT_REPO: $baseline_agent_sha → $current_agent_sha")
+fi
+
+# Empty baseline = first run; just log and exit without firing. Bootstrap
+# the baseline by editing $STATE_FILE manually with today's SHAs.
+if [ -z "$baseline_webui_sha" ] && [ -z "$baseline_agent_sha" ]; then
+    echo "[tripwire/license] baseline empty; bootstrap $STATE_FILE with:"
+    echo "  webui ($WEBUI_REPO): $current_webui_sha"
+    echo "  agent ($AGENT_REPO): $current_agent_sha"
+    exit 0
+fi
+
+if [ ${#fires[@]} -eq 0 ]; then
+    echo "[tripwire/license] both LICENSE SHAs match baseline; no-op"
+    exit 0
+fi
+
+body=$(cat <<EOF
+## LICENSE drift detected on at least one upstream
+
+$(printf -- '- %s\n' "${fires[@]}")
+
+The baseline SHA in \`$STATE_FILE\` no longer matches the upstream LICENSE file's blob SHA. Possible causes:
+1. **Cosmetic change** (formatting, copyright year bump) — acceptable; update baseline and move on.
+2. **Material license change** — STOP. Do not bump the submodule pin until legal/compliance review.
+
+## Resolution
+
+1. Inspect the diff:
+   \`\`\`
+   gh api repos/$WEBUI_REPO/contents/LICENSE?ref=$WEBUI_BRANCH -q .content | base64 -d
+   gh api repos/$AGENT_REPO/contents/LICENSE?ref=$AGENT_BRANCH -q .content | base64 -d
+   \`\`\`
+2. If accepted: open a PR updating \`$STATE_FILE\` with the new SHA(s) — workflow will go quiet.
+3. If material: file a P0 + halt the next \`upstream-watch.yml\` bump-PR until resolved.
+EOF
+)
+
+tripwire_fire \
+    "[tripwire/license] upstream LICENSE drift" \
+    "$body" \
+    "tripwire-fire,tripwire/license,P1"

--- a/.github/scripts/tripwire-maintainer-absence.sh
+++ b/.github/scripts/tripwire-maintainer-absence.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Tripwire #211 — maintainer absence canary (nesquena).
+#
+# Fires if `nesquena` (the upstream webui maintainer) has zero commits to
+# nesquena/hermes-webui in the last N days. Default N=5 (matches v0.6.0
+# baseline of "zero 5+ day gaps in 48 days").
+
+set -eu
+source "$(dirname "$0")/tripwire-common.sh"
+
+MAINTAINER="nesquena"
+WINDOW_DAYS=5
+
+since=$(date -u -v-${WINDOW_DAYS}d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+        || date -u -d "$WINDOW_DAYS days ago" +%Y-%m-%dT%H:%M:%SZ)
+
+count=$(gh api -X GET "repos/$WEBUI_REPO/commits" \
+          -f sha="$WEBUI_BRANCH" -f author="$MAINTAINER" -f since="$since" --paginate 2>/dev/null \
+          | jq -r '.[].sha' | wc -l | tr -d ' ')
+
+if [ "$count" -gt 0 ]; then
+    echo "[tripwire/absence] $MAINTAINER: $count commits in last $WINDOW_DAYS days; no-op"
+    exit 0
+fi
+
+body=$(cat <<EOF
+## \`$MAINTAINER\` silent for $WINDOW_DAYS+ days on \`$WEBUI_REPO\`
+
+Baseline at v0.6.0: zero gaps of $WINDOW_DAYS+ silent days in 48 observed days. Today's run finds zero \`$MAINTAINER\`-authored commits to \`$WEBUI_BRANCH\` since $since.
+
+## Why this matters
+
+\`$WEBUI_REPO\` is Fox's webui submodule source. If \`$MAINTAINER\` becomes unresponsive (illness, life event, abandonment), the project enters Scenario A per Architect 3 §8: Fox eventually has to fork-and-stop or migrate to an alternative.
+
+## Actions
+
+- [ ] Check \`$MAINTAINER\`'s public activity: https://github.com/$MAINTAINER
+- [ ] Inspect \`$WEBUI_REPO\`'s issue tracker for maintainer comments in the last week
+- [ ] If genuinely absent for an extended period: re-evaluate v0.6.x/v0.7.x strategy
+- [ ] Debounce: during known multi-week migrations (e.g. our own v0.6.0), this fires spuriously — close this issue if context explains the gap
+
+EOF
+)
+
+tripwire_fire \
+    "[tripwire/absence] $MAINTAINER silent for $WINDOW_DAYS+ days on $WEBUI_REPO" \
+    "$body" \
+    "tripwire-fire,tripwire/absence,P1"

--- a/.github/scripts/tripwire-nous-ui-watch.sh
+++ b/.github/scripts/tripwire-nous-ui-watch.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Tripwire #210 — NousResearch official-UI watch.
+#
+# Checks for the appearance of `webui/`, `frontend/`, or `static/`
+# directories at the root of NousResearch/hermes-agent. Their appearance
+# would signal NousResearch is shipping their own UI — Fox should pivot
+# to "build-our-own" per Architect 3 §8 Scenario B.
+
+set -eu
+source "$(dirname "$0")/tripwire-common.sh"
+
+# `gh api repos/{owner}/{repo}/contents/` lists root dir; filter for any
+# directory entry whose name matches our watch list.
+dirs=$(gh api "repos/$AGENT_REPO/contents?ref=$AGENT_BRANCH" \
+        -q '.[] | select(.type=="dir") | .name' 2>/dev/null || true)
+
+watch_list="webui frontend static ui app react-app"
+matches=""
+for d in $dirs; do
+    for w in $watch_list; do
+        if [ "$d" = "$w" ]; then
+            matches="$matches $d"
+        fi
+    done
+done
+
+# Trim leading whitespace.
+matches="$(echo "$matches" | sed -E 's/^[[:space:]]+//')"
+
+if [ -z "$matches" ]; then
+    echo "[tripwire/nous-ui] no UI-suggestive dir at root of $AGENT_REPO"
+    exit 0
+fi
+
+body=$(cat <<EOF
+## CRITICAL — NousResearch may be shipping an official UI
+
+\`$AGENT_REPO@$AGENT_BRANCH\` root now contains UI-suggestive directories:
+
+$(printf -- '- `%s/`\n' $matches)
+
+If NousResearch ships an official UI, the calculus for depending on \`nesquena/hermes-webui\` changes substantially. Per Architect 3 §8 Scenario B: pivot Fox to either (a) use the official UI directly with a thin Fox overlay, or (b) build Fox's own UI.
+
+## Actions
+
+- [ ] Inspect the directory: https://github.com/$AGENT_REPO/tree/$AGENT_BRANCH/$(echo $matches | awk '{print $1}')
+- [ ] Read NousResearch's announcement / discussion / README context
+- [ ] Strategic review with Dennis — does this change v0.7.x / v0.8.x direction?
+- [ ] If false positive (dir exists for unrelated reasons), close this issue
+
+EOF
+)
+
+tripwire_fire \
+    "[tripwire/nous-ui] $AGENT_REPO root contains UI-suggestive directory" \
+    "$body" \
+    "tripwire-fire,tripwire/nous-ui,P0"

--- a/.github/scripts/tripwire-rebase-clock.sh
+++ b/.github/scripts/tripwire-rebase-clock.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Tripwire #215 — patch-series rebase clock.
+#
+# v0 implementation: opens issue if any patch file under
+# `packages/fox-overlay/patches/{webui,agent}/*.patch` was last modified
+# more than $THRESHOLD_DAYS days ago.
+#
+# Original spec wanted a rolling-average of "time-to-rebase per upstream
+# pull" — that needs historical telemetry we don't have. The freshness
+# clock catches the same underlying concern (overlay anchors going stale)
+# with simpler infrastructure.
+
+set -eu
+source "$(dirname "$0")/tripwire-common.sh"
+
+THRESHOLD_DAYS=90
+
+stale=()
+for series_dir in packages/fox-overlay/patches/webui packages/fox-overlay/patches/agent; do
+    [ -d "$series_dir" ] || continue
+    for patch in "$series_dir"/*.patch; do
+        [ -f "$patch" ] || continue
+        # Last commit touching this file.
+        last_iso=$(git log -1 --format=%cI -- "$patch" 2>/dev/null || true)
+        [ -z "$last_iso" ] && continue
+        last_epoch=$(date -u -j -f '%Y-%m-%dT%H:%M:%S%z' "$last_iso" +%s 2>/dev/null \
+                     || date -u -d "$last_iso" +%s 2>/dev/null \
+                     || echo 0)
+        now_epoch=$(date -u +%s)
+        age_days=$(( (now_epoch - last_epoch) / 86400 ))
+        if [ "$age_days" -gt "$THRESHOLD_DAYS" ]; then
+            stale+=("\`$patch\` ($age_days days since last touch)")
+        fi
+    done
+done
+
+if [ ${#stale[@]} -eq 0 ]; then
+    echo "[tripwire/rebase-clock] no overlay patch file older than $THRESHOLD_DAYS days; no-op"
+    exit 0
+fi
+
+body=$(cat <<EOF
+## Overlay patch files exceed freshness threshold ($THRESHOLD_DAYS days)
+
+$(printf -- '- %s\n' "${stale[@]}")
+
+## Why this matters
+
+Long-lived overlay patches against upstream that keeps moving are a structural risk: the anchors silently rot, then a routine \`upstream-watch.yml\` bump fails \`check-overlay-basis.sh\` with no recent context to guide the fix. Per Architect 3 §9 (\"fork-and-stop precondition\"), persistently stale overlay code is a leading indicator that the overlay strategy itself needs re-evaluation.
+
+## Actions
+
+- [ ] For each stale patch: refresh against the current submodule pin (re-generate from a fresh \`git apply\`-able state)
+- [ ] If a patch is intentionally long-lived because the anchor truly hasn't moved, document why in a comment above the patch in its \`series\` file
+- [ ] Close this issue once patches are refreshed; will re-fire if it crosses the threshold again
+
+EOF
+)
+
+tripwire_fire \
+    "[tripwire/rebase-clock] overlay patch file(s) older than ${THRESHOLD_DAYS}d" \
+    "$body" \
+    "tripwire-fire,tripwire/rebase-clock,P2"

--- a/.github/scripts/tripwire-stage-batch-gap.sh
+++ b/.github/scripts/tripwire-stage-batch-gap.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Tripwire #213 — stage-batch monitoring.
+#
+# nesquena's release cadence stamps commits with messages like
+# "Stamp CHANGELOG for v0.51.84 (Release BH / stage-377)".
+# If the gap between the most-recent such stamp and now > $THRESHOLD_HOURS
+# AND there have been non-stamp commits since (unreleased activity), the
+# release pipeline is likely down. Early signal of maintainer outage.
+
+set -eu
+source "$(dirname "$0")/tripwire-common.sh"
+
+STAMP_REGEX='Stamp CHANGELOG'
+THRESHOLD_HOURS=48
+
+last_stamp_iso=$(gh api -X GET "repos/$WEBUI_REPO/commits" \
+                   -f sha="$WEBUI_BRANCH" -f per_page=100 --paginate 2>/dev/null \
+                   | jq -r '.[] | select(.commit.message | test("'"$STAMP_REGEX"'")) | .commit.committer.date' \
+                   2>/dev/null \
+                   | head -1 || true)
+
+if [ -z "$last_stamp_iso" ]; then
+    echo "[tripwire/stage-batch] no stamp commit found in recent history; cannot evaluate"
+    exit 0
+fi
+
+# Hours since last stamp.
+now_epoch=$(date -u +%s)
+last_stamp_epoch=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$last_stamp_iso" +%s 2>/dev/null \
+                   || date -u -d "$last_stamp_iso" +%s)
+gap_hours=$(( (now_epoch - last_stamp_epoch) / 3600 ))
+
+# Commits since the last stamp (i.e. unreleased work).
+unreleased=$(gh api -X GET "repos/$WEBUI_REPO/commits" \
+               -f sha="$WEBUI_BRANCH" -f since="$last_stamp_iso" --paginate 2>/dev/null \
+               | jq -r '.[].sha' | wc -l | tr -d ' ')
+# Subtract 1 (the stamp itself is in the range).
+unreleased=$((unreleased - 1))
+[ "$unreleased" -lt 0 ] && unreleased=0
+
+if [ "$gap_hours" -lt "$THRESHOLD_HOURS" ]; then
+    echo "[tripwire/stage-batch] last stamp $gap_hours h ago (< $THRESHOLD_HOURS h); no-op"
+    exit 0
+fi
+
+if [ "$unreleased" -eq 0 ]; then
+    echo "[tripwire/stage-batch] $gap_hours h since last stamp BUT no unreleased commits; no-op (quiet period, not a stall)"
+    exit 0
+fi
+
+body=$(cat <<EOF
+## Stage-batch release stamp gap on \`$WEBUI_REPO\`
+
+Last \`$STAMP_REGEX\` commit on \`$WEBUI_BRANCH\` was **$gap_hours hours ago** ($last_stamp_iso). Since then, **$unreleased non-stamp commits** have landed without a new release stamp.
+
+Threshold: $THRESHOLD_HOURS hours.
+
+## Why this matters
+
+\`nesquena\`'s normal cadence is a stage-NNN release within hours of merging stage-N commits. A multi-day gap with unreleased work usually signals the release pipeline broke (CI failure, deployment block, maintainer outage).
+
+## Actions
+
+- [ ] Check \`$WEBUI_REPO\`'s Actions tab for failing release runs
+- [ ] Read recent unreleased commits — anything indicating intentional release delay?
+- [ ] If genuine stall, surface to upstream via issue
+- [ ] If intentional pause (e.g. holiday, planned reorg), close this issue
+
+EOF
+)
+
+tripwire_fire \
+    "[tripwire/stage-batch] $WEBUI_REPO release stamp gap >${THRESHOLD_HOURS}h" \
+    "$body" \
+    "tripwire-fire,tripwire/stage-batch,P2"

--- a/.github/state/upstream-licenses.json
+++ b/.github/state/upstream-licenses.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "License-watch baseline (tripwire #208). Blob SHAs of LICENSE on each upstream's default branch at the time of v0.6.0 ship. Update via PR when an intentional license change is reviewed and accepted; the workflow goes quiet once the SHAs match.",
+  "_recorded_at": "2026-05-18 (v0.6.0)",
+  "_recorded_by": "tripwire-license-watch.sh — bootstrap entry",
+  "webui": "b1beedc34d88c427425f732a3669e5b2ee6ee8b9",
+  "agent": "75410e73319c72cd3e991a501c5455eb78f38375"
+}

--- a/.github/workflows/upstream-tripwires.yml
+++ b/.github/workflows/upstream-tripwires.yml
@@ -1,0 +1,241 @@
+# .github/workflows/upstream-tripwires.yml
+#
+# Consolidated upstream-monitoring tripwires (v0.6.0 — issue #206).
+#
+# Originally specced as 10 separate workflows (#207 thru #216). Consolidated
+# into one file because they share scaffolding: daily cron, GitHub API
+# calls against the two upstream repos, dedupe-by-title issue creation.
+# Splitting would multiply maintenance with no benefit.
+#
+# Each tripwire is its own job. All jobs are independent; one failing does
+# not skip the others. A job's "fire" condition opens (or reuses) one issue
+# with a stable title; subsequent fires bump the existing issue rather than
+# stack. Issue closes happen by human inspection after the upstream condition
+# clears.
+#
+# Tripwires implemented:
+#   #207  upstream_commit_digest   — daily commits + keyword/file flagging
+#   #208  license_watch            — LICENSE drift on either upstream
+#   #209  branch_creation_watch    — new upstream branch matches rewrite-regex
+#   #210  nousresearch_ui_watch    — webui/frontend/static dir appears in agent
+#   #211  maintainer_absence       — nesquena silent for 5+ days
+#   #212  cve_feed                 — new GHSA on either upstream
+#   #213  stage_batch_gap          — stage-NNN release stamp gap >48h
+#   #214  e2e_pair_test            — verified-shipped (see comment in job)
+#   #215  patch_rebase_clock       — oldest overlay patch refresh-age
+#   #216  open_issue_age           — oldest upstream open issue >90d
+#
+# See docs/architecture/upstream-overlay.md §Operational → "Tripwires" for
+# the resolution playbook for each label.
+
+name: Upstream Tripwires
+
+on:
+  schedule:
+    # 06:00 UTC daily — 43 min after upstream-watch.yml (05:17 UTC) so
+    # they don't race on the GitHub API rate limit.
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+    inputs:
+      only:
+        description: 'Run only this tripwire (e.g. "license_watch"); empty = all'
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  WEBUI_REPO: nesquena/hermes-webui
+  AGENT_REPO: NousResearch/hermes-agent
+  WEBUI_BRANCH: master
+  AGENT_BRANCH: main
+  # Shared label all tripwire-opened issues carry; lets you filter the
+  # backlog at a glance with `gh issue list --label tripwire-fire`.
+  TRIPWIRE_LABEL: tripwire-fire
+
+jobs:
+
+  # ── #207 — Daily upstream-commit digest ─────────────────────────────────
+  # Highlights commits matching keyword regex AND commits touching the
+  # "always-conflict" file set. If both upstreams have zero commits in the
+  # last 24h, no-op. Issue carries `tripwire/digest` for filtering.
+  upstream_commit_digest:
+    if: github.event.inputs.only == '' || github.event.inputs.only == 'upstream_commit_digest'
+    name: "#207 daily commit digest"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/tripwire-commit-digest.sh
+
+  # ── #208 — License watch ────────────────────────────────────────────────
+  # SHA of LICENSE on each upstream is compared to the SHA stored in
+  # .github/state/upstream-licenses.json. Fires on drift. Resolve by
+  # running the workflow's "update baseline" step manually after the human
+  # review of the new license.
+  license_watch:
+    if: github.event.inputs.only == '' || github.event.inputs.only == 'license_watch'
+    name: "#208 license watch"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/tripwire-license-watch.sh
+
+  # ── #209 — Branch-creation watch ────────────────────────────────────────
+  # `git ls-remote --heads` against each upstream, filter on regex matching
+  # rewrite/major-version signals. Fires once per matching branch (dedupe
+  # by branch name in issue title).
+  branch_creation_watch:
+    if: github.event.inputs.only == '' || github.event.inputs.only == 'branch_creation_watch'
+    name: "#209 branch creation watch"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/tripwire-branch-watch.sh
+
+  # ── #210 — NousResearch official-UI watch ───────────────────────────────
+  # Critical pivot signal — if Nous ships their own UI, Fox should
+  # re-evaluate its dependency on nesquena/hermes-webui.
+  nousresearch_ui_watch:
+    if: github.event.inputs.only == '' || github.event.inputs.only == 'nousresearch_ui_watch'
+    name: "#210 NousResearch UI watch"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/tripwire-nous-ui-watch.sh
+
+  # ── #211 — Maintainer absence canary (nesquena) ────────────────────────
+  # Baseline at v0.6.0: 0 gaps of 5+ silent days in 48 days. Fires if
+  # nesquena has zero commits to upstream/master for 5 consecutive days.
+  # Debounce note: during 5-week migrations (rare), suppress manually by
+  # closing the issue.
+  maintainer_absence:
+    if: github.event.inputs.only == '' || github.event.inputs.only == 'maintainer_absence'
+    name: "#211 maintainer absence"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/tripwire-maintainer-absence.sh
+
+  # ── #212 — CVE feed (GHSA polling) ─────────────────────────────────────
+  # Polls /repos/{owner}/{repo}/security-advisories for both upstreams.
+  # Any new advisory opens an issue with severity in title.
+  cve_feed:
+    if: github.event.inputs.only == '' || github.event.inputs.only == 'cve_feed'
+    name: "#212 CVE feed"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/tripwire-cve-feed.sh
+
+  # ── #213 — Stage-batch monitoring ──────────────────────────────────────
+  # nesquena's release cadence stamps commits like
+  # "Stamp CHANGELOG for v0.51.84 (Release BH / stage-377)". If the gap
+  # between the most recent such stamp and now exceeds 48h while there
+  # is unreleased commit activity, the release pipeline likely broke —
+  # early signal of maintainer outage.
+  stage_batch_gap:
+    if: github.event.inputs.only == '' || github.event.inputs.only == 'stage_batch_gap'
+    name: "#213 stage-batch gap"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/tripwire-stage-batch-gap.sh
+
+  # ── #214 — E2E pair test ────────────────────────────────────────────────
+  # ALREADY SHIPPED. build-container.yml builds the assembled container
+  # (webui pin + agent pin + overlay) and runs the smoke jobs against it —
+  # that IS the pair test. This job exists only to surface the assertion
+  # in the daily report so the tripwire stays accounted for.
+  e2e_pair_test:
+    if: github.event.inputs.only == '' || github.event.inputs.only == 'e2e_pair_test'
+    name: "#214 e2e pair test (verify build-container.yml)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/tripwire-e2e-pair-verify.sh
+
+  # ── #215 — Patch-series rebase clock ───────────────────────────────────
+  # v0 impl: opens issue if the oldest patch file under
+  # packages/fox-overlay/patches/{webui,agent}/*.patch is older than
+  # the threshold (THRESHOLD_DAYS in script). Original spec wanted a
+  # rolling-average of "time-to-rebase per upstream pull" — that needs
+  # historical telemetry we don't have, so v0 ships the freshness clock.
+  patch_rebase_clock:
+    if: github.event.inputs.only == '' || github.event.inputs.only == 'patch_rebase_clock'
+    name: "#215 patch rebase clock"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # need full history to compute file age
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/tripwire-rebase-clock.sh
+
+  # ── #216 — Open-issue-age sentry ───────────────────────────────────────
+  # Tracks the oldest open issue on each upstream. Fires when oldest > 90d
+  # AND upstream is < 12mo old (so old-issue accretion doesn't mask the
+  # baseline neglect signal once the project ages naturally).
+  open_issue_age:
+    if: github.event.inputs.only == '' || github.event.inputs.only == 'open_issue_age'
+    name: "#216 open issue age sentry"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/tripwire-issue-age.sh
+
+  # ── Tripwire-job failure handler ────────────────────────────────────────
+  # If any tripwire job itself fails (network blip, API rate limit, script
+  # bug), open one combined issue rather than ten — surfacing infra failure
+  # separately from upstream-condition fires.
+  workflow_self_health:
+    name: "self-health (open issue on tripwire-job failure)"
+    needs:
+      - upstream_commit_digest
+      - license_watch
+      - branch_creation_watch
+      - nousresearch_ui_watch
+      - maintainer_absence
+      - cve_feed
+      - stage_batch_gap
+      - e2e_pair_test
+      - patch_rebase_clock
+      - open_issue_age
+    if: always() && contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          title="[tripwire-self-health] one or more upstream-tripwire jobs failed in run ${{ github.run_id }}"
+          existing=$(gh issue list --repo "${{ github.repository }}" \
+                       --label tripwire-self-health --state open \
+                       --search "in:title \"tripwire-self-health\"" \
+                       --json number -q '.[0].number' 2>/dev/null || echo "")
+          body="Tripwire job(s) failed (not a real upstream condition — workflow itself broke). See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} for the failing job. Common causes: GitHub API rate limit, network blip, upstream URL change, script regression. Resolve by fixing the script or transient retry; close this issue when next run is green."
+          if [ -n "$existing" ]; then
+              gh issue comment "$existing" --body "Re-fired on run ${{ github.run_id }}. $body"
+          else
+              gh issue create --title "$title" --body "$body" \
+                --label tripwire-self-health --label P2
+          fi

--- a/docs/architecture/upstream-overlay.md
+++ b/docs/architecture/upstream-overlay.md
@@ -153,6 +153,25 @@ If `check-overlay-basis.sh` reported drift, an open issue (label
 `upstream-drift`) lists the failing anchor(s) — refresh in a preceding
 PR, then bump.
 
+### Tripwires (upstream-dependency monitoring)
+
+`.github/workflows/upstream-tripwires.yml` runs daily at 06:00 UTC (43 min after `upstream-watch.yml`) and exposes 10 independent monitoring jobs. Each opens (or re-fires on) an issue labeled `tripwire-fire + tripwire/<name>` when its condition triggers. Workflow-self-failure (network, API rate limit, script bug) opens a separate `tripwire-self-health` issue.
+
+| Job | Label | What it watches | Where to resolve |
+|-----|-------|----------------|------------------|
+| `upstream_commit_digest` (#207) | `tripwire/digest` | 24h commits on either upstream; flags keyword/conflict-file hits | Inspect listed commits; pre-emptive anchor refresh if any will conflict |
+| `license_watch` (#208) | `tripwire/license` | LICENSE blob SHA drift | Review diff; update `.github/state/upstream-licenses.json` baseline once intentional change is accepted |
+| `branch_creation_watch` (#209) | `tripwire/branch` | New upstream branch matching rewrite-regex (`react|vue|...|major`) | Inspect branch; strategic review if it's a rewrite-in-progress |
+| `nousresearch_ui_watch` (#210) | `tripwire/nous-ui` | `webui/`, `frontend/`, `static/` dir appearing at root of agent repo | Pivot review per Architect 3 §8 Scenario B |
+| `maintainer_absence` (#211) | `tripwire/absence` | `nesquena` silent for 5+ days on webui | Check public activity; close if explained by known context |
+| `cve_feed` (#212) | `tripwire/cve`, `security` | New GitHub Security Advisory on either upstream | Determine if pinned tag affected; emergency bump if so |
+| `stage_batch_gap` (#213) | `tripwire/stage-batch` | nesquena's `Stamp CHANGELOG` cadence breaks >48h with unreleased work | Check upstream CI; surface to upstream if real stall |
+| `e2e_pair_test` (#214) | `tripwire/e2e-pair` | Sanity check that `build-container.yml` still does the pair-test (already shipped) | Restore missing invariant or update tripwire expectations |
+| `patch_rebase_clock` (#215) | `tripwire/rebase-clock` | Overlay patch file untouched for >90 days | Refresh against current pin OR document why anchor is intentionally stable |
+| `open_issue_age` (#216) | `tripwire/issue-age` | Oldest open upstream issue >90d while upstream <12mo old | Inspect; re-evaluate dependence if upstream triage degrading |
+
+The full implementation lives in `.github/workflows/upstream-tripwires.yml` + `.github/scripts/tripwire-*.sh` (one script per tripwire — bash-based, no runtime deps beyond `gh` + `jq`). Per-tripwire dedupe is by exact issue title, so re-fires comment on the existing issue rather than stack new ones. Bootstrap baseline state for stateful tripwires (license + future ones): `.github/state/`.
+
 ### Build-time flags
 
 - `FITB_DISABLE_WEBUI_OVERLAY=1` (build arg) — skip the webui patch


### PR DESCRIPTION
## Summary

**Closes #206, #207, #208, #209, #210, #211, #212, #213, #214, #215, #216.**

Ships `.github/workflows/upstream-tripwires.yml` + 10 per-tripwire bash scripts under `.github/scripts/` + bootstrap baseline state under `.github/state/`.

Consolidated into one workflow (one job per tripwire) instead of 10 separate workflows because they share scaffolding: daily cron, `gh` + `jq` against upstream, dedupe-by-title issue creation. Splitting would multiply maintenance with no benefit. Each tripwire is an independent job; one failing doesn't skip the others. A self-health job opens a `tripwire-self-health` issue if any tripwire job itself fails (network blip, API rate limit, script regression) — so infra failures don't masquerade as silent successes.

Daily cron at **06:00 UTC** (43 min after `upstream-watch.yml` at 05:17 UTC) so they don't race on the GitHub API rate limit. `workflow_dispatch` supports running a single tripwire via the `only` input for ad-hoc testing.

## Tripwires

| # | Job | What it watches |
|---|-----|-----------------|
| #207 | `upstream_commit_digest` | 24h commits with keyword + always-conflict-file flagging |
| #208 | `license_watch` | LICENSE blob-SHA drift on either upstream |
| #209 | `branch_creation_watch` | Branch name matching `react\|vue\|...\|major` regex |
| #210 | `nousresearch_ui_watch` | UI dirs appearing at root of `NousResearch/hermes-agent` |
| #211 | `maintainer_absence` | `nesquena` silent for 5+ days on webui |
| #212 | `cve_feed` | GitHub Security Advisories on either upstream |
| #213 | `stage_batch_gap` | nesquena release-stamp gap >48h with unreleased work |
| #214 | `e2e_pair_test` | Invariant check that `build-container.yml` still pair-tests |
| #215 | `patch_rebase_clock` | Oldest overlay patch file age >90d |
| #216 | `open_issue_age` | Oldest upstream open issue >90d while upstream <12mo |

## Bootstrap

`.github/state/upstream-licenses.json` is pre-populated with the current upstream LICENSE blob SHAs (webui `b1beedc3...`, agent `75410e73...`), so the workflow goes immediately live and stays quiet until a real LICENSE change.

## Docs

`docs/architecture/upstream-overlay.md` gets a new \"Tripwires\" subsection with the resolution playbook for each label.

## Test plan

- [ ] CI green (this PR doesn't modify the container build, so only lint-style + the existing required checks need to pass)
- [ ] After merge, manually trigger the workflow once via \`gh workflow run upstream-tripwires.yml\` to verify it runs end-to-end (each job either no-ops with a clean log or fires its issue)
- [ ] Force-fire test on at least one tripwire: edit \`.github/state/upstream-licenses.json\` baseline to a wrong SHA, manually trigger \`only: license_watch\`, confirm issue opens, revert