### PR TITLE
bump(upstream): webui v0.51.92 → v0.51.95 (closes #277)

### DIFF
--- a/packages/fox-overlay/versions.toml
+++ b/packages/fox-overlay/versions.toml
@@ -10,19 +10,20 @@
 # for shell-friendly grepping.
 
 [upstream]
-hermes_webui_tag = "v0.51.92"
+hermes_webui_tag = "v0.51.95"
 hermes_webui_url = "https://github.com/nesquena/hermes-webui"
 hermes_agent_tag = "v2026.5.16"
 hermes_agent_url = "https://github.com/NousResearch/hermes-agent"
 
 [meta]
-pinned_at = "2026-05-19"
-pinned_in_pr = "fox-in-the-box-ai/fox-in-the-box#276"  # v0.6.3 — first auto-watch-driven bump
-phase = "v0.6.3"
-notes = "First upstream bump driven by upstream-watch.yml auto-issue (#275). Webui v0.51.84 → v0.51.92 (8 patch versions); agent unchanged. check-overlay-basis.sh confirmed clean against the new pair before merge."
+pinned_at = "2026-05-20"
+pinned_in_pr = "fox-in-the-box-ai/fox-in-the-box#277"  # first Option B upstream-only bump (no Fox version change)
+phase = "container-only-bump"
+notes = "First exercise of the v0.7.0 Option B versioning policy. No Fox code change; no VERSION bump; no DMG/exe rebuild. Webui v0.51.92 → v0.51.95 driven by upstream-watch.yml auto-issue (#277). check-overlay-basis.sh confirmed clean against the new pair. Container :stable auto-advances via build-container.yml merge step when this PR's squash commit (subject prefix bump(upstream):) lands on main."
 
 [history]
 prior_pins = [
   # newest first
+  "webui=v0.51.92, agent=v2026.5.16 — v0.6.3 #276 (2026-05-19)",
   "webui=v0.51.84, agent=v2026.5.16 — Phase 8 ATOMIC #237 (2026-05-17)",
 ]


### PR DESCRIPTION
## Summary

**First exercise of the Option B versioning policy (v0.7.0).** Closes #277.

This PR's purpose is to validate the new flow end-to-end:
1. ✅ Branch off main, check out new upstream tag in submodule, update `versions.toml`
2. ✅ Commit subject starts with `bump(upstream):` — the marker that triggers the conditional `:stable` auto-bump in `build-container.yml`
3. ✅ No VERSION bump, no `package.json` version change, no CHANGELOG `## [X.Y.Z]` entry
4. ✅ Local `check-overlay-basis.sh` clean against v0.51.95
5. ⏳ Wait for PR CI green (will use `bump(upstream):` subject after squash-merge)
6. ⏳ Merge to main (squash, keep the `bump(upstream):` subject)
7. ⏳ `build-container.yml` push run on main:
   - Builds container against v0.51.95 + agent v2026.5.16 (unchanged)
   - **Merge job's new "Auto-bump :stable on upstream-only commits" step detects the `bump(upstream):` subject, advances `:stable` to the new manifest digest**
   - Smokes run, all green
8. ⏳ Verify `:stable` digest changed to match the new build
9. ⏳ Confirm NO `release.yml` run was triggered (this isn't a tag-push)
10. ⏳ Confirm NO new GitHub Release was created
11. ⏳ Close #277 (auto-closed by `closes #277` in this PR)

## Diff

```
forks/hermes-webui                 |  2 +-          (submodule pointer)
packages/fox-overlay/versions.toml | 11 ++++++-----  (pin + meta + history)
2 files changed
```

That's it. No Python, no JS, no CSS, no Electron, no signing pipeline.

## Upstream changes in v0.51.93..v0.51.95

(3 patch versions of upstream churn — Fox doesn't claim ownership of upstream's individual changes; existing users will pick them up on next Electron launch.)

## Verification after merge

I'll watch the build-container.yml push run on main + check:
- `:stable` digest moves
- `release.yml` does NOT fire
- GitHub Releases list shows no new entry
- The merge step's log shows the "✅ :stable now points at <digest>" line

If everything works: the Option B flow is production-validated. From here, future upstream bumps are 5-minute PRs with this exact pattern.

If something breaks: see commit body for the revert plan.

## Out of scope

- Smoke against v0.51.95's new features (do that separately if anything stands out — but the basis check + container smoke is sufficient confidence for a routine bump)
- Auto-bump workflow (the PR-opening automation that would skip even this manual PR) — deferred per v0.7.0's "future improvements" section