### PR TITLE
fix(ci): Option B :stable auto-bump step crashed in merge job — git log unusable without checkout

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -236,9 +236,19 @@ jobs:
       # bump(upstream): commit by hand.
       - name: Auto-bump :stable on upstream-only commits (Option B)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          # github.event.head_commit.message is multi-line (subject + body);
+          # piped through env var (rather than direct ${{ }} interpolation
+          # into the bash script) for safe quoting. Read via shell parameter
+          # expansion to isolate the subject line — that's where the Option B
+          # marker lives.
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           set -euo pipefail
-          MSG=$(git log -1 --pretty=%s)
+          # Subject = first line of the commit message. Avoids needing a
+          # `git log` call (the merge job has no actions/checkout — it works
+          # entirely from downloaded per-arch digests, so `git` is unusable).
+          MSG="${HEAD_COMMIT_MESSAGE%%$'\n'*}"
           if [[ "$MSG" =~ ^bump\(upstream\): ]]; then
               DIGEST="${{ steps.merge.outputs.digest }}"
               echo "Commit subject matches Option B upstream-bump convention:"


### PR DESCRIPTION
## Root cause

The new "Auto-bump :stable on upstream-only commits" step I added in #283 (v0.7.0) used `git log -1 --pretty=%s` to read the commit subject. But the `merge` job in `build-container.yml` doesn't run `actions/checkout` — it works entirely from per-arch digest artifacts downloaded into `${runner.temp}/digests`. So `git log` dies with:

```
fatal: not a git repository (or any of the parent directories): .git
##[error]Process completed with exit code 128.
```

Caught by [run 26147604957](https://github.com/fox-in-the-box-ai/fox-in-the-box/actions/runs/26147604957) — the post-merge push-to-main run after v0.7.0 landed. The v0.7.0 commit subject doesn't start with `bump(upstream):` so the script *should* have hit the else branch and skipped — instead it crashed before evaluating the conditional.

Impact: every push-to-main runs the merge job's `Auto-bump :stable` step, so this would have broken every subsequent Fox-code main merge OR upstream-bump merge until fixed.

## Fix

Read the commit subject from `github.event.head_commit.message` (a context variable available without checkout) via an env var (safe quoting for multi-line values). Extract just the subject line via shell parameter expansion.

Diff:

```diff
 - name: Auto-bump :stable on upstream-only commits (Option B)
   if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  env:
+    HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
   run: |
     set -euo pipefail
-    MSG=$(git log -1 --pretty=%s)
+    MSG="${HEAD_COMMIT_MESSAGE%%$'\n'*}"
     if [[ "$MSG" =~ ^bump\(upstream\): ]]; then
```

11 lines net. No checkout needed; no slowdown.

## What's unaffected

- The `if: github.event_name == 'push'` gate still applies, so this step only fires on push-to-main. Tag pushes (release.yml's `workflow_call` into build-container) and PR runs never run it.
- The Option B contract is preserved exactly — fix is purely about HOW we read the commit subject.
- FITB#122 protection still holds: Fox-code commits don't have the `bump(upstream):` prefix → no `:stable` auto-bump on their merges.

## Test plan

- [ ] CI green on this PR (the PR run itself won't exercise the fix because the conditional gates on push-to-main, but the syntax / setup-completes will validate)
- [ ] After merge to main: the build-container.yml push run should now complete cleanly (Fox-code commit → else branch logged, no `:stable` bump, smoke proceeds)
- [ ] **Critical:** v0.7.0 tag (held until this lands) should ship cleanly via release.yml
- [ ] **First real Option B verification** afterward: open `bump(upstream): webui v0.51.92 → v0.51.95` PR per #277, merge, watch :stable auto-bump fire correctly

## Why I'm holding the v0.7.0 tag for this

The v0.7.0 release tag uses release.yml which calls build-container.yml via `workflow_call` — that's NOT a push event, so the conditional shouldn't fire on the release. BUT: the broken main is uncomfortable + I'd rather ship v0.7.0 from a known-clean main. Same-day fix, ~5 min CI.