### PR TITLE
fix(nsis): suppress warning 6010 for install-only page functions

### DIFF
--- a/packages/electron/build/installer.nsh
+++ b/packages/electron/build/installer.nsh
@@ -14,7 +14,12 @@
 !define FITB_CONTAINER   "fox-in-the-box"
 !define FITB_IMAGE       "ghcr.io/fox-in-the-box-ai/cloud:stable"
 
+; NSIS warning 6010 ("install function not referenced") fires for FitbModePageCreate
+; and FitbModePageLeave during the uninstaller pass — NSIS doesn't count Page custom
+; registrations as function references. electron-builder passes -WX, so suppress it.
+!pragma warning disable 6010
 !include "mode-page.nsh"
+!pragma warning default 6010
 
 ; Register the mode-selection page after the directory selection page.
 ; electron-builder calls !insertmacro customPageAfterChangeDir in its


### PR DESCRIPTION
## Summary

NSIS warning 6010 (`install function not referenced`) fires for `FitbModePageCreate` and `FitbModePageLeave` during the **uninstaller** compilation pass. NSIS doesn't count `Page custom` registrations as function references, so it marks the install-phase page callbacks as "unreferenced" when building the uninstall binary.

electron-builder passes `-WX` (treat warnings as errors) to makensis, so this warning was causing the build to fail.

Fix: wrap the `!include "mode-page.nsh"` with `!pragma warning disable/default 6010`.

## Test plan

- [ ] `Electron smoke — windows-latest` passes (NSIS builds without error)
- [ ] After merge: retag `v0.7.34` → full release build succeeds → Windows `.exe` uploaded to GitHub Release