### PR TITLE
feat(overlay): Fox Soul UX patches (supersedes #327) — bot name + avatar + empty state

### DIFF
--- a/packages/fox-overlay/patches/webui/004-fox-bot-name-override.patch
+++ b/packages/fox-overlay/patches/webui/004-fox-bot-name-override.patch
@@ -1,0 +1,14 @@
+diff --git a/static/boot.js b/static/boot.js
+index 3cc6445d..fc07dc69 100644
+--- a/static/boot.js
++++ b/static/boot.js
+@@ -1469,6 +1469,9 @@ function applyBotName(){
+     window._busyInputMode=(s.busy_input_mode||'queue');
+     window._sessionEndlessScrollEnabled=!!s.session_endless_scroll;
+     window._botName=s.bot_name||'Hermes';
++    if(typeof document!=='undefined'&&document.documentElement&&document.documentElement.classList.contains('fox-in-the-box')){
++      window._botName='Fox in the box';
++    }
+     if(s.default_model_provider) window._activeProvider=s.default_model_provider;
+     if(s.default_model){
+       window._defaultModel=s.default_model;

--- a/packages/fox-overlay/patches/webui/005-fox-avatar-override.patch
+++ b/packages/fox-overlay/patches/webui/005-fox-avatar-override.patch
@@ -1,0 +1,13 @@
+diff --git a/static/ui.js b/static/ui.js
+index 76a44fae..97ead5be 100644
+--- a/static/ui.js
++++ b/static/ui.js
+@@ -4851,7 +4851,7 @@ function isTpsDisplayEnabled(){
+ function _assistantRoleHtml(tsTitle='', tpsText=''){
+   const _bn=assistantDisplayName();
+   const tps=(isTpsDisplayEnabled()&&tpsText)?`<span class="msg-tps-inline" title="Tokens per second">${esc(tpsText)}</span>`:'';
+-  return `<div class="msg-role assistant" ${tsTitle?`title="${esc(tsTitle)}"`:''}><div class="role-icon assistant">${esc(_bn.charAt(0).toUpperCase())}</div><span style="font-size:12px">${esc(_bn)}</span>${tps}</div>`;
++  return `<div class="msg-role assistant" ${tsTitle?`title="${esc(tsTitle)}"`:''} ><img class="role-icon assistant app-avatar" src="static/fox_avatar_cropped.jpg" alt="${esc(_bn)}" width="20" height="20" decoding="async"><span style="font-size:12px">${esc(_bn)}</span>${tps}</div>`;
+ }
+ function _setAssistantTurnTps(turn, tpsText=''){
+   if(!turn) return;

--- a/packages/fox-overlay/patches/webui/006-fox-empty-state-branding.patch
+++ b/packages/fox-overlay/patches/webui/006-fox-empty-state-branding.patch
@@ -1,0 +1,21 @@
+diff --git a/static/index.html b/static/index.html
+index 6fd160b3..8b1cf871 100644
+--- a/static/index.html
++++ b/static/index.html
+@@ -386,12 +386,12 @@
+           <circle cx="32" cy="10" r="4" fill="#F5C542"/>
+           <circle cx="32" cy="10" r="2" fill="#FFF8E1" opacity="0.7"/>
+         </svg></div>
+-        <h2 data-i18n="empty_title">What can I help with?</h2>
+-        <p data-i18n="empty_subtitle">Ask anything, run commands, explore files, or manage your scheduled tasks.</p>
++        <h2 data-i18n="empty_title">Think less. Start here.</h2>
++        <p data-i18n="empty_subtitle">Ask the way you would a teammate: research, terminal work, files, schedules. The Fox runs it in the box — private, on your machine.</p>
+         <div class="suggestion-grid">
+-          <button class="suggestion" data-msg="What files are in this workspace?"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg> <span data-i18n="suggest_files">What files are in this workspace?</span></button>
++          <button class="suggestion" data-msg="What's in this workspace?"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg> <span data-i18n="suggest_files">What's in this workspace?</span></button>
+           <button class="suggestion" data-msg="What's on my schedule today?"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><rect x="8" y="2" width="8" height="4" rx="1" ry="1"/><line x1="9" y1="12" x2="15" y2="12"/><line x1="9" y1="16" x2="12" y2="16"/></svg> <span data-i18n="suggest_schedule">What's on my schedule today?</span></button>
+-          <button class="suggestion" data-msg="Help me plan a small project."><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polygon points="1 6 1 22 8 18 16 22 23 18 23 2 16 6 8 2 1 6"/><line x1="8" y1="2" x2="8" y2="18"/><line x1="16" y1="6" x2="16" y2="22"/></svg> <span data-i18n="suggest_plan">Help me plan a small project.</span></button>
++          <button class="suggestion" data-msg="Help me plan a small project step by step."><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polygon points="1 6 1 22 8 18 16 22 23 18 23 2 16 6 8 2 1 6"/><line x1="8" y1="2" x2="8" y2="18"/><line x1="16" y1="6" x2="16" y2="22"/></svg> <span data-i18n="suggest_plan">Help me plan a small project step by step.</span></button>
+         </div>
+       </div>
+       <div class="messages-inner" id="msgInner"></div>

--- a/packages/fox-overlay/patches/webui/series
+++ b/packages/fox-overlay/patches/webui/series
@@ -11,3 +11,6 @@
 001-server-py-bootstrap.patch
 002-routes-py-dispatch-hook.patch
 003-server-py-onboarding-redirect.patch
+004-fox-bot-name-override.patch
+005-fox-avatar-override.patch
+006-fox-empty-state-branding.patch

--- a/packages/fox-overlay/webui_static/fox-in-the-box.css
+++ b/packages/fox-overlay/webui_static/fox-in-the-box.css
@@ -1080,3 +1080,18 @@ pre[class*=language-] {
   align-items: center;
 }
 
+
+/* ── Fox avatar in message role header (from PR #327, @bsgdigital) ─── */
+.role-icon-avatar.fox-avatar {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 1px solid var(--accent-bg-strong);
+  flex-shrink: 0;
+}
+
+/* Ensure avatar aligns with role text baseline */
+.msg-role.assistant {
+  align-items: center;
+}


### PR DESCRIPTION
## Summary

Supersedes #327 (@bsgdigital). After architect + 2 senior-engineer review of #327 against current main, 70% of the PR's file diff was found byte-identical to main (the SOUL.md overlay shipped independently in #297 while #327 was open; the Dockerfile additions were the same; the test file was the same). This PR cherry-picks only the genuinely-new ~80 lines.

## What's in here

**3 new webui patches** (renumbered 004/005/006 to preserve main's `003-server-py-onboarding-redirect`):

- **004-fox-bot-name-override** — overrides `window._botName` to "Fox in the box" when `<html>` has the `.fox-in-the-box` class. **Regenerated against v0.51.118 boot.js** — original PR's patch was authored against v0.51.95 and the trailing context drifted (`if(s.default_model) window._defaultModel=…` → `if(s.default_model_provider) window._activeProvider=…`).
- **005-fox-avatar-override** — `_assistantRoleHtml` emits `<img>` with the Fox avatar instead of the upstream caduceus initial. Applies via fuzzy context match.
- **006-fox-empty-state-branding** — replaces upstream "What can I help with?" empty-state copy with Fox-tone copy + suggestion button rewording.

**15-line CSS append** to `packages/fox-overlay/webui_static/fox-in-the-box.css`:

- `.role-icon-avatar.fox-avatar` selector (pairs with patch 005)
- `.msg-role.assistant { align-items: center }` baseline alignment fix

## Intentionally NOT taken from #327

| File | Reason |
|---|---|
| `agent_overlay/SOUL.md` | byte-identical to main (shipped in #297) |
| `MANIFEST.toml` entry | already in main verbatim |
| `tests/integration/test_fox_soul_overlay.py` | identical to main |
| `packages/integration/Dockerfile` | PR's version would REVERT v0.7.17's `[anthropic,bedrock,google]` extras (P0 regression risk) |
| whole-file CSS takeover | PR's base lacked v0.7.10 mobile-avatar block (#299); only the 15-line APPEND is pulled |
| `.github/workflows/build-container.yml` | adds destructive submodule reset — architect flagged it may mask flakiness instead of fixing it. Defer to separate review |

## Test plan

- [x] `check-overlay-basis.sh` clean — all 6 patches apply sequentially against v0.51.118
- [x] 71/71 jest tests green
- [ ] CI: validate + smoke + container build + container smoke (will run on PR)
- [ ] Post-merge: visual verification on a Fox install — bot name says "Fox in the box", avatar image renders, empty-state copy is the Fox version
- [ ] @bsgdigital's authorship preserved in the file additions; this PR's commit message credits him as original PR author

## On #327

After this PR merges, close #327 with link here as superseded. Co-authorship to @bsgdigital noted.