### PR TITLE
fix(upstream-watch): set -e killed workflow before drift check ran (#273)

### DIFF
--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -141,8 +141,18 @@ jobs:
               echo "[upstream-watch] both pins match latest; nothing to do"
           else
               echo "no_drift=no" >> "$GITHUB_OUTPUT"
-              [ "$webui_drift" = "yes" ] && echo "[upstream-watch] webui drift: $pinned_webui → $latest_webui"
-              [ "$agent_drift" = "yes" ] && echo "[upstream-watch] agent drift: $pinned_agent → $latest_agent"
+              # Use `if/then` rather than `[ ] && echo` — `set -e` treats a
+              # false `[ ]` test (exit 1) as fatal even when the short-circuit
+              # was the intended behavior. The old pattern killed the
+              # workflow before it could run check-overlay-basis on a one-
+              # sided drift (FITB observed 2026-05-18 + 19 when webui drifted
+              # to v0.51.92 but agent stayed pinned — see #273).
+              if [ "$webui_drift" = "yes" ]; then
+                  echo "[upstream-watch] webui drift: $pinned_webui → $latest_webui"
+              fi
+              if [ "$agent_drift" = "yes" ]; then
+                  echo "[upstream-watch] agent drift: $pinned_agent → $latest_agent"
+              fi
           fi
 
       - name: Check overlay basis against latest tags


### PR DESCRIPTION
## Root cause

`Determine drift` step in `.github/workflows/upstream-watch.yml` had a classic `set -e` + `[ ] && echo` gotcha:

```bash
[ "$webui_drift" = "yes" ] && echo "..."
[ "$agent_drift" = "yes" ] && echo "..."
```

When only ONE of the two upstreams drifts, one of those `[ ]` tests returns false (exit 1) → `set -e` halts the script even though the `&&` short-circuit correctly skipped the echo. The workflow died BEFORE running `check-overlay-basis.sh` against the new tag AND before opening the `upstream-update-available` issue. Only the generic `if: failure()` self-health step fired (#273).

## Observed

Both 2026-05-18 + 2026-05-19 nightly runs failed identically:

```
[upstream-watch] webui drift: v0.51.84 → v0.51.92
##[error]Process completed with exit code 1.
```

nesquena/hermes-webui shipped v0.51.92 (we're pinned at v0.51.84, 8 patch versions behind); NousResearch/hermes-agent stayed at v2026.5.16. The asymmetric drift triggered the bug.

## Fix

Replace `[ ] && echo` with `if/then` blocks. Equivalent semantics; test exit code no longer escapes to `set -e`.

## After merge

1. Manually trigger `upstream-watch.yml` via `gh workflow run upstream-watch.yml` to actually run `check-overlay-basis.sh` against v0.51.92 and open the proper issue
2. Close #273 (the spurious self-health issue) with a back-reference

## Test plan

- [ ] CI green
- [ ] After merge: manual workflow_dispatch produces either an `upstream-update-available` issue (basis clean) or an `upstream-drift` issue (anchors broke against v0.51.92)
- [ ] Either way, we get a real signal about v0.51.92 compatibility instead of a generic "workflow failed" issue