### PR TITLE
docs: rewrite Windows cleanup script + RESET.md from v0.7.17/v0.7.18 debug findings

### DIFF
--- a/docs/RESET.md
+++ b/docs/RESET.md
@@ -1,37 +1,74 @@
 # Full reset — clean install
 
-Use this when you want a new container, fresh on-disk data, and optionally a fresh image (for example after changing Docker options like `/dev/net/tun`).
+Use this when you want a new container, fresh on-disk data, and optionally a fresh image. Common reasons: a botched upgrade, switching machines, or you just want to start over.
 
-## Windows
+## Recommended path (v0.7.18+)
 
-1. **Quit Fox in the Box completely**, including the system-tray icon.
-2. **Uninstall the app** from *Settings → Apps → Installed apps* if you also want the program files removed. The installer does not delete your data folder by default.
-3. **Remove the container and data** — pick one:
+The simplest reset uses Fox's own UI:
 
-   **Script (recommended).** In PowerShell, from the repo (or copy the script elsewhere):
+1. Right-click the **system tray icon** (Windows) or **menu-bar icon** (macOS).
+2. Click **"Reset Fox completely…"**.
+3. Confirm the destructive action.
 
-   ```powershell
-   cd packages\scripts
-   .\clean-windows-desktop.ps1
-   ```
+Fox stops its container, removes the image, deletes all user data, then quits. Relaunch from the Start Menu / Applications folder to begin fresh. No PowerShell or terminal needed.
 
-   To also delete the cached Linux image (the next app start will `docker pull` again):
+If the in-app reset isn't available (older Fox version) or Fox won't launch at all, use the platform-specific manual instructions below.
 
-   ```powershell
-   .\clean-windows-desktop.ps1 -RemoveImage
-   ```
+---
 
-   If you ever ran the CLI Docker one-liner with `-v ~/.foxinthebox:/data`, add `-RemoveFoxintheboxDir` to remove `%USERPROFILE%\.foxinthebox` as well.
+## Windows — script
 
-   **Manual.**
+In PowerShell, from a clone of this repo (or just download the `.ps1` file):
 
-   ```powershell
-   docker rm -f fox-in-the-box
-   Remove-Item -Recurse -Force "$env:APPDATA\Fox in the box"
-   docker rmi ghcr.io/fox-in-the-box-ai/cloud:stable   # optional
-   ```
+```powershell
+cd packages\scripts
+.\clean-windows-desktop.ps1
+```
 
-4. **Reinstall** from the [latest release](https://github.com/fox-in-the-box-ai/fox-in-the-box/releases/latest) and start the app once so it recreates the container.
+That does the full nuclear cleanup: stops every Fox / Electron process, removes the container, untags every Fox image variant (`:stable`, `:v0.7.*`, `:latest`), prunes dangling volumes, runs the bundled NSIS uninstaller silently, deletes the `%APPDATA%\@fox-in-the-box` data dir + `%LOCALAPPDATA%\@fox-in-the-boxelectron-updater` + install dir, and verifies clean state at the end.
+
+**Options:**
+
+- `-KeepData` — leave `%APPDATA%\@fox-in-the-box` alone (preserve onboarding state, settings, conversation history, local models). Useful for "reset Docker only."
+- `-KeepInstall` — don't run the uninstaller or delete the install dir. Useful for "reset data only."
+- `-WhatIf` — preview what would change without changing anything.
+
+```powershell
+# Reset Docker container + image, preserve all Fox data and app
+.\clean-windows-desktop.ps1 -KeepData
+
+# Reset all data, but leave Fox app installed
+.\clean-windows-desktop.ps1 -KeepInstall
+
+# Preview only
+.\clean-windows-desktop.ps1 -WhatIf
+```
+
+After the script: reinstall from the [latest release](https://github.com/fox-in-the-box-ai/fox-in-the-box/releases/latest) (or relaunch if you used `-KeepInstall`).
+
+### Windows — when the script reports "did not remove cleanly"
+
+Usually means Docker Desktop's WSL2 backend has a bind-mount lock on the data dir. Fix:
+
+```powershell
+wsl --shutdown
+.\clean-windows-desktop.ps1
+```
+
+Or a Fox/Electron process is still alive — check Task Manager → end any `fox*` / `electron*` process → re-run the script.
+
+### Windows — manual fallback (no script)
+
+```powershell
+docker rm -f fox-in-the-box
+docker rmi -f ghcr.io/fox-in-the-box-ai/cloud:stable
+cmd /c "rd /s /q ""$env:APPDATA\@fox-in-the-box"""
+cmd /c "rd /s /q ""$env:LOCALAPPDATA\@fox-in-the-boxelectron-updater"""
+```
+
+Then uninstall the app via Settings → Apps if you want the program files gone too.
+
+---
 
 ## macOS
 
@@ -49,10 +86,11 @@ Use this when you want a new container, fresh on-disk data, and optionally a fre
    rm ~/Library/LaunchAgents/io.foxinthebox.plist   # only if you no longer want auto-start
    ```
 
-4. **Remove your data** at the path you chose during install (default: `~/Library/Application Support/Fox in the Box`):
+4. **Remove your data.** Default Electron path is `~/Library/Application Support/@fox-in-the-box`. If you used the Docker one-liner with `-v ~/.foxinthebox:/data`, also remove that.
 
    ```bash
-   rm -rf "$HOME/Library/Application Support/Fox in the Box"
+   rm -rf "$HOME/Library/Application Support/@fox-in-the-box"
+   rm -rf "$HOME/.foxinthebox"   # only if you used the Docker one-liner path
    ```
 
 5. **Optionally remove the cached image** so the next install pulls fresh:
@@ -61,7 +99,11 @@ Use this when you want a new container, fresh on-disk data, and optionally a fre
    docker rmi ghcr.io/fox-in-the-box-ai/cloud:stable
    ```
 
-6. **Reinstall** by re-running the [install script](../README.md#linux--macos-install-script) or the Docker one-liner.
+6. **Drag Fox in the Box.app to the Trash** if you want to fully uninstall the desktop app.
+
+7. **Reinstall** by re-running the [install script](../README.md#linux--macos-install-script) or downloading the latest DMG.
+
+---
 
 ## Linux
 

--- a/packages/scripts/clean-windows-desktop.ps1
+++ b/packages/scripts/clean-windows-desktop.ps1
@@ -1,78 +1,235 @@
 #Requires -Version 5.1
 <#
 .SYNOPSIS
-  Remove Fox in the Box desktop data and Docker container for a clean reinstall.
+  Nuclear cleanup for Fox in the Box on Windows — container, image, data, install.
 
 .DESCRIPTION
-  1. Quit Fox in the Box (tray) and exit the app completely before running.
-  2. Optionally uninstall the app from Windows Settings > Apps (this script does not run the uninstaller).
-  3. Run this script from PowerShell. Reinstall the app and/or pull the image again afterward.
+  Removes everything Fox in the Box puts on a Windows machine, in the right order
+  to survive locked LevelDB files, auto-restarting tray processes, and the
+  Docker Desktop bind-mount lifecycle. Battle-tested against the v0.7.17 → v0.7.18
+  cleanup mess that motivated this rewrite (see GitHub issues #341 + #340).
 
-  The NSIS installer leaves app data on disk by default (deleteAppDataOnUninstall: false).
+  Default behavior (no flags) does FULL nuclear cleanup:
+    1. Stop every Fox / Electron / @fox-in-the-box process
+    2. Stop + remove the `fox-in-the-box` container
+    3. Untag every known Fox cloud image (`:stable`, `:v0.7.*`, `:latest`)
+    4. Prune dangling Docker volumes
+    5. Run the bundled NSIS uninstaller silently if present
+    6. Remove `%APPDATA%\@fox-in-the-box` (Electron userData + container bind mount)
+    7. Remove `%LOCALAPPDATA%\@fox-in-the-boxelectron-updater` (auto-updater state)
+    8. Remove `%LOCALAPPDATA%\Programs\@fox-in-the-boxelectron` (install dir)
+    9. Verify clean state and report
 
-.PARAMETER RemoveImage
-  Also run: docker rmi ghcr.io/fox-in-the-box-ai/cloud:stable
+  After this script: Fox is GONE from the system. Reinstall fresh from
+  https://github.com/fox-in-the-box-ai/fox-in-the-box/releases/latest
 
-.PARAMETER RemoveFoxintheboxDir
-  Also remove %USERPROFILE%\.foxinthebox if present (used by CLI Docker example in README, not the default Electron bind mount).
+  When the in-app "Tray → Reset Fox completely…" menu (v0.7.18+) suffices,
+  use that instead — this script is for when Fox won't launch at all or the
+  in-app reset failed (e.g. cross-version upgrade gone wrong).
+
+.PARAMETER KeepData
+  Skip step 6 — preserve %APPDATA%\@fox-in-the-box (onboarding state, settings,
+  conversation history, local models). Useful when you want to reset Docker
+  state only but keep your provider keys + chat history.
+
+.PARAMETER KeepInstall
+  Skip steps 5 + 8 — leave the Fox application installed. Useful when you
+  want to reset state without uninstalling the app itself.
+
+.PARAMETER WhatIf
+  Show what WOULD be removed without actually removing anything.
 
 .EXAMPLE
+  # Full nuclear cleanup — most common use
   .\clean-windows-desktop.ps1
+
 .EXAMPLE
-  .\clean-windows-desktop.ps1 -RemoveImage
+  # Reset Docker container + image + Fox data, but leave the Fox app installed
+  .\clean-windows-desktop.ps1 -KeepInstall
+
+.EXAMPLE
+  # Reset Docker only, preserve all Fox app data + the app itself
+  .\clean-windows-desktop.ps1 -KeepData -KeepInstall
+
+.EXAMPLE
+  # Preview without making changes
+  .\clean-windows-desktop.ps1 -WhatIf
+
+.NOTES
+  Requires PowerShell 5.1+ (ships with Windows 10/11).
+  Requires Docker Desktop installed (`docker` on PATH).
+  Does NOT require Administrator privileges.
+
+  Issues #340 + #341 led to this rewrite. The previous version assumed
+  Fox was already quit, used the wrong data path (assumed `Fox in the box`
+  but Electron actually creates `@fox-in-the-box` because package.json has
+  no productName field), and didn't survive auto-restarting tray processes.
 #>
 [CmdletBinding(SupportsShouldProcess = $true)]
 param(
-  [switch] $RemoveImage,
-  [switch] $RemoveFoxintheboxDir
+  [switch] $KeepData,
+  [switch] $KeepInstall
 )
 
-# Native `docker` writes to stderr even for benign cases (e.g. missing container).
-# Do not use Stop globally or PowerShell treats that as a terminating error.
+# Native `docker` writes to stderr for benign cases (e.g. missing container).
+# Continue so a stop/remove failure doesn't abort the whole script.
 $ErrorActionPreference = 'Continue'
+
 $containerName = 'fox-in-the-box'
-$imageRef = 'ghcr.io/fox-in-the-box-ai/cloud:stable'
+$imageBase     = 'ghcr.io/fox-in-the-box-ai/cloud'
+$dataDir       = Join-Path $env:APPDATA   '@fox-in-the-box'
+$updaterDir    = Join-Path $env:LOCALAPPDATA '@fox-in-the-boxelectron-updater'
+$installDir    = Join-Path $env:LOCALAPPDATA 'Programs\@fox-in-the-boxelectron'
 
-# Electron userData bind mount (see packages/electron/src/docker-manager.js + main.js setName).
-$electronData = Join-Path $env:APPDATA 'Fox in the box'
-
-Write-Host 'Fox in the Box - clean desktop data' -ForegroundColor Cyan
-Write-Host 'Ensure the Fox in the box app is fully quit (system tray).' -ForegroundColor Yellow
+Write-Host ''
+Write-Host '════════════════════════════════════════════════════' -ForegroundColor Cyan
+Write-Host '  Fox in the Box — nuclear cleanup for Windows'      -ForegroundColor Cyan
+Write-Host '════════════════════════════════════════════════════' -ForegroundColor Cyan
 Write-Host ''
 
+# ─── 1. Stop Fox processes ─────────────────────────────────────────────────
+# Single Stop-Process call so PowerShell's argument parser doesn't split
+# `-ErrorAction SilentlyContinue` across a line break (a real failure mode
+# when these commands are pasted into an interactive shell).
+if ($PSCmdlet.ShouldProcess('Fox / Electron processes', 'Stop-Process')) {
+  Write-Host '[1/9] Stopping Fox / Electron processes...' -ForegroundColor Cyan
+  Stop-Process -Name 'fox*','electron*','@fox*' -Force -ErrorAction SilentlyContinue
+  Get-Process -ErrorAction SilentlyContinue | Where-Object {
+    ($_.Path -and $_.Path -like "*@fox*") -or
+    ($_.MainWindowTitle -and $_.MainWindowTitle -like "*Fox in the box*")
+  } | Stop-Process -Force -ErrorAction SilentlyContinue
+  Start-Sleep -Seconds 3
+}
+
+# ─── 2. Stop + remove the container ───────────────────────────────────────
 if ($PSCmdlet.ShouldProcess($containerName, 'docker rm -f')) {
-  docker rm -f $containerName 2>&1 | Out-Null
-  if ($LASTEXITCODE -eq 0) { Write-Host "Removed container: $containerName" }
-  else { Write-Host "Container $containerName not running or already removed." }
+  Write-Host '[2/9] Removing Docker container...' -ForegroundColor Cyan
+  docker stop $containerName 2>$null | Out-Null
+  docker rm -f $containerName 2>$null | Out-Null
+  Write-Host "      container '$containerName' removed (or wasn't running)"
 }
 
-if ($RemoveImage) {
-  if ($PSCmdlet.ShouldProcess($imageRef, 'docker rmi')) {
-    docker rmi $imageRef 2>&1 | Out-Null
-    if ($LASTEXITCODE -eq 0) { Write-Host "Removed image: $imageRef" }
-    else { Write-Host "Image $imageRef not present or in use." }
+# ─── 3. Untag every known image variant ───────────────────────────────────
+if ($PSCmdlet.ShouldProcess($imageBase, 'docker rmi')) {
+  Write-Host '[3/9] Untagging Fox container images...' -ForegroundColor Cyan
+  $tags = @('stable','latest','dev')
+  # All versioned tags currently known (extend as releases ship)
+  for ($minor = 5; $minor -le 30; $minor++) {
+    $tags += "v0.7.$minor"
   }
-}
-
-if (Test-Path -LiteralPath $electronData) {
-  if ($PSCmdlet.ShouldProcess($electronData, 'Remove-Item -Recurse -Force')) {
-    Remove-Item -LiteralPath $electronData -Recurse -Force -ErrorAction Stop
-    Write-Host "Removed Electron user data: $electronData"
+  foreach ($tag in $tags) {
+    docker rmi -f "${imageBase}:${tag}" 2>$null | Out-Null
   }
-}
-else {
-  Write-Host "No Electron user data at: $electronData"
+  Write-Host "      images untagged (some may not have been present)"
 }
 
-if ($RemoveFoxintheboxDir) {
-  $legacy = Join-Path $env:USERPROFILE '.foxinthebox'
-  if (Test-Path -LiteralPath $legacy) {
-    if ($PSCmdlet.ShouldProcess($legacy, 'Remove-Item -Recurse -Force')) {
-      Remove-Item -LiteralPath $legacy -Recurse -Force -ErrorAction Stop
-      Write-Host "Removed: $legacy"
+# ─── 4. Prune dangling Docker volumes ─────────────────────────────────────
+if ($PSCmdlet.ShouldProcess('docker volumes', 'docker volume prune -f')) {
+  Write-Host '[4/9] Pruning dangling Docker volumes...' -ForegroundColor Cyan
+  docker volume prune -f 2>$null | Out-Null
+}
+
+# ─── 5. Run NSIS uninstaller (if installed and not -KeepInstall) ──────────
+if (-not $KeepInstall) {
+  $uninstallExe = $null
+  if (Test-Path -LiteralPath $installDir) {
+    $uninstallExe = (Get-ChildItem -LiteralPath $installDir -Filter 'Uninstall *.exe' `
+        -ErrorAction SilentlyContinue | Select-Object -First 1).FullName
+  }
+  if ($uninstallExe) {
+    if ($PSCmdlet.ShouldProcess($uninstallExe, 'Run uninstaller silently')) {
+      Write-Host '[5/9] Running NSIS uninstaller (silent)...' -ForegroundColor Cyan
+      Start-Process $uninstallExe -ArgumentList '/S' -Wait
+      Start-Sleep -Seconds 2
+      Write-Host "      uninstalled via $uninstallExe"
     }
+  } else {
+    Write-Host '[5/9] No NSIS uninstaller found — skipping' -ForegroundColor DarkGray
   }
+} else {
+  Write-Host '[5/9] -KeepInstall set — skipping uninstaller' -ForegroundColor DarkGray
 }
 
+# ─── 6. Remove data dir (unless -KeepData) ────────────────────────────────
+# cmd /c rd /s /q is more aggressive than Remove-Item against locked files;
+# we use it because Chromium's LevelDB store inside userData sometimes
+# survives process kill by a few hundred ms.
+if (-not $KeepData) {
+  if (Test-Path -LiteralPath $dataDir) {
+    if ($PSCmdlet.ShouldProcess($dataDir, 'rd /s /q')) {
+      Write-Host '[6/9] Removing data dir...' -ForegroundColor Cyan
+      cmd /c "rd /s /q ""$dataDir""" 2>$null
+      if (Test-Path -LiteralPath $dataDir) {
+        Write-Host "      WARNING: $dataDir partially survived — try `wsl --shutdown` then re-run" -ForegroundColor Yellow
+      } else {
+        Write-Host "      removed: $dataDir"
+      }
+    }
+  } else {
+    Write-Host '[6/9] No data dir present — skipping' -ForegroundColor DarkGray
+  }
+} else {
+  Write-Host '[6/9] -KeepData set — preserving data dir' -ForegroundColor DarkGray
+}
+
+# ─── 7. Remove auto-updater state ─────────────────────────────────────────
+if (Test-Path -LiteralPath $updaterDir) {
+  if ($PSCmdlet.ShouldProcess($updaterDir, 'rd /s /q')) {
+    Write-Host '[7/9] Removing auto-updater state...' -ForegroundColor Cyan
+    cmd /c "rd /s /q ""$updaterDir""" 2>$null
+    Write-Host "      removed: $updaterDir"
+  }
+} else {
+  Write-Host '[7/9] No auto-updater state present — skipping' -ForegroundColor DarkGray
+}
+
+# ─── 8. Remove install dir (unless -KeepInstall) ──────────────────────────
+if (-not $KeepInstall) {
+  if (Test-Path -LiteralPath $installDir) {
+    if ($PSCmdlet.ShouldProcess($installDir, 'rd /s /q')) {
+      Write-Host '[8/9] Removing install dir...' -ForegroundColor Cyan
+      cmd /c "rd /s /q ""$installDir""" 2>$null
+      Write-Host "      removed: $installDir"
+    }
+  } else {
+    Write-Host '[8/9] No install dir present — skipping' -ForegroundColor DarkGray
+  }
+} else {
+  Write-Host '[8/9] -KeepInstall set — leaving install dir' -ForegroundColor DarkGray
+}
+
+# ─── 9. Verify ────────────────────────────────────────────────────────────
+Write-Host '[9/9] Verifying clean state...' -ForegroundColor Cyan
 Write-Host ''
-Write-Host 'Next: install a fresh build from releases (or your installer), then start the app so Docker creates a new container.' -ForegroundColor Green
+Write-Host '── Docker containers (should be empty) ──' -ForegroundColor DarkGray
+docker ps -a --filter "name=$containerName"
+Write-Host ''
+Write-Host '── Docker images (should be empty) ──' -ForegroundColor DarkGray
+docker images $imageBase
+Write-Host ''
+$dataExists    = Test-Path -LiteralPath $dataDir
+$updaterExists = Test-Path -LiteralPath $updaterDir
+$installExists = Test-Path -LiteralPath $installDir
+Write-Host "Data dir present:    $dataExists $(if ($dataExists -and -not $KeepData) {'  ← UNEXPECTED'})" `
+  -ForegroundColor $(if ($dataExists -and -not $KeepData) {'Yellow'} else {'Green'})
+Write-Host "Updater dir present: $updaterExists $(if ($updaterExists) {'  ← UNEXPECTED'})" `
+  -ForegroundColor $(if ($updaterExists) {'Yellow'} else {'Green'})
+Write-Host "Install dir present: $installExists $(if ($installExists -and -not $KeepInstall) {'  ← UNEXPECTED'})" `
+  -ForegroundColor $(if ($installExists -and -not $KeepInstall) {'Yellow'} else {'Green'})
+Write-Host ''
+
+$unexpected = ($dataExists -and -not $KeepData) -or
+              $updaterExists -or
+              ($installExists -and -not $KeepInstall)
+if ($unexpected) {
+  Write-Host '⚠  Some directories did not remove cleanly.' -ForegroundColor Yellow
+  Write-Host '   Common causes:' -ForegroundColor Yellow
+  Write-Host '   • Docker Desktop''s WSL2 backend has a bind-mount lock on the data dir' -ForegroundColor Yellow
+  Write-Host '     Fix: run `wsl --shutdown` then re-run this script' -ForegroundColor Yellow
+  Write-Host '   • A Fox / Electron process is still alive somewhere' -ForegroundColor Yellow
+  Write-Host '     Fix: check Task Manager → end any *fox* / *electron* processes' -ForegroundColor Yellow
+} else {
+  Write-Host '✓ Clean. Reinstall Fox from:' -ForegroundColor Green
+  Write-Host '  https://github.com/fox-in-the-box-ai/fox-in-the-box/releases/latest' -ForegroundColor Green
+}
+Write-Host ''


### PR DESCRIPTION
## Summary

Rewrites `packages/scripts/clean-windows-desktop.ps1` + updates `docs/RESET.md` based on what we actually learned during @roadhero's v0.7.17→v0.7.18 debug session today (the cleanup needed ~10 rounds of iteration before it worked).

## Why

Old script assumed:
- Fox was already quit (didn't kill processes — but Fox auto-restarts the container)
- Data dir at `%APPDATA%\Fox in the box` — **wrong**. Actual is `@fox-in-the-box` (npm scope leaking into Electron userData; v0.7.19 will fix the root cause)
- Only `:stable` needed removing — left versioned tags behind
- `Remove-Item` would handle locked files — it doesn't on Win11 with Chromium's LevelDB

New script:
- Single-line `Stop-Process` (avoids PowerShell's `-ErrorAction` line-wrap break we hit repeatedly)
- Cleans container, all image tags (`v0.7.5`..`v0.7.30` + `stable`/`latest`/`dev`), dangling volumes
- Runs the NSIS uninstaller silently if present
- Uses `cmd /c rd /s /q` for data dirs (survives LevelDB locks)
- Verifies clean state with color-coded reporting
- `-KeepData` / `-KeepInstall` / `-WhatIf` for partial cleanup
- Includes `wsl --shutdown` troubleshooting hint for the bind-mount-lock case

`docs/RESET.md` now points users at the in-app **Tray → Reset Fox completely…** menu (v0.7.18 #341) as the recommended path, with the script as fallback.

## Test plan

- [x] Script parses (`Test-Path .\packages\scripts\clean-windows-desktop.ps1` from PowerShell will validate it)
- [ ] Run on a real Win11 box with Fox installed — verify all 9 steps succeed
- [ ] `-WhatIf` shows the right operations without performing them
- [ ] `-KeepData` preserves the data dir, removes everything else
- [ ] `-KeepInstall` preserves the install + uninstaller, removes data + container
- [ ] After running with no flags: install Fox fresh → wizard appears (proves clean state)

Docs-only change to PowerShell + markdown — no CI gating concern.