### PR TITLE
feat(fox-overlay): rebuild silent failover engine (closes #303 symptom 3)

### DIFF
--- a/packages/fox-overlay/fox_overlay/webui_patches/streaming.py
+++ b/packages/fox-overlay/fox_overlay/webui_patches/streaming.py
@@ -1,21 +1,63 @@
-"""Fox webui patch: streaming.py — FITB#9 local-fallback plumbing.
+"""Fox webui patch: streaming.py — FITB#9 local-fallback plumbing + #303
+silent failover engine (v0.7.6 rebuild).
 
-Adds the Fox local-fallback plumbing inside ``_run_agent_streaming``:
-if Settings → Providers "Local fallback" is ON AND the bundled
-llama-server is healthy, plumb it through as ``_fallback_resolved``
-(preempts any config-driven fallback).
+Three substitutions inside ``_run_agent_streaming``:
+
+1. **FITB#9 local-fallback plumbing.** If Settings → Providers
+   "Local fallback" is ON AND the bundled llama-server is healthy,
+   plumb it through as ``_fallback_resolved`` (preempts any
+   config-driven fallback).
+2. **FITB#303 silent failover — success path.** When upstream's
+   classification reports a failover-eligible error (per Fox's
+   ``local_fallback.should_failover()`` filter) AND the local
+   llama-server is ready, swap to local + emit ``provider_switched``
+   instead of ``apperror``. Splices just before
+   ``_provider_error_payload(...)`` in the success-path block.
+3. **FITB#303 silent failover — exception path.** Same logic as (2)
+   but at the exception-handler block (when the agent's
+   ``run_conversation()`` raises rather than returning an error
+   response). Splices just before ``_provider_error_payload(...)`` in
+   the exception-path block.
+
+## Why a wrap-and-splice wasn't an option
+
+Wrap-and-splice (the pattern from v0.7.4 ``_wrap_get_available_models``)
+works for post-call mutations of a return value. ``_run_agent_streaming``
+is a stream-emitting function (yields nothing, writes SSE events via a
+passed handler) — there is no return value to mutate. The right tool
+here is in-function substitution.
+
+## Relationship to upstream's self-heal
+
+Upstream's ``_attempt_credential_self_heal()`` already retries
+``auth_mismatch`` errors automatically with refreshed credentials. Fox's
+failover deliberately filters out ``auth_mismatch`` (via
+``_NEVER_FAILOVER_SUBSTRINGS`` in ``local_fallback.py``) so the two
+mechanisms don't double-retry. Fox covers what self-heal doesn't:
+``rate_limit`` (429), ``no_response``, ``stream_interrupted`` mid-stream
+exceptions, and other non-auth/non-quota transient failures.
+
+## What this does NOT do (intentional scope limits)
+
+- Does NOT auto-retry the user's message against the local model.
+  Emits ``provider_switched`` and stops the current stream cleanly;
+  the user's message stays in the transcript, and their next send
+  hits local. Auto-retry was the v0.5.2 behavior but adds real
+  complexity (rebuilding the agent + replaying context against a
+  potentially different context-window) for marginal UX gain over a
+  single re-send tap.
+- Does NOT modify the v0.6.1 retry-panel UX. The retry panel still
+  fires on ``apperror``; when failover handles the error first,
+  ``apperror`` is never emitted, so the panel naturally doesn't show
+  — no UI changes needed.
+- Does NOT handle ``quota_exhausted`` (filtered out — retrying on
+  local doesn't fix a billing-side quota problem; user must address
+  their account state).
 
 Self-checks: ``inspect.signature`` on ``_run_agent_streaming`` (catches
-drift outside the anchor; v0.51.84 added ``goal_related=False``); anchor
-exactly-once via ``substitute_function``; per-patch sentinel +
-apply-level idempotency guard.
-
-**Missing in this patch (intentional, dropped in Phase 8 #241):**
-FITB#89 mid-stream-break label and #129b silent auto-failover. They
-were 5 of the original 6 hunks and became structurally unmappable when
-upstream refactored to ``_classify_provider_error()`` +
-``_attempt_credential_self_heal()`` in v0.51.84. Tracked for v0.7.5+
-rebuild (see #303 symptom 3). See git history for the original hunks.
+signature drift); anchor exactly-once via ``substitute_function`` for
+each of the 3 substitutions; per-patch sentinel + apply-level
+idempotency guard.
 """
 import inspect
 import logging
@@ -57,16 +99,15 @@ def apply() -> None:
     _check_signature(_u._run_agent_streaming, _EXPECTED_RUN_AGENT_STREAMING_SIG,
                      "_run_agent_streaming")
 
-    # ── Substitute _run_agent_streaming with 1 anchored edit ────────────
-    # (Hunks 2-6 from the original Phase 6 patch dropped in Phase 8 follow-
-    # up #241 — see module docstring for rationale.)
+    # ── Substitute _run_agent_streaming with 3 anchored edits ───────────
     substitute_function(
         upstream_module=_u,
         function_name="_run_agent_streaming",
         substitutions=[
-            # FITB#9 local-fallback plumbing. Insert the local-fallback block
-            # right BEFORE "Build kwargs defensively". Anchor includes 3 lines
-            # of context to remain unique within the function.
+            # ── (1) FITB#9 local-fallback plumbing ──
+            # Insert the local-fallback block right BEFORE "Build kwargs
+            # defensively". Anchor includes 3 lines of context to remain
+            # unique within the function.
             (
                 "                    }\n"
                 "\n"
@@ -89,6 +130,93 @@ def apply() -> None:
                 "                }\n"
                 "\n"
                 "            # Build kwargs defensively — guard newer params so the WebUI\n",
+            ),
+            # ── (2) FITB#303 silent failover — success path ──
+            # Splice just before _provider_error_payload(...) in the
+            # success-path block (post-self-heal). Anchor includes the
+            # if-_assistant_added / else / _error_payload structure that
+            # is unique to this block (the exception-path block does NOT
+            # have the `if _assistant_added:` pre-amble).
+            (
+                "                    if _assistant_added:\n"
+                "                        # Self-heal succeeded: messages are already merged into s,\n"
+                "                        # fall through to normal post-result persistence below.\n"
+                "                        pass\n"
+                "                    else:\n"
+                "                        _error_payload = _provider_error_payload(\n",
+
+                "                    if _assistant_added:\n"
+                "                        # Self-heal succeeded: messages are already merged into s,\n"
+                "                        # fall through to normal post-result persistence below.\n"
+                "                        pass\n"
+                "                    else:\n"
+                "                        # ── FITB v0.7.6 silent failover (success path, #303) ──\n"
+                "                        # When upstream's classification says the error is failover-\n"
+                "                        # eligible AND the bundled local llama-server is ready, swap\n"
+                "                        # to local and emit `provider_switched` instead of apperror.\n"
+                "                        # auth_mismatch is excluded by Fox's should_failover() filter\n"
+                "                        # (upstream's _attempt_credential_self_heal handles that case\n"
+                "                        # automatically); quota_exhausted is excluded because retrying\n"
+                "                        # on local doesn't fix a billing-side problem.\n"
+                "                        try:\n"
+                "                            from fox_overlay.webui_modules import local_fallback as _fitb_lf\n"
+                "                            if _fitb_lf.should_failover(_err_str or _err_label, None):\n"
+                "                                _fitb_status = _fitb_lf.get_status()\n"
+                "                                if _fitb_status.get('ready'):\n"
+                "                                    _fitb_result = _fitb_lf.activate()\n"
+                "                                    if _fitb_result.get('ok'):\n"
+                "                                        put('provider_switched', {\n"
+                "                                            'from_provider': resolved_provider or '',\n"
+                "                                            'to_provider': 'local',\n"
+                "                                            'reason': _err_type or 'failover',\n"
+                "                                            'message': 'Switched to local model. Re-send your message to retry.',\n"
+                "                                        })\n"
+                "                                        _materialize_pending_user_turn_before_error(s)\n"
+                "                                        s.active_stream_id = None\n"
+                "                                        s.pending_user_message = None\n"
+                "                                        s.pending_attachments = []\n"
+                "                                        s.pending_started_at = None\n"
+                "                                        return\n"
+                "                        except Exception:\n"
+                "                            logger.exception('[fox-overlay] silent failover (success path) failed; falling through to upstream apperror')\n"
+                "                        _error_payload = _provider_error_payload(\n",
+            ),
+            # ── (3) FITB#303 silent failover — exception path ──
+            # Splice just before _provider_error_payload(err_str, _exc_type,
+            # _exc_hint) in the exception-handler block. Anchor includes
+            # the trailing `else: _exc_label, _exc_type, _exc_hint = 'Error',
+            # 'error', ''` line which is unique to the exception path.
+            (
+                "        else:\n"
+                "            _exc_label, _exc_type, _exc_hint = 'Error', 'error', ''\n"
+                "\n"
+                "        _error_payload = _provider_error_payload(err_str, _exc_type, _exc_hint)\n",
+
+                "        else:\n"
+                "            _exc_label, _exc_type, _exc_hint = 'Error', 'error', ''\n"
+                "\n"
+                "        # ── FITB v0.7.6 silent failover (exception path, #303) ──\n"
+                "        # Same logic as the success-path splice. On failover success we\n"
+                "        # return without persisting any error message; the user's original\n"
+                "        # message stays in the transcript and the next send hits local.\n"
+                "        try:\n"
+                "            from fox_overlay.webui_modules import local_fallback as _fitb_lf\n"
+                "            if _fitb_lf.should_failover(err_str, None):\n"
+                "                _fitb_status = _fitb_lf.get_status()\n"
+                "                if _fitb_status.get('ready'):\n"
+                "                    _fitb_result = _fitb_lf.activate()\n"
+                "                    if _fitb_result.get('ok'):\n"
+                "                        put('provider_switched', {\n"
+                "                            'from_provider': resolved_provider or '',\n"
+                "                            'to_provider': 'local',\n"
+                "                            'reason': _exc_type or 'failover',\n"
+                "                            'message': 'Switched to local model. Re-send your message to retry.',\n"
+                "                        })\n"
+                "                        return\n"
+                "        except Exception:\n"
+                "            logger.exception('[fox-overlay] silent failover (exception path) failed; falling through to upstream apperror')\n"
+                "\n"
+                "        _error_payload = _provider_error_payload(err_str, _exc_type, _exc_hint)\n",
             ),
         ],
         sentinel=_RUN_AGENT_STREAMING_SENTINEL,

--- a/packages/fox-overlay/tests/test_streaming_patch.py
+++ b/packages/fox-overlay/tests/test_streaming_patch.py
@@ -1,16 +1,19 @@
-"""Phase 8 follow-up #241 regression tests for fox_overlay.webui_patches.streaming.
+"""Regression tests for fox_overlay.webui_patches.streaming.
 
-This patch was extensively trimmed in Phase 8 — only the FITB#9
-local-fallback plumbing substitution survives (hunks 2-6 from the
-original Phase 6 patch were dropped because v0.51.84 refactored the
-err_label/self-heal flow they targeted). See module docstring for
-the full rationale.
+History: Phase 8 follow-up #241 trimmed the original 6-hunk patch down
+to just FITB#9 plumbing. v0.7.6 (#303 symptom 3) rebuilt the silent
+failover as 2 new substitutions on top of upstream's new
+``_classify_provider_error()`` + ``_attempt_credential_self_heal()``
+architecture — separate from the original hunks, different splice
+points. See module docstring for the full rationale.
 
 Coverage:
-* apply() sets the sentinel + sig-check passes against the stub
+* Module load + structural sanity (sentinel, signature constant, helpers)
 * Signature drift fails fast with diagnostic
-* Anchor drift fails fast with diagnostic
-* Apply is idempotent
+* All 3 substitutions present
+* Substitution content sanity (correct fox_overlay calls, correct events
+  emitted) — guards against accidentally breaking the splice logic in
+  refactors
 """
 import importlib
 import sys
@@ -120,3 +123,99 @@ def test_signature_check_helper_directly():
     def _fake(): pass
     with pytest.raises(AssertionError, match="signature drift"):
         patch_mod._check_signature(_fake, "(x, y)", "fake")
+
+
+# ── v0.7.6 #303: silent failover substitution content checks ────────────────
+# Anchor uniqueness against real upstream is verified by container smoke
+# (PR body). These tests guard the substitution CONTENT — accidentally
+# removing the local_fallback wiring or the provider_switched emission
+# would slip past container smoke if the apperror path still works.
+
+def _get_substitutions():
+    """Build the substitutions list without applying. Mirrors what apply()
+    would pass to substitute_function — extracted by reading the patch
+    module's own source."""
+    import inspect
+    import fox_overlay.webui_patches.streaming as patch_mod
+    src = inspect.getsource(patch_mod.apply)
+    return src
+
+
+def test_three_substitutions_present():
+    """v0.7.6 added 2 substitutions to the original 1 (FITB#9 plumbing)."""
+    src = _get_substitutions()
+    # Each substitution is a 2-tuple inside the substitutions= list. Count
+    # the comment headers as a proxy.
+    assert "(1) FITB#9 local-fallback plumbing" in src
+    assert "(2) FITB#303 silent failover — success path" in src
+    assert "(3) FITB#303 silent failover — exception path" in src
+
+
+def test_failover_substitution_wires_local_fallback_module():
+    """Both #303 splices must import and call Fox's local_fallback module."""
+    src = _get_substitutions()
+    # Substitution should reference the Fox module (not upstream's api.local_fallback,
+    # which is the FITB#9 endpoint API — different concern).
+    assert "from fox_overlay.webui_modules import local_fallback as _fitb_lf" in src
+    assert "_fitb_lf.should_failover" in src
+    assert "_fitb_lf.get_status()" in src
+    assert "_fitb_lf.activate()" in src
+
+
+def test_failover_substitution_emits_provider_switched_event():
+    """Successful failover must emit `provider_switched`, NOT `apperror`."""
+    src = _get_substitutions()
+    assert "put('provider_switched'" in src
+    # Both splices include a re-send hint string. Don't pin exact wording
+    # (it may evolve); just verify the event has a 'message' field.
+    assert "'message':" in src
+    assert "'to_provider': 'local'" in src
+
+
+def test_failover_substitution_clears_session_state_on_success_path():
+    """The success-path splice must clear pending-* and active_stream_id
+    so the session doesn't appear stuck after a successful failover."""
+    src = _get_substitutions()
+    assert "_materialize_pending_user_turn_before_error(s)" in src
+    assert "s.active_stream_id = None" in src
+    assert "s.pending_user_message = None" in src
+
+
+def test_failover_substitution_falls_through_on_exception():
+    """If Fox's failover logic raises, the splice must NOT swallow silently —
+    log the exception and fall through to upstream's apperror emission."""
+    src = _get_substitutions()
+    # Both splices have a try/except around the failover block.
+    assert src.count("except Exception:") >= 2
+    # Each except branches logs via logger.exception (not warning, not silent).
+    assert "logger.exception('[fox-overlay] silent failover (success path) failed" in src
+    assert "logger.exception('[fox-overlay] silent failover (exception path) failed" in src
+
+
+def test_failover_substitution_does_not_emit_apperror_when_succeeds():
+    """When failover succeeds, the splice MUST `return` before reaching
+    upstream's `_error_payload = _provider_error_payload(...)` /
+    `put('apperror', ...)` calls."""
+    src = _get_substitutions()
+    # The success-path splice's failover block ends with `return` inside the
+    # `if _fitb_result.get('ok'):` branch.
+    success_splice_idx = src.find("(success path, #303)")
+    exception_splice_idx = src.find("(exception path, #303)")
+    assert success_splice_idx > 0
+    assert exception_splice_idx > 0
+    # The success-path splice's return must come BEFORE the exception path comment
+    success_return_idx = src.find("return\\n", success_splice_idx)
+    assert 0 < success_return_idx < exception_splice_idx
+
+
+def test_v076_docstring_acknowledges_rebuild():
+    """The module docstring must reflect that #303 is now addressed (so the
+    'tracked for v0.7.5+ rebuild' line from the pre-v0.7.6 docstring doesn't
+    silently linger)."""
+    import fox_overlay.webui_patches.streaming as patch_mod
+    doc = patch_mod.__doc__ or ""
+    assert "v0.7.6" in doc
+    assert "#303" in doc
+    # The pre-v0.7.6 "Missing in this patch" disclaimer about #129b being
+    # dropped should be GONE.
+    assert "Missing in this patch" not in doc


### PR DESCRIPTION
## Summary

Brings back the v0.5.2 silent auto-failover behavior that was lost in the v0.6.0 ATOMIC refactor (#241). The original 5 hunks (FITB#89 + #129b) could not be re-anchored against upstream v0.51.84's refactored error-handling architecture — this rebuild uses a different design that maps cleanly onto the new flow.

## What's added

Two new substitutions in `fox_overlay/webui_patches/streaming.py` on top of the existing FITB#9 plumbing:

- **Success-path splice** (~upstream L4644) — after `_classify_provider_error` + self-heal, before `_provider_error_payload`. If the classified error is failover-eligible and local llama-server is ready, swap to local + emit `provider_switched` instead of `apperror`.
- **Exception-path splice** (~upstream L5455) — same logic in the exception-handler branch (when the agent's `run_conversation()` raises rather than returns an error response).

## Design decisions

| Decision | Why |
|---|---|
| Filter out `auth_mismatch` | Upstream's `_attempt_credential_self_heal` already retries with refreshed credentials. Fox's `local_fallback.should_failover()` excludes auth via `_NEVER_FAILOVER_SUBSTRINGS` so the two don't double-retry. |
| Filter out `quota_exhausted` | Same — retrying on local doesn't fix a billing-side problem. User must address account state. |
| Do NOT auto-retry the message | Emit `provider_switched` and stop the stream cleanly. User's message stays in transcript; their next send hits local. Auto-retry (v0.5.2 behavior) adds real complexity for marginal UX gain over a single re-send tap. |
| `substitute_function` not wrap-and-splice | `_run_agent_streaming` is a stream-emitting function (writes SSE events via passed handler) — no return value to mutate. Wrap-and-splice is the wrong tool here. |
| Two splice points, one PR | Success path + exception path are structurally identical; splitting would be churn. |

## Verification

- ✅ **10/10 tests** pass in `test_streaming_patch.py`: module load, signature drift, substitution count = 3, `local_fallback` wiring, `provider_switched` emission, session-state clearing on success path, fail-loud `logger.exception` on splice errors, `return` before reaching `apperror`, docstring updated for v0.7.6
- ✅ **132/132 total tests** pass across the fox-overlay suite (1 skipped)
- ✅ **`check-overlay-basis.sh`** clean against current pin (webui v0.51.107)
- ✅ **Anchor uniqueness** verified — all 3 substitution anchors return `grep -c` = 1 in real upstream

## Out of scope (intentional)

- **Mid-stream `stream_interrupted` failover when tokens have already been partially emitted** — separate hazard with transcript-cleanup considerations. v0.7.7 candidate if it surfaces.
- **v0.6.1 retry-panel UX changes** — when failover handles the error first, `apperror` is never emitted, so the panel naturally doesn't show. No UI changes needed.
- **v0.7.6 release mechanics** — VERSION/CHANGELOG/smoke-row land in a separate companion PR (matches v0.7.5's pattern).