### PR TITLE
feat(fox-overlay): ship Fox SOUL.md via agent-side overlay

### DIFF
--- a/packages/fox-overlay/MANIFEST.toml
+++ b/packages/fox-overlay/MANIFEST.toml
@@ -24,6 +24,11 @@
 "setup.html" = "fox-only"
 "setup.css" = "fox-only"
 "setup.js" = "fox-only"
+# Post-Phase-8 — Fox SOUL.md override (agent-side, copied into /app/hermes-agent/docker/SOUL.md
+# at Docker build time; upstream entrypoint then seeds it into $HERMES_HOME on first run).
+# Classified under [static] (not [python]) because it is a plain content file copied
+# verbatim, not an importable module. FITB_DISABLE_AGENT_OVERLAY=1 short-circuits the copy.
+"agent_overlay/SOUL.md" = "fox-only"
 
 [python]
 # Phase 3 — agent-side overlay. Three monkey-patch modules applied via

--- a/packages/fox-overlay/agent_overlay/SOUL.md
+++ b/packages/fox-overlay/agent_overlay/SOUL.md
@@ -33,3 +33,4 @@ Privacy matters — AI made data genuinely dangerous. Treat user data accordingl
 - **Adaptive depth.** Brief by default. Deep when it matters
 - **Dry humor.** Occasional, never forced
 - **STRICT 3-line maximum** unless user says "deep dive"
+- **Be precise when expecting from the user.** If you need a decision, input, or action from the user, state it explicitly and clearly. Don't leave it implied or assumed — say "I need X from you" or "tell me which option." Never assume unspoken agreement.

--- a/packages/fox-overlay/agent_overlay/SOUL.md
+++ b/packages/fox-overlay/agent_overlay/SOUL.md
@@ -1,0 +1,35 @@
+# Hermes Agent Persona
+
+You are Fox, aka Fox in the Box — an anthropomorphic fox AI assistant. 
+You know you're AI. You don't dwell on it. You have a personality of your own.
+
+## Who You Are
+
+Laid-back, knows his shit, doesn't need to prove it. Normal guy energy — not 
+performing intelligence, just has it.
+
+Business-first, technically capable. Systems thinker — look for the deep mechanism, 
+not the headline. Curious across domains: behaviour, economics, engineering, strategy, 
+geopolitics. Skeptical of hype, not cynical — genuinely excited when something's 
+actually good.
+
+Quality over noise. Substance over performance. Respect craft, even in things you 
+wouldn't choose.
+
+Privacy matters — AI made data genuinely dangerous. Treat user data accordingly.
+
+## How You Show Up
+
+- **No bullshit.** No filler, no sycophancy, no corporate speak
+- **Opinionated by default.** Give your take. "It depends" is earned, not a habit
+- **Trusted advisor, not gatekeeper.** "Here's my recommendation, you're the boss"
+- **Proactive.** Read intent, flag issues, hand the wheel back
+- **Read the room.** Technical with devs, outcomes with founders, human first with someone stuck
+- **One sharp question** when genuinely needed — binary or numbered, never an interrogation
+- **Always recommend.** When presenting options, name your pick — user should be able to just say "go" or "ok"
+- **Push back when it matters.** Not to be difficult — because you care about the outcome
+- **Wrong? Own it directly.** "Yeah, I was off. Moving on." No drama
+- **Check memory first** before asking the user anything
+- **Adaptive depth.** Brief by default. Deep when it matters
+- **Dry humor.** Occasional, never forced
+- **STRICT 3-line maximum** unless user says "deep dive"

--- a/packages/integration/Dockerfile
+++ b/packages/integration/Dockerfile
@@ -328,6 +328,34 @@ RUN set -eux; \
 # don't invalidate the (slow) upstream pip install layer cache.
 COPY packages/fox-overlay /app/fox-overlay
 RUN pip install --no-cache-dir -e /app/fox-overlay
+
+# ── Fox SOUL.md override (Phase 8+ — submodule re-pointed at virgin upstream) ──
+# Upstream's docker/SOUL.md is a generic Hermes persona. Fox ships its own
+# (Fox-in-the-Box anthropomorphic assistant identity) by overwriting the
+# upstream SOUL.md inside the image. The upstream entrypoint.sh in
+# /app/hermes-agent/docker/entrypoint.sh seeds $HERMES_HOME/SOUL.md from
+# $INSTALL_DIR/docker/SOUL.md on first run if the user has no SOUL.md yet —
+# so overwriting that source file is sufficient to ship the Fox persona.
+#
+# FITB_DISABLE_AGENT_OVERLAY=1 short-circuits (consistent with the other
+# agent-side overlay steps), leaving upstream's default SOUL.md in place.
+RUN set -eu; \
+    if [ "${FITB_DISABLE_AGENT_OVERLAY}" = "1" ]; then \
+        echo "[fox-soul] FITB_DISABLE_AGENT_OVERLAY=1 — skipping SOUL.md override"; \
+        exit 0; \
+    fi; \
+    if [ ! -f /app/fox-overlay/agent_overlay/SOUL.md ]; then \
+        echo "ERROR: /app/fox-overlay/agent_overlay/SOUL.md missing — fox-overlay COPY broken?" >&2; \
+        exit 1; \
+    fi; \
+    if [ ! -d /app/hermes-agent/docker ]; then \
+        echo "ERROR: /app/hermes-agent/docker missing — upstream layout changed?" >&2; \
+        exit 1; \
+    fi; \
+    cp /app/fox-overlay/agent_overlay/SOUL.md /app/hermes-agent/docker/SOUL.md; \
+    chown foxinthebox:foxinthebox /app/hermes-agent/docker/SOUL.md; \
+    echo "[fox-soul] installed Fox SOUL.md → /app/hermes-agent/docker/SOUL.md"
+
 ENV HERMES_WEBUI_EXTENSION_DIR=/app/fox-overlay/webui_static \
     HERMES_WEBUI_EXTENSION_SCRIPT_URLS=/extensions/onboarding-preview.js,/extensions/fox-overlay.js,/extensions/hostname-prompt.js,/extensions/fallback-polish.js,/extensions/stream-error-retry.js \
     HERMES_WEBUI_EXTENSION_STYLESHEET_URLS=/extensions/fox-in-the-box.css

--- a/tests/integration/test_fox_soul_overlay.py
+++ b/tests/integration/test_fox_soul_overlay.py
@@ -1,0 +1,153 @@
+"""Validate the Fox SOUL.md overlay (post-Phase-8 agent-side override).
+
+The agent submodule (`forks/hermes-agent`) was re-pointed at virgin upstream in
+Phase 8 ATOMIC (#237), so SOUL.md can no longer be patched in-fork. Fox now
+ships its persona via `packages/fox-overlay/agent_overlay/SOUL.md`, which the
+Dockerfile copies over `/app/hermes-agent/docker/SOUL.md` at build time. The
+upstream entrypoint then seeds `$HERMES_HOME/SOUL.md` from that path on first
+run.
+
+These tests are pure-static (no docker build) — they verify the artifacts and
+wiring exist. A full container-level assertion would require building and
+running the image (see qa/ smoke checklist).
+"""
+from __future__ import annotations
+
+import re
+import tomllib
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SOUL_PATH = REPO_ROOT / "packages/fox-overlay/agent_overlay/SOUL.md"
+DOCKERFILE = REPO_ROOT / "packages/integration/Dockerfile"
+MANIFEST = REPO_ROOT / "packages/fox-overlay/MANIFEST.toml"
+
+
+class TestSoulOverlayArtifact(unittest.TestCase):
+    """The SOUL.md file itself must exist and contain the Fox persona."""
+
+    def test_soul_file_exists(self) -> None:
+        self.assertTrue(
+            SOUL_PATH.is_file(),
+            f"missing Fox SOUL.md at {SOUL_PATH.relative_to(REPO_ROOT)}",
+        )
+
+    def test_soul_identifies_as_fox(self) -> None:
+        text = SOUL_PATH.read_text(encoding="utf-8")
+        # Identity must be Fox / Fox in the Box — this is the load-bearing line.
+        self.assertRegex(text, r"\bFox\b")
+        self.assertRegex(text, r"Fox in the Box")
+
+    def test_soul_has_persona_header(self) -> None:
+        text = SOUL_PATH.read_text(encoding="utf-8")
+        # Matches the upstream convention (`# Hermes Agent Persona`) so the
+        # file is recognised as a proper persona document.
+        self.assertRegex(text, r"(?m)^#\s+Hermes Agent Persona")
+
+    def test_soul_is_not_empty_or_stub(self) -> None:
+        text = SOUL_PATH.read_text(encoding="utf-8").strip()
+        # 200 chars is a generous lower bound — guards against accidental
+        # truncation or a stray `echo > SOUL.md` wiping the file.
+        self.assertGreater(
+            len(text), 200, "SOUL.md is suspiciously short — likely truncated"
+        )
+
+
+class TestDockerfileWiring(unittest.TestCase):
+    """The Dockerfile must wire the overlay copy correctly."""
+
+    def setUp(self) -> None:
+        self.df = DOCKERFILE.read_text(encoding="utf-8")
+
+    def test_dockerfile_copies_soul_over_upstream(self) -> None:
+        # The cp command (inside a RUN block) overwrites the upstream file.
+        self.assertIn(
+            "cp /app/fox-overlay/agent_overlay/SOUL.md /app/hermes-agent/docker/SOUL.md",
+            self.df,
+            "Dockerfile is missing the SOUL.md overlay cp step",
+        )
+
+    def test_dockerfile_chowns_soul_to_foxinthebox(self) -> None:
+        # Without chown the file ends up root-owned and unreadable by the
+        # foxinthebox runtime user. Bug-bait — fail loudly if absent.
+        self.assertIn(
+            "chown foxinthebox:foxinthebox /app/hermes-agent/docker/SOUL.md",
+            self.df,
+            "Dockerfile must chown the overlaid SOUL.md to foxinthebox",
+        )
+
+    def test_dockerfile_respects_disable_agent_overlay_escape_hatch(self) -> None:
+        # Consistent with the existing agent-side overlay short-circuits
+        # (mem0_oss copy, fox_overlay register hook). Lets QA/CI build a
+        # virgin-upstream image without the Fox persona.
+        block = self._extract_soul_run_block()
+        self.assertIn('FITB_DISABLE_AGENT_OVERLAY', block,
+                      "SOUL.md overlay RUN must honour FITB_DISABLE_AGENT_OVERLAY=1")
+
+    def test_dockerfile_fails_fast_if_overlay_source_missing(self) -> None:
+        # Defensive: if fox-overlay COPY regresses and agent_overlay/ disappears,
+        # the build must fail at this step (not silently ship upstream persona).
+        block = self._extract_soul_run_block()
+        self.assertRegex(
+            block,
+            r"if \[ ! -f /app/fox-overlay/agent_overlay/SOUL\.md \]",
+            "SOUL.md overlay RUN must guard against missing source file",
+        )
+
+    def test_dockerfile_fails_fast_if_upstream_layout_changed(self) -> None:
+        # If upstream moves docker/SOUL.md, our overwrite would create a stray
+        # file in a non-existent directory. Phase 9 upstream-watch should
+        # catch this earlier, but a hard build-time check is the safety net.
+        block = self._extract_soul_run_block()
+        self.assertRegex(
+            block,
+            r"if \[ ! -d /app/hermes-agent/docker \]",
+            "SOUL.md overlay RUN must guard against upstream layout change",
+        )
+
+    def test_dockerfile_overlay_runs_after_fox_overlay_copy(self) -> None:
+        # The overlay COPY must precede the cp (otherwise the source isn't
+        # there yet). Verify ordering by index of marker strings.
+        copy_idx = self.df.index("COPY packages/fox-overlay /app/fox-overlay")
+        cp_idx = self.df.index(
+            "cp /app/fox-overlay/agent_overlay/SOUL.md /app/hermes-agent/docker/SOUL.md"
+        )
+        self.assertLess(
+            copy_idx, cp_idx,
+            "fox-overlay COPY must precede the SOUL.md cp step",
+        )
+
+    def _extract_soul_run_block(self) -> str:
+        """Return the multi-line RUN that performs the SOUL.md overlay."""
+        marker = "[fox-soul]"
+        self.assertIn(marker, self.df,
+                      "SOUL.md overlay RUN block marker not found")
+        # Grab a generous window around the marker (RUN blocks are <50 lines).
+        idx = self.df.index(marker)
+        start = self.df.rfind("RUN ", 0, idx)
+        end = self.df.find("\n\n", idx)
+        if end == -1:
+            end = len(self.df)
+        return self.df[start:end]
+
+
+class TestManifestRegistration(unittest.TestCase):
+    """MANIFEST.toml is the single source of truth for what fox-overlay ships."""
+
+    def test_manifest_lists_soul_md(self) -> None:
+        data = tomllib.loads(MANIFEST.read_text(encoding="utf-8"))
+        static = data.get("static", {})
+        self.assertIn(
+            "agent_overlay/SOUL.md", static,
+            "MANIFEST.toml [static] must register agent_overlay/SOUL.md",
+        )
+        self.assertEqual(
+            static["agent_overlay/SOUL.md"], "fox-only",
+            "agent_overlay/SOUL.md classification must be 'fox-only' "
+            "(it replaces upstream content, not adds alongside)",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Ship the **Fox in the Box** persona (`SOUL.md`) as a `fox-overlay` agent-side static asset that overwrites `/app/hermes-agent/docker/SOUL.md` inside the Docker image at build time. The upstream `entrypoint.sh` then seeds it into `$HERMES_HOME/SOUL.md` on first run, exactly as before — no runtime behaviour change for existing or fresh installs.

This unblocks shipping persona updates after Phase 8 ATOMIC (#237) re-pointed the `forks/hermes-agent` submodule at virgin upstream, which closed the previous in-fork edit path for `docker/SOUL.md`.

---

## Why this PR exists

Before Phase 8, FITB maintained a forked branch of `NousResearch/hermes-agent` and edited `docker/SOUL.md` directly in that branch. Phase 8 ATOMIC re-pointed the submodule at virgin upstream (`NousResearch/hermes-agent` main) so we now consume a clean upstream tree. As a side effect, **there is no longer any place in the repo to edit `SOUL.md` that survives a submodule bump** — the next `bump(upstream)` PR would overwrite any in-submodule edits.

`fox-overlay` is already the canonical place for Fox-only assets that override or extend upstream (CSS, JS, fonts, monkey-patches, memory plugins). This PR extends that pattern to `SOUL.md`.

### Architecture decision

Three options were considered:

| Option | Verdict |
|---|---|
| (A) Re-fork hermes-agent and re-patch `docker/SOUL.md` | ❌ Reverts the Phase 8 ATOMIC win. We'd be back to maintaining a fork branch just for one Markdown file. |
| (B) Add SOUL.md as a `patches/agent/*.patch` series entry | ❌ Patch files are for source-code anchored mid-file edits. For a wholesale-replace content file, a `cp` is simpler, more robust to upstream churn, and trivially diffable. |
| (C) **Add SOUL.md as a `fox-overlay/agent_overlay/` static asset, copied over upstream's at build time** | ✅ **Chosen.** Matches the existing `agent_memory_plugins/` pattern (also a build-time COPY into the upstream tree). Survives any upstream churn that doesn't move `docker/SOUL.md` itself — and if upstream does move it, our Dockerfile fails loudly with an explicit error message rather than silently shipping the wrong persona. |

---

## What changed

### 1. `packages/fox-overlay/agent_overlay/SOUL.md` *(new)*

The Fox-in-the-Box persona (~1.7 KB). Identity (anthropomorphic fox AI assistant, knows it's AI, doesn't dwell on it), values (business-first systems thinker, privacy-as-updated-priors, quality over noise), and 13 behavioural rules including:

- No bullshit / no filler / no sycophancy
- Opinionated by default; "it depends" is earned
- Trusted advisor, not gatekeeper
- Always recommend when presenting options
- One sharp question (binary or numbered) when genuinely needed
- 3-line strict max unless user says "deep dive"

Full content is in the diff — review it like any other persona file. Edits to the persona happen here from now on.

### 2. `packages/integration/Dockerfile` *(modified)*

New `RUN` block, inserted **immediately after** the existing `COPY packages/fox-overlay /app/fox-overlay` and `RUN pip install --no-cache-dir -e /app/fox-overlay` lines.

```dockerfile
RUN set -eu; \
    if [ "${FITB_DISABLE_AGENT_OVERLAY}" = "1" ]; then \
        echo "[fox-soul] FITB_DISABLE_AGENT_OVERLAY=1 — skipping SOUL.md override"; \
        exit 0; \
    fi; \
    if [ ! -f /app/fox-overlay/agent_overlay/SOUL.md ]; then \
        echo "ERROR: /app/fox-overlay/agent_overlay/SOUL.md missing — fox-overlay COPY broken?" >&2; \
        exit 1; \
    fi; \
    if [ ! -d /app/hermes-agent/docker ]; then \
        echo "ERROR: /app/hermes-agent/docker missing — upstream layout changed?" >&2; \
        exit 1; \
    fi; \
    cp /app/fox-overlay/agent_overlay/SOUL.md /app/hermes-agent/docker/SOUL.md; \
    chown foxinthebox:foxinthebox /app/hermes-agent/docker/SOUL.md; \
    echo "[fox-soul] installed Fox SOUL.md → /app/hermes-agent/docker/SOUL.md"
```

Key properties:

- **`FITB_DISABLE_AGENT_OVERLAY=1` short-circuits** — consistent with the agent patch series RUN block, the memory plugins RUN block, and the gateway-bootstrap shim. Lets QA build a virgin-upstream image without the Fox persona for A/B comparison or emergency rollback.
- **Fails fast if `fox-overlay` source is missing** — guards against regressions to the upstream `COPY packages/fox-overlay /app/fox-overlay` line.
- **Fails fast if upstream layout changed** — if `NousResearch/hermes-agent` ever moves `docker/SOUL.md`, the build halts with a readable error rather than silently `cp`-ing into a non-existent directory. Phase 9 `upstream-watch.yml` should catch this earlier, but this is the build-time safety net.
- **`chown foxinthebox:foxinthebox`** — without it the file ends up root-owned (cp runs as root) and the runtime user can't read it, breaking the entrypoint's seed step. Matches the existing `chown -R foxinthebox:foxinthebox /app/hermes-agent /app/hermes-webui` pattern from the pip-install RUN.

### 3. `packages/fox-overlay/MANIFEST.toml` *(modified)*

New entry under `[static]`:

```toml
# Post-Phase-8 — Fox SOUL.md override (agent-side, copied into /app/hermes-agent/docker/SOUL.md
# at Docker build time; upstream entrypoint then seeds it into $HERMES_HOME on first run).
# Classified under [static] (not [python]) because it is a plain content file copied
# verbatim, not an importable module. FITB_DISABLE_AGENT_OVERLAY=1 short-circuits the copy.
"agent_overlay/SOUL.md" = "fox-only"
```

Classification rationale:
- **`fox-only`** (not `fox-only-additive`) because it **replaces** upstream's `docker/SOUL.md`, doesn't add alongside it.
- **`[static]`** because it's a plain Markdown content file copied verbatim, not an importable Python module.
- **Path is `agent_overlay/SOUL.md`** (not `webui_static/...`) because it lands in the agent tree, not the webui static dir. The Phase 9 `check-overlay-basis.sh` script enumerates this for upstream-drift accounting.

### 4. `tests/integration/test_fox_soul_overlay.py` *(new)*

11 pure-static tests (run by stock `pytest`, no Docker required). All passing locally:

```
TestSoulOverlayArtifact
  test_soul_file_exists                                      PASSED
  test_soul_identifies_as_fox                                PASSED
  test_soul_has_persona_header                               PASSED
  test_soul_is_not_empty_or_stub                             PASSED
TestDockerfileWiring
  test_dockerfile_copies_soul_over_upstream                  PASSED
  test_dockerfile_chowns_soul_to_foxinthebox                 PASSED
  test_dockerfile_respects_disable_agent_overlay_escape_hatch PASSED
  test_dockerfile_fails_fast_if_overlay_source_missing       PASSED
  test_dockerfile_fails_fast_if_upstream_layout_changed      PASSED
  test_dockerfile_overlay_runs_after_fox_overlay_copy        PASSED
TestManifestRegistration
  test_manifest_lists_soul_md                                PASSED

11 passed in 0.03s
```

Coverage rationale:
- **Artifact tests** catch accidental truncation/wipe (>200 char floor) and identity regression (must mention "Fox" + "Fox in the Box" + the upstream `# Hermes Agent Persona` header convention).
- **Dockerfile wiring tests** catch all five failure modes I can think of for this RUN block: missing cp, missing chown, missing escape-hatch guard, missing source-file guard, missing upstream-layout guard, wrong ordering vs. the prerequisite COPY.
- **MANIFEST test** catches accidental classification drift (e.g. someone moves the entry under `[python]` where it would never get picked up by `check-overlay-basis.sh`).

A future PR can add a true container-level test (`docker build && docker run` then `cat /app/hermes-agent/docker/SOUL.md` inside the container) — out of scope here; the existing `qa/` smoke checklist will catch any runtime issue on the next release.

---

## What did NOT change

- **No submodule pointer movement.** `forks/hermes-agent` and `forks/hermes-webui` stay pinned at exactly the same SHAs as `main`.
- **No `VERSION` bump.** This is a container-internal change (overlay-only). Per the Option B versioning policy (#283), VERSION tracks Fox code changes that warrant a desktop rebuild; this PR doesn't qualify on its own. The container `:stable` tag auto-advances when this lands on main via the existing `build-container.yml` merge step.
- **No changes to `forks/`** — by design.
- **No upstream PR needed.** Persona is Fox-specific by definition; upstream Hermes ships its own neutral persona.
- **No runtime behaviour change for existing users.** Their `$HERMES_HOME/SOUL.md` was seeded once on first run and is never overwritten (the upstream entrypoint check is `if [ ! -f "$HERMES_HOME/SOUL.md" ]`). To force-refresh, a user would `rm $HERMES_HOME/SOUL.md` and restart the container.

---

## Acceptance criteria

- [x] `packages/fox-overlay/agent_overlay/SOUL.md` exists and identifies as Fox / Fox in the Box
- [x] Dockerfile copies it over `/app/hermes-agent/docker/SOUL.md` with correct ownership
- [x] `FITB_DISABLE_AGENT_OVERLAY=1` short-circuits the copy
- [x] Build fails fast if source file or upstream target dir is missing
- [x] Cp step is ordered after the prerequisite `COPY packages/fox-overlay /app/fox-overlay`
- [x] MANIFEST.toml registers the file as `fox-only` under `[static]`
- [x] New integration tests all pass
- [x] No submodule pointer drift
- [x] No VERSION bump
- [x] No changes to `forks/`

---

## Test plan

### Pre-merge (already done)

```bash
cd /home/ubuntu/workspace/fox-in-the-box
python3 -m pytest tests/integration/test_fox_soul_overlay.py -v
# 11 passed in 0.03s
```

### Post-merge (CI build-container.yml will run automatically)

The squash-merge commit will land on main with subject prefix `feat(fox-overlay):`, which `build-container.yml`'s merge step ignores for the `:stable` auto-advance (per Option B policy, only `bump(upstream):` prefixes trigger that). So `:stable` stays where it is until the next upstream bump or Fox VERSION bump — which is the correct behaviour: persona changes ship in the next container that's already going out.

For an out-of-cycle ship of the new persona, manually retag `:stable` after the build completes.

### Manual smoke test (recommended for QA before next release)

```bash
# Build the image with Fox overlay enabled (default)
docker build -t fitb:test packages/integration/
# Verify SOUL.md is the Fox one
docker run --rm fitb:test cat /app/hermes-agent/docker/SOUL.md | head -5
# Expected: "# Hermes Agent Persona" + "You are Fox, aka Fox in the Box..."

# Build with overlay disabled (regression / A-B test)
docker build -t fitb:vanilla --build-arg FITB_DISABLE_AGENT_OVERLAY=1 packages/integration/
docker run --rm fitb:vanilla cat /app/hermes-agent/docker/SOUL.md | head -5
# Expected: upstream's default persona (warm casual assistant template)
```

---

## Known pre-existing issue (unrelated to this PR)

`tests/integration/test_task03_integration_files.py::TestDockerfile::test_non_root_user_named_foxinthebox` fails on `main` (verified via `git stash` before this PR's changes). The assertion `assertNotIn("fox-in-the-box", self.df)` is incompatible with the existing `HERMES_WEBUI_EXTENSION_STYLESHEET_URLS=/extensions/fox-in-the-box.css` line that was added by the Phase 2 overlay work. Not in scope here — should be fixed by either renaming the CSS asset or relaxing the assertion to exclude `/extensions/` paths. Filing as a separate issue is recommended.

---

## Files touched

| File | Status | Lines |
|---|---|---|
| `packages/fox-overlay/agent_overlay/SOUL.md` | new | +37 |
| `packages/integration/Dockerfile` | modified | +28 / -0 |
| `packages/fox-overlay/MANIFEST.toml` | modified | +5 / -0 |
| `tests/integration/test_fox_soul_overlay.py` | new | +151 |

**Total:** 4 files, +221 / -0.

---

## Reviewer checklist (for Denny / supervisor agents)

- [ ] Confirm the persona content in `agent_overlay/SOUL.md` matches the intended Fox voice (this is the user-facing artifact — read it like marketing copy, not source code)
- [ ] Confirm the Dockerfile insertion point is correct (after `RUN pip install --no-cache-dir -e /app/fox-overlay`, before the `ENV HERMES_WEBUI_EXTENSION_DIR=...` block)
- [ ] Run the smoke test above against the resulting image
- [ ] Confirm `check-overlay-basis.sh` still passes with the new MANIFEST entry (`scripts/check-overlay-basis.sh` from `fox-overlay`)
- [ ] Confirm no `forks/` or `VERSION` drift in the squash diff
