### PR TITLE
fix(electron): recover from dead container state (HTTP 409)

### DIFF
--- a/packages/electron/src/docker-manager.js
+++ b/packages/electron/src/docker-manager.js
@@ -514,11 +514,30 @@ async function ensureContainerRunning() {
       log.info('Container already running:', CNAME);
       return { container, reused: true, reason: 'already-running' };
     }
+
+    // Dead containers are pending removal — Docker won't start them (HTTP 409).
+    // Remove and recreate rather than erroring out.
+    if (existing.State === 'dead' || existing.Status === 'Dead') {
+      log.warn('Container is dead (pending removal) — removing and recreating:', CNAME);
+      try { await container.remove({ force: true }); } catch (e) {
+        log.warn('Failed to remove dead container:', e.message);
+      }
+      const created = await createAndStartContainer();
+      return { ...created, reason: 'recreated-after-dead' };
+    }
+
     try {
       await container.start();
       log.info('Started existing container:', CNAME);
       return { container, reused: true, reason: 'started-existing' };
     } catch (err) {
+      // 409 means the container is being removed concurrently — recreate.
+      if (err.statusCode === 409 || (err.message && err.message.includes('marked for removal'))) {
+        log.warn('Container 409 on start (marked for removal) — recreating:', CNAME);
+        try { await container.remove({ force: true }); } catch (_) {}
+        const created = await createAndStartContainer();
+        return { ...created, reason: 'recreated-after-dead' };
+      }
       throw dockerError('CONTAINER_START_FAILED', `Failed to start existing container "${CNAME}"`, err);
     }
   }

--- a/tests/electron/docker-manager.test.js
+++ b/tests/electron/docker-manager.test.js
@@ -189,6 +189,51 @@ test('ensureContainerRunning reports started-existing reason', async () => {
   expect(result.reason).toBe('started-existing');
 });
 
+test('ensureContainerRunning recreates when container is dead (HTTP 409 on start)', async () => {
+  // Regression: container state "dead" means Docker marked it for removal.
+  // Calling container.start() returns 409 "marked for removal and cannot be started".
+  // Fox must remove + recreate rather than surfacing an unrecoverable error.
+  mockDockerInstance.listContainers.mockResolvedValueOnce([
+    { Id: 'dead-1', State: 'dead', Status: 'Dead', Names: ['/fox-in-the-box'], ImageID: 'sha256:any' },
+  ]);
+  mockDockerInstance.getImage = jest.fn().mockReturnValue({
+    inspect: jest.fn().mockRejectedValue(new Error('no image')),
+  });
+  const deadContainer = { remove: jest.fn().mockResolvedValue({}) };
+  const newContainer  = { start: jest.fn().mockResolvedValue({}) };
+  mockDockerInstance.getContainer.mockReturnValueOnce(deadContainer);
+  mockDockerInstance.createContainer.mockResolvedValue(newContainer);
+
+  const result = await docker.ensureContainerRunning();
+
+  expect(deadContainer.remove).toHaveBeenCalledWith({ force: true });
+  expect(mockDockerInstance.createContainer).toHaveBeenCalledTimes(1);
+  expect(result.reason).toBe('recreated-after-dead');
+});
+
+test('ensureContainerRunning recreates when container.start() throws 409 marked-for-removal', async () => {
+  // Same failure mode but detected via 409 on start() rather than state check.
+  mockDockerInstance.listContainers.mockResolvedValueOnce([
+    { Id: 'dying-1', State: 'exited', Status: 'Exited', Names: ['/fox-in-the-box'], ImageID: 'sha256:any' },
+  ]);
+  mockDockerInstance.getImage = jest.fn().mockReturnValue({
+    inspect: jest.fn().mockRejectedValue(new Error('no image')),
+  });
+  const err409 = Object.assign(new Error('container is marked for removal'), { statusCode: 409 });
+  const dyingContainer = {
+    start:  jest.fn().mockRejectedValue(err409),
+    remove: jest.fn().mockResolvedValue({}),
+  };
+  const newContainer = { start: jest.fn().mockResolvedValue({}) };
+  mockDockerInstance.getContainer.mockReturnValueOnce(dyingContainer);
+  mockDockerInstance.createContainer.mockResolvedValue(newContainer);
+
+  const result = await docker.ensureContainerRunning();
+
+  expect(dyingContainer.remove).toHaveBeenCalledWith({ force: true });
+  expect(result.reason).toBe('recreated-after-dead');
+});
+
 test('ensureContainerRunning reports created-new reason', async () => {
   mockDockerInstance.listContainers.mockResolvedValueOnce([]);
   const mockContainer = { start: jest.fn().mockResolvedValue({}) };


### PR DESCRIPTION
## Problem

User hit: `(HTTP code 409) unexpected - container is marked for removal and cannot be started`

Container state was `"dead"` — Docker marks a container dead when it crashed or was forcefully killed and is pending removal. Fox was calling `container.start()` on the dead container, which always returns 409.

## Fix

- Check for `State === 'dead'` before attempting `start()` — force-remove and recreate
- Also catch HTTP 409 on `start()` as a fallback for race conditions where the state changes between the list check and the start call
- Both paths: `remove({ force: true })` → `createAndStartContainer()` → return `reason: 'recreated-after-dead'`
- User data is preserved via the `/data` bind mount

## Tests

+2 regression tests covering both paths. Full suite: 92/92.

Reported by @foxrunner.