### PR TITLE
fix(nsis): remove MUI_HEADER_TEXT — MUI2 not loaded at include time

### DIFF
--- a/packages/electron/build/mode-page.nsh
+++ b/packages/electron/build/mode-page.nsh
@@ -20,8 +20,6 @@ Function FitbModePageCreate
     Abort   ; skip this page — fresh install
   ${EndIf}
 
-  !insertmacro MUI_HEADER_TEXT "Installation mode" "An existing Fox in the Box installation was found."
-
   nsDialogs::Create 1018
   Pop $FitbDlg
   ${If} $FitbDlg == error


### PR DESCRIPTION
## Summary

- `mode-page.nsh` calls `!insertmacro MUI_HEADER_TEXT` inside `FitbModePageCreate`. This is a compile-time macro expansion.
- electron-builder includes our `installer.nsh` (and transitively `mode-page.nsh`) **before** it includes `MUI2.nsh`, so `MUI_HEADER_TEXT` is not yet defined when makensis compiles the script.
- Error from CI: `!insertmacro: macro named "MUI_HEADER_TEXT" not found!`
- Fix: remove the call. The page already has an `NSD_CreateLabel` that explains the context to the user; the MUI2 header is purely decorative and not needed.

## Test plan

- [ ] CI passes (`Electron smoke — windows-latest`)
- [ ] After merge: retag `v0.7.34` → triggers full release build → Windows `.exe` uploads to GitHub Release