### PR TITLE
fix(ux): dialog parent z-order, Docker wait message, Tailscale guidance

### DIFF
--- a/packages/electron/src/main.js
+++ b/packages/electron/src/main.js
@@ -296,7 +296,7 @@ async function ensureDockerWindows(progressCb = showProgress) {
     const dockerConfigPath = path.join(os.homedir(), 'AppData', 'Roaming', 'Docker', 'settings.json');
     const dockerAlreadyConfigured = fs.existsSync(dockerConfigPath);
     if (!dockerAlreadyConfigured) {
-      await dialog.showMessageBox({
+      await dialog.showMessageBox(getDialogParent(), {
         type: 'info',
         title: 'Fox in the Box — Docker setup',
         message: 'Docker Desktop is about to start.',
@@ -333,7 +333,7 @@ async function ensureDockerWindows(progressCb = showProgress) {
 // ─── macOS Docker install (kept separate) ────────────────────────────────────
 
 async function installDockerMac(progressCb = showProgress) {
-  const { response } = await dialog.showMessageBox({
+  const { response } = await dialog.showMessageBox(getDialogParent(), {
     type: 'question',
     buttons: ['Install Docker', 'Cancel'],
     defaultId: 0,
@@ -394,7 +394,7 @@ async function showDaemonRecoveryRequired(platform) {
     // fails, the dialog copy below would be a lie — registerWindowsRunOnceResume
     // logs but does not throw, so detect that we have an exe path at least.
     await registerWindowsRunOnceResume(app.getPath('exe'));
-    const { response } = await dialog.showMessageBox({
+    const { response } = await dialog.showMessageBox(getDialogParent(), {
       type: 'warning',
       title: 'Restart required to finish Docker setup',
       message: 'Docker Desktop needs a restart before Fox in the box can continue.',
@@ -414,7 +414,7 @@ async function showDaemonRecoveryRequired(platform) {
   }
 
   if (platform === 'darwin') {
-    const { response } = await dialog.showMessageBox({
+    const { response } = await dialog.showMessageBox(getDialogParent(), {
       type: 'warning',
       title: 'Docker not ready',
       message: 'Docker Desktop is installed but daemon is not ready yet.',
@@ -502,7 +502,7 @@ async function openFox() {
       const lines = mode === '3'
         ? `Local access: http://localhost:8787\nFrom other devices: ${tailnetUrl}`
         : `From other devices: ${tailnetUrl}`;
-      const { response } = await dialog.showMessageBox({
+      const { response } = await dialog.showMessageBox(getDialogParent(), {
         type: 'info',
         title: 'Fox in the box — Ready',
         message: 'Fox in the box is ready!',
@@ -511,6 +511,15 @@ async function openFox() {
         defaultId: 0,
       });
       if (response === 1) clipboard.writeText(tailnetUrl);
+    } else {
+      await dialog.showMessageBox(getDialogParent(), {
+        type: 'info',
+        title: 'Fox in the box — Tailscale not connected yet',
+        message: 'Tailscale hasn\'t connected yet.',
+        detail: 'Open the Tailscale app, sign in if prompted, and wait until it shows "Connected".\n\nFox is opening locally in the meantime. Once Tailscale connects, your tailnet URL will be available from the Tailscale menu.',
+        buttons: ['OK'],
+        defaultId: 0,
+      });
     }
   }
   shell.openExternal(APP_HOME_URL);

--- a/packages/electron/src/startup.js
+++ b/packages/electron/src/startup.js
@@ -499,6 +499,7 @@ async function ensureDockerWindows(deps) {
     // path fires Fox immediately after login while Docker Desktop is still
     // initializing its WSL distros. Give Docker a 15s head start before the
     // first probe so we don't waste the first polling slice on a guaranteed miss.
+    showProgress('Docker Desktop is starting up — waiting for it to initialize…');
     await _sleep(15_000);
     let remainingMs = 360_000;  // 240s → 360s: covers slower hardware on reboot
     let diagnostics = null;


### PR DESCRIPTION
## Summary

Three low-risk UX fixes shipped together.

**1. System dialogs now appear on top of the launcher (#324 follow-up)**
All 6 `dialog.showMessageBox` calls that were missing a parent now pass `getDialogParent()` (returns `_progressWin` or null). The helper already existed — just wasn't wired to the call sites. Prevents dialogs from hiding behind the progress window.

**2. 15-second silent freeze eliminated**
`startup.js` — added `showProgress('Docker Desktop is starting up — waiting for it to initialize…')` immediately before the 15s settle delay. Previously the launcher sat frozen on the last message while Docker warmed up on the reboot/RunOnce path.

**3. Tailscale auth guidance when not connected**
`openFox()` — added `else` branch for when `pollTailscaleUrl` times out with `null`. Shows a dialog: "Open the Tailscale app, sign in if prompted, and wait until it shows Connected." Fox still opens locally regardless.

## Test plan

- [ ] 101/101 Jest pass (confirmed locally)
- [ ] CI green
- [ ] After merge: bump to v0.7.35 and tag