### PR TITLE
bump(upstream): webui v0.51.95 → v0.51.107 (closes #296)

### DIFF
--- a/packages/fox-overlay/versions.toml
+++ b/packages/fox-overlay/versions.toml
@@ -10,20 +10,21 @@
 # for shell-friendly grepping.
 
 [upstream]
-hermes_webui_tag = "v0.51.95"
+hermes_webui_tag = "v0.51.107"
 hermes_webui_url = "https://github.com/nesquena/hermes-webui"
 hermes_agent_tag = "v2026.5.16"
 hermes_agent_url = "https://github.com/NousResearch/hermes-agent"
 
 [meta]
-pinned_at = "2026-05-20"
-pinned_in_pr = "fox-in-the-box-ai/fox-in-the-box#277"  # first Option B upstream-only bump (no Fox version change)
+pinned_at = "2026-05-22"
+pinned_in_pr = "fox-in-the-box-ai/fox-in-the-box#296"  # Option B bump closing the v0.51.95 → v0.51.103 auto-issue (we picked the higher v0.51.107 to minimize round-trips)
 phase = "container-only-bump"
-notes = "First exercise of the v0.7.0 Option B versioning policy. No Fox code change; no VERSION bump; no DMG/exe rebuild. Webui v0.51.92 → v0.51.95 driven by upstream-watch.yml auto-issue (#277). check-overlay-basis.sh confirmed clean against the new pair. Container :stable auto-advances via build-container.yml merge step when this PR's squash commit (subject prefix bump(upstream):) lands on main."
+notes = "Second Option B upstream-only bump (no Fox version change, no DMG/exe rebuild). Auto-issue #296 surfaced webui v0.51.95 → v0.51.103 was available; by the time we acted, upstream had reached v0.51.107 — bumping to the actual latest minimizes round-trips. check-overlay-basis.sh confirmed clean against the new pair. Container :stable auto-advances via build-container.yml merge step on this PR's squash commit (subject prefix bump(upstream):)."
 
 [history]
 prior_pins = [
   # newest first
+  "webui=v0.51.95, agent=v2026.5.16 — first Option B exercise #289 (2026-05-20)",
   "webui=v0.51.92, agent=v2026.5.16 — v0.6.3 #276 (2026-05-19)",
   "webui=v0.51.84, agent=v2026.5.16 — Phase 8 ATOMIC #237 (2026-05-17)",
 ]


### PR DESCRIPTION
## Summary

**Closes #296.** Second exercise of the Option B versioning policy.

Auto-issue #296 surfaced webui v0.51.95 → v0.51.103 was available; by the time we acted, upstream had reached v0.51.107 — bumping to the actual latest minimizes round-trips.

## Diff

```
forks/hermes-webui                 | 2 +-          (submodule pointer)
packages/fox-overlay/versions.toml | 9 +++++----   (pin + meta + history)
```

Pure pin bump. No Fox code, no VERSION change, no CHANGELOG entry.

## Pre-flight verified

`./packages/fox-overlay/scripts/check-overlay-basis.sh` against v0.51.107 → CLEAN locally before pushing.

## On merge

build-container.yml's merge job detects `bump(upstream):` subject + auto-bumps `:stable` to the new manifest digest. No DMG/exe rebuild, no GitHub Release. Same flow as PR #289 (first Option B exercise).