### PR TITLE
fix(tripwires): label auto-create + e2e-pair invariant + self-health checkout

### DIFF
--- a/.github/scripts/tripwire-common.sh
+++ b/.github/scripts/tripwire-common.sh
@@ -33,12 +33,21 @@ tripwire_fire() {
         return 0
     fi
 
-    # Build --label args from comma-separated list.
+    # Build --label args from comma-separated list. Idempotently create
+    # any missing labels first; `gh issue create --label X` errors out if
+    # X doesn't exist in the repo, and we don't want to pre-seed labels
+    # by hand or in a separate workflow step. `gh label create --force`
+    # is the idempotent variant: creates if missing, updates if present.
     local label_args=()
     IFS=',' read -ra parts <<<"$labels"
     for l in "${parts[@]}"; do
         l="$(echo "$l" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
         [ -z "$l" ] && continue
+        # Best-effort: don't fail the tripwire if label creation hits a
+        # permissions issue (the issue creation will surface the error).
+        gh label create "$l" --repo "$REPO" --force \
+            --color "$(tripwire_label_color "$l")" \
+            --description "auto-created by upstream-tripwires.yml" >/dev/null 2>&1 || true
         label_args+=("--label" "$l")
     done
 
@@ -46,6 +55,22 @@ tripwire_fire() {
         --title "$title" \
         --body "$(printf '%s\n\n_Fired by upstream-tripwires.yml run %s_' "$body" "$RUN_URL")" \
         "${label_args[@]}"
+}
+
+# Stable colour per label family so the issue list reads at a glance.
+tripwire_label_color() {
+    case "$1" in
+        tripwire-fire)         echo "d73a4a" ;;  # red
+        tripwire-self-health)  echo "fbca04" ;;  # yellow
+        tripwire/cve|security) echo "b60205" ;;  # dark red
+        tripwire/license)      echo "5319e7" ;;  # purple
+        tripwire/branch|tripwire/nous-ui) echo "d93f0b" ;;  # orange
+        tripwire/*)            echo "1d76db" ;;  # blue (generic tripwire scope)
+        P0)                    echo "b60205" ;;
+        P1)                    echo "d93f0b" ;;
+        P2)                    echo "fbca04" ;;
+        *)                     echo "cccccc" ;;
+    esac
 }
 
 # Read JSON state file (one shared file per category), defaulting to "{}"

--- a/.github/scripts/tripwire-e2e-pair-verify.sh
+++ b/.github/scripts/tripwire-e2e-pair-verify.sh
@@ -14,22 +14,35 @@ set -eu
 source "$(dirname "$0")/tripwire-common.sh"
 
 failures=()
+wf=.github/workflows/build-container.yml
 
 # 1. build-container.yml exists.
-if [ ! -f .github/workflows/build-container.yml ]; then
-    failures+=("missing: .github/workflows/build-container.yml")
+if [ ! -f "$wf" ]; then
+    failures+=("missing: $wf")
 fi
 
-# 2. It still references both Smoke jobs.
-for arch in amd64 arm64; do
-    if ! grep -qE "Smoke.*$arch|smoke.*$arch" .github/workflows/build-container.yml; then
-        failures+=("build-container.yml no longer references Smoke ($arch)")
-    fi
-done
+# 2. It defines a `smoke:` job (lowercase YAML key — the job that actually
+#    runs the assembled container, distinct from the build-and-push jobs).
+if [ -f "$wf" ] && ! grep -qE '^[[:space:]]+smoke:' "$wf"; then
+    failures+=("$wf no longer defines a 'smoke:' job — pair-test entry point gone")
+fi
 
-# 3. It still includes the check-overlay-basis gate (proves it's exercising the overlay).
-if ! grep -q 'check-overlay-basis.sh' .github/workflows/build-container.yml; then
-    failures+=("build-container.yml no longer runs check-overlay-basis.sh — pair test may not be exercising overlay properly")
+# 3. It runs on both archs via matrix entries. The exact format is
+#    `short: amd64` / `short: arm64` in the matrix list (rendered into
+#    the visible job name `Smoke (amd64)` / `Smoke (arm64)`), not a
+#    single line. Check each matrix entry.
+if [ -f "$wf" ]; then
+    for arch in amd64 arm64; do
+        if ! grep -qE "short:[[:space:]]+$arch" "$wf"; then
+            failures+=("$wf matrix no longer includes arch '$arch' (looked for 'short: $arch')")
+        fi
+    done
+fi
+
+# 4. It still includes the check-overlay-basis gate (proves the build
+#    actually exercises the overlay).
+if [ -f "$wf" ] && ! grep -q 'check-overlay-basis.sh' "$wf"; then
+    failures+=("$wf no longer runs check-overlay-basis.sh — pair test may not be exercising overlay properly")
 fi
 
 if [ ${#failures[@]} -eq 0 ]; then

--- a/.github/workflows/upstream-tripwires.yml
+++ b/.github/workflows/upstream-tripwires.yml
@@ -224,18 +224,30 @@ jobs:
     if: always() && contains(needs.*.result, 'failure')
     runs-on: ubuntu-latest
     steps:
+      # `gh` needs a git context for repo-scoped commands, and the
+      # `tripwire_label_color` helper needs the common script on disk.
+      # Without checkout this job dies with "fatal: not a git repository"
+      # before it can even open the self-health issue.
+      - uses: actions/checkout@v4
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          title="[tripwire-self-health] one or more upstream-tripwire jobs failed in run ${{ github.run_id }}"
-          existing=$(gh issue list --repo "${{ github.repository }}" \
-                       --label tripwire-self-health --state open \
-                       --search "in:title \"tripwire-self-health\"" \
-                       --json number -q '.[0].number' 2>/dev/null || echo "")
-          body="Tripwire job(s) failed (not a real upstream condition — workflow itself broke). See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} for the failing job. Common causes: GitHub API rate limit, network blip, upstream URL change, script regression. Resolve by fixing the script or transient retry; close this issue when next run is green."
-          if [ -n "$existing" ]; then
-              gh issue comment "$existing" --body "Re-fired on run ${{ github.run_id }}. $body"
-          else
-              gh issue create --title "$title" --body "$body" \
-                --label tripwire-self-health --label P2
-          fi
+          # Use the shared helper to ensure the self-health label exists,
+          # then open or re-fire the issue.
+          source .github/scripts/tripwire-common.sh
+          title="[tripwire-self-health] one or more upstream-tripwire jobs failed (rolling)"
+          body=$(cat <<EOF
+          ## At least one tripwire job failed in run \`${{ github.run_id }}\`
+
+          A tripwire-job-level failure usually means the workflow itself broke (script regression, GitHub API rate limit, network blip, upstream URL changed) — NOT a real upstream condition fire.
+
+          See: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          ## Resolution
+
+          - Inspect the failing job's log; fix the script if it's a regression
+          - If transient (rate limit / network), close this issue and wait for the next run
+          - If multiple jobs are failing concurrently, suspect a shared cause (label permissions, token expiry)
+          EOF
+          )
+          tripwire_fire "$title" "$body" "tripwire-self-health,P2"


### PR DESCRIPTION
## Summary

Three bugs surfaced by the first manual workflow run (run [26008432962](https://github.com/fox-in-the-box-ai/fox-in-the-box/actions/runs/26008432962)) after merging #259. All three are bootstrap-layer issues, not real upstream-condition fires.

| # | Symptom | Root cause | Fix |
|---|---------|------------|-----|
| 1 | #207 + #214 jobs failed with `could not add label: 'tripwire-fire' not found` | Labels never existed in the repo; `gh issue create --label X` errors on missing labels | `tripwire_fire` now `gh label create --force`s each label idempotently before opening the issue. Stable per-family colours via `tripwire_label_color` |
| 2 | #214 failed claiming `build-container.yml no longer references Smoke (amd64)` even though it does | Invariant check looked for literal "Smoke amd64" adjacent, but those strings are rendered from `${{ matrix.platform.short }}` — not adjacent in the YAML source | Check for the `smoke:` job key + `short: amd64`/`short: arm64` matrix entries separately + existing `check-overlay-basis.sh` reference |
| 3 | `self-health` job failed with `fatal: not a git repository` | Missing `actions/checkout` step; `gh` needs a git context | Add checkout + switch to the shared `tripwire_fire` helper (so self-health also benefits from label auto-create) |

## Test plan

- [ ] CI green on this PR
- [ ] After merge, re-trigger `gh workflow run upstream-tripwires.yml --ref main` → all 10 jobs should be green (or fire their issues correctly with proper labels). Self-health should stay green (no failed jobs to react to)