### PR TITLE
fix(progress): steps and diagnostics never appeared in launcher window

### DIFF
--- a/packages/electron/assets/progress.html
+++ b/packages/electron/assets/progress.html
@@ -57,7 +57,7 @@ body {
 }
 .step.done    { color: #4CAF50; }
 .step.active  { color: #FFF8DC; font-weight: 600; }
-.step.pending { color: rgba(255,248,220,0.22); }
+.step.pending { color: rgba(255,248,220,0.38); }
 
 .icon {
   width: 20px;

--- a/packages/electron/src/main.js
+++ b/packages/electron/src/main.js
@@ -125,6 +125,7 @@ function showProgress(message) {
 
   if (_progressWin) {
     _progressWin.webContents.send('progress:step', idx, _progressState.detail || '');
+    _progressWin.webContents.send('progress:log', _progressState.title);
     if (_progressState.detail) {
       _progressWin.webContents.send('progress:log', _progressState.detail);
     }
@@ -157,10 +158,13 @@ function showProgress(message) {
   _progressWin.loadFile(path.join(__dirname, '..', 'assets', 'progress.html'));
   _progressWin.setMenu(null);
 
-  // Send initial state once the page is ready.
+  // Send current state once the page is ready. Use _progressState at fire time,
+  // not the idx captured at window-creation time (startup may have advanced).
   _progressWin.webContents.once('did-finish-load', () => {
     if (!_progressWin || _progressWin.isDestroyed()) return;
-    _progressWin.webContents.send('progress:step', idx, _progressState.detail || '');
+    const currentIdx = _activeStepIndex(_progressState.title);
+    _progressWin.webContents.send('progress:step', currentIdx, _progressState.detail || '');
+    _progressWin.webContents.send('progress:log', _progressState.title);
     if (_progressState.detail) {
       _progressWin.webContents.send('progress:log', _progressState.detail);
     }


### PR DESCRIPTION
## Summary

- `showProgress()` was only sending `progress:log` when `_progressState.detail` was set. Since all callers pass plain strings (title only), the diagnostics pane was always empty. Now every progress update also logs its title.
- `did-finish-load` handler captured `idx` at window-creation time. If startup had advanced before the page loaded, the stale step index was sent. Recomputes `currentIdx` at fire time instead.
- `.step.pending` was at 22% opacity on the dark `#0D0D1A` background — effectively invisible. Raised to 38%.

## Test plan

- [ ] Launch Fox and verify the progress window shows active step with spinner and completed steps with ✓
- [ ] Open the Diagnostics disclosure and verify log lines appear as startup progresses
- [ ] Verify pending steps are legible (not invisible) on the dark background
- [ ] Verify no regression on normal launch flow through all 6 steps