### PR TITLE
fix(electron): consistent dark-style error window — eliminates two-style launcher (#362)

### DIFF
--- a/packages/electron/assets/error.html
+++ b/packages/electron/assets/error.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy"
+      content="default-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self';">
+<style>
+@font-face {
+  font-family: "Sora";
+  src: url("fonts/Sora.woff2") format("woff2-variations");
+  font-weight: 100 900;
+  font-display: swap;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: "Sora", "Segoe UI", system-ui, sans-serif;
+  background: #0D0D1A;
+  color: #FFF8DC;
+  height: 100vh;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 36px 44px;
+  overflow: hidden;
+}
+
+.wrap { width: 100%; max-width: 480px; }
+
+.brand-name {
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: rgba(255,248,220,0.5);
+  margin-bottom: 4px;
+}
+
+.error-bar {
+  height: 2px;
+  background: linear-gradient(90deg, #E53935 0%, rgba(229,57,53,0.2) 100%);
+  border-radius: 1px;
+  margin: 12px 0 20px;
+}
+
+.error-heading {
+  font-size: 16px;
+  font-weight: 600;
+  color: #EF5350;
+  letter-spacing: -0.01em;
+  margin-bottom: 14px;
+}
+
+.meta {
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.07);
+  border-radius: 8px;
+  padding: 10px 12px;
+  margin-bottom: 14px;
+  font-size: 11.5px;
+  color: rgba(255,248,220,0.55);
+  line-height: 1.7;
+}
+.meta b { color: rgba(255,248,220,0.8); }
+
+.message {
+  font-size: 12.5px;
+  color: rgba(255,248,220,0.8);
+  line-height: 1.6;
+  margin-bottom: 10px;
+}
+
+.remediation {
+  font-size: 12px;
+  color: rgba(255,248,220,0.55);
+  line-height: 1.6;
+  margin-bottom: 10px;
+}
+.remediation b { color: rgba(255,215,0,0.8); }
+
+.log-path {
+  font-size: 11px;
+  color: rgba(255,248,220,0.3);
+  margin-bottom: 12px;
+  word-break: break-all;
+}
+
+/* Diagnostics collapsible */
+.diag {
+  border-top: 1px solid rgba(255,255,255,0.07);
+  padding-top: 10px;
+  margin-bottom: 16px;
+}
+.diag summary {
+  font-size: 11px;
+  font-weight: 500;
+  color: rgba(255,248,220,0.35);
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  outline: none;
+  transition: color 0.15s;
+}
+.diag summary:hover { color: rgba(255,248,220,0.6); }
+.diag summary::-webkit-details-marker { display: none; }
+.diag-arrow {
+  display: inline-block;
+  font-size: 8px;
+  transition: transform 0.2s;
+}
+details[open] .diag-arrow { transform: rotate(90deg); }
+.diag-body {
+  margin-top: 8px;
+  font-family: ui-monospace, "Cascadia Code", Consolas, monospace;
+  font-size: 10px;
+  color: rgba(255,248,220,0.28);
+  line-height: 1.55;
+  max-height: 90px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+.diag-body::-webkit-scrollbar { width: 3px; }
+.diag-body::-webkit-scrollbar-track { background: transparent; }
+.diag-body::-webkit-scrollbar-thumb { background: rgba(229,57,53,0.25); border-radius: 2px; }
+
+.actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.btn {
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 8px 16px;
+  border-radius: 6px;
+  border: none;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+.btn:hover { opacity: 0.85; }
+
+.btn-copy {
+  background: rgba(255,215,0,0.12);
+  color: #FFD700;
+  border: 1px solid rgba(255,215,0,0.3);
+}
+.btn-close {
+  background: rgba(255,255,255,0.08);
+  color: rgba(255,248,220,0.7);
+  border: 1px solid rgba(255,255,255,0.1);
+}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="brand-name">Fox in the Box</div>
+  <div class="error-bar"></div>
+  <div class="error-heading">Startup failed</div>
+
+  <div class="meta" id="meta">
+    <!-- populated by JS -->
+  </div>
+
+  <p class="message" id="message"></p>
+  <p class="remediation" id="remediation"></p>
+  <p class="log-path" id="log-path"></p>
+
+  <details class="diag" id="diag">
+    <summary><span class="diag-arrow">▶</span> Diagnostics</summary>
+    <div class="diag-body" id="diag-body"></div>
+  </details>
+
+  <div class="actions">
+    <button class="btn btn-copy" id="btn-copy">Copy diagnostics</button>
+    <button class="btn btn-close" id="btn-close">Close</button>
+  </div>
+</div>
+
+<script>
+if (window.fitbError) {
+  window.fitbError.getData().then(d => {
+
+    document.getElementById('meta').innerHTML =
+      `<div><b>Session:</b> ${esc(d.sessionId)}</div>` +
+      `<div><b>Phase:</b> ${esc(d.phase)}</div>` +
+      `<div><b>Error code:</b> ${esc(d.code)}</div>`;
+    document.getElementById('message').textContent = d.message;
+    document.getElementById('remediation').innerHTML = `<b>Try:</b> ${esc(d.remediation)}`;
+    document.getElementById('log-path').textContent = d.logPath;
+    document.getElementById('diag-body').textContent = d.diagnosticsText;
+  });
+}
+
+document.getElementById('btn-copy').addEventListener('click', () => {
+  if (window.fitbError) window.fitbError.copyDiagnostics();
+});
+
+document.getElementById('btn-close').addEventListener('click', () => {
+  if (window.fitbError) window.fitbError.close();
+});
+
+function esc(s) {
+  return String(s || '')
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+</script>
+</body>
+</html>

--- a/packages/electron/src/main.js
+++ b/packages/electron/src/main.js
@@ -215,6 +215,9 @@ function buildDiagnosticsText({
   ].join('\n');
 }
 
+// Error data stored here so the preload's ipcMain.handle can return it synchronously.
+let _errorData = null;
+
 function showError(details) {
   if (typeof details === 'string') {
     details = {
@@ -233,81 +236,46 @@ function showError(details) {
   } = details;
   closeProgress();
 
+  _errorData = {
+    sessionId, phase, code, message, remediation, diagnosticsText,
+    logPath: path.join(app.getPath('logs'), 'main.log'),
+  };
+
   const win = new BrowserWindow({
     width: 560,
-    height: 340,
+    height: 400,
     resizable: false,
     minimizable: false,
     maximizable: false,
     closable: true,
     alwaysOnTop: true,
     frame: true,
-    title: 'Fox in the box — Error',
+    title: 'Fox in the Box — Error',
     icon: APP_ICON,
-    webPreferences: { nodeIntegration: true, contextIsolation: false },
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      preload: path.join(__dirname, 'preload-error.js'),
+    },
   });
 
-  const escaped = String(message)
-    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-    .replace(/\n/g, '<br>');
-  const escapedRemediation = String(remediation)
-    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-    .replace(/\n/g, '<br>');
-  const escapedDiag = String(diagnosticsText)
-    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-    .replace(/\n/g, '<br>');
-  const copyChannel = `copy-diagnostics-${Date.now()}`;
-
-  const html = `<!DOCTYPE html>
-<html><head><meta charset="utf-8">
-<style>
-  body { font-family: "Segoe UI", sans-serif; margin: 0; display: flex;
-         align-items: center; justify-content: center; height: 100vh;
-         background: #fff; }
-  .wrap { text-align: left; padding: 24px; max-width: 520px; }
-  .logo { font-size: 32px; margin-bottom: 12px; }
-  h2 { font-size: 15px; margin: 0 0 10px; color: #c0392b; }
-  p  { font-size: 12px; color: #555; margin: 0 0 12px; line-height: 1.5; text-align: left; }
-  .meta { background:#f7f7f7; border:1px solid #ddd; border-radius:8px; padding:8px; margin-bottom:12px; font-size:12px; }
-  .diag { font-size:11px; max-height:95px; overflow:auto; background:#fafafa; border:1px solid #eee; padding:8px; border-radius:6px; }
-  .actions { display:flex; gap:8px; justify-content:flex-end; margin-top:12px; }
-  button { background: #444; color: #fff; border: none; padding: 8px 14px;
-           font-size: 13px; border-radius: 6px; cursor: pointer; }
-  button:hover { background: #222; }
-</style></head>
-<body><div class="wrap">
-  <div class="logo">🦊</div>
-  <h2>Startup failed</h2>
-  <div class="meta">
-    <div><b>Session:</b> ${sessionId}</div>
-    <div><b>Phase:</b> ${phase}</div>
-    <div><b>Error code:</b> ${code}</div>
-  </div>
-  <p>${escaped}</p>
-  <p><b>Try:</b> ${escapedRemediation}</p>
-  <p><b>Log file:</b> ${path.join(app.getPath('logs'), 'main.log')}</p>
-  <div class="diag">${escapedDiag}</div>
-  <div class="actions">
-    <button onclick="require('electron').ipcRenderer.send('${copyChannel}')">Copy diagnostics</button>
-    <button onclick="window.close()">Close</button>
-  </div>
-</div></body></html>`;
-
-  win.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(html));
-  win.setMenu(null);
-  ipcMain.once(copyChannel, () => {
+  ipcMain.handleOnce('error:get-data', () => _errorData);
+  ipcMain.once('error:copy', () => {
     clipboard.writeText(diagnosticsText);
-    dialog.showMessageBox({
+    dialog.showMessageBox(win, {
       type: 'info',
       message: 'Diagnostics copied to clipboard.',
       buttons: ['OK'],
     });
   });
+  ipcMain.once('error:close', () => win.close());
+
+  win.loadFile(path.join(__dirname, '..', 'assets', 'error.html'));
+  win.setMenu(null);
 
   win.on('closed', () => {
-    if (_fatalStartup) {
-      app.exit(1);
-    }
+    _errorData = null;
+    if (_fatalStartup) app.exit(1);
   });
 }
 

--- a/packages/electron/src/preload-error.js
+++ b/packages/electron/src/preload-error.js
@@ -1,0 +1,8 @@
+'use strict';
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('fitbError', {
+  getData: () => ipcRenderer.invoke('error:get-data'),
+  copyDiagnostics: () => ipcRenderer.send('error:copy'),
+  close: () => ipcRenderer.send('error:close'),
+});


### PR DESCRIPTION
The startup launcher had two completely different visual styles:

- **Progress window** (`progress.html`): dark navy #0D0D1A, Sora font, gold accents, spinning steps — looks great
- **Error window** (inline `data:` HTML): white #fff background, Segoe UI, black/grey — looks like a placeholder

This replaces the error window with `error.html` matching the Fox dark palette exactly: same navy background, same Sora font, red accent bar instead of gold, collapsible diagnostics pane, "Copy diagnostics" and "Close" buttons with Fox styling.

Also fixes: `nodeIntegration: true` security hole replaced with proper `contextBridge` preload.

Tests: 101/101 green.