### PR TITLE
fix(build): correct NSIS image option names (installerHeader/installerSidebar)

### DIFF
--- a/packages/electron/electron-builder.yml
+++ b/packages/electron/electron-builder.yml
@@ -42,8 +42,8 @@ nsis:
   shortcutName: Fox in the Box
   installerIcon: assets/icon.ico
   uninstallerIcon: assets/icon.ico
-  installerHeaderImage: assets/installer/header.bmp
-  installerSidebarImage: assets/installer/sidebar.bmp
+  installerHeader: assets/installer/header.bmp
+  installerSidebar: assets/installer/sidebar.bmp
   include: build/installer.nsh
 
 mac:


### PR DESCRIPTION
Fixes the electron-builder ValidationError that failed the v0.7.31 release build.

electron-builder 24.x NSIS schema uses `installerHeader` and `installerSidebar`, not `installerHeaderImage`/`installerSidebarImage`. The wrong names were added in v0.7.26 (#323) — they passed local validation but were rejected by electron-builder at build time.

**Verified:** Config parses cleanly. No other changes.