### PR TITLE
fix(launcher): CSP blocked inline scripts — progress steps and error content never rendered

### DIFF
--- a/packages/electron/assets/error.html
+++ b/packages/electron/assets/error.html
@@ -181,34 +181,6 @@ details[open] .diag-arrow { transform: rotate(90deg); }
   </div>
 </div>
 
-<script>
-if (window.fitbError) {
-  window.fitbError.getData().then(d => {
-
-    document.getElementById('meta').innerHTML =
-      `<div><b>Session:</b> ${esc(d.sessionId)}</div>` +
-      `<div><b>Phase:</b> ${esc(d.phase)}</div>` +
-      `<div><b>Error code:</b> ${esc(d.code)}</div>`;
-    document.getElementById('message').textContent = d.message;
-    document.getElementById('remediation').innerHTML = `<b>Try:</b> ${esc(d.remediation)}`;
-    document.getElementById('log-path').textContent = d.logPath;
-    document.getElementById('diag-body').textContent = d.diagnosticsText;
-  });
-}
-
-document.getElementById('btn-copy').addEventListener('click', () => {
-  if (window.fitbError) window.fitbError.copyDiagnostics();
-});
-
-document.getElementById('btn-close').addEventListener('click', () => {
-  if (window.fitbError) window.fitbError.close();
-});
-
-function esc(s) {
-  return String(s || '')
-    .replace(/&/g, '&amp;').replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-}
-</script>
+<script src="error.js"></script>
 </body>
 </html>

--- a/packages/electron/assets/error.js
+++ b/packages/electron/assets/error.js
@@ -1,0 +1,28 @@
+'use strict';
+
+function esc(s) {
+  return String(s || '')
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+if (window.fitbError) {
+  window.fitbError.getData().then(d => {
+    document.getElementById('meta').innerHTML =
+      `<div><b>Session:</b> ${esc(d.sessionId)}</div>` +
+      `<div><b>Phase:</b> ${esc(d.phase)}</div>` +
+      `<div><b>Error code:</b> ${esc(d.code)}</div>`;
+    document.getElementById('message').textContent = d.message;
+    document.getElementById('remediation').innerHTML = `<b>Try:</b> ${esc(d.remediation)}`;
+    document.getElementById('log-path').textContent = d.logPath;
+    document.getElementById('diag-body').textContent = d.diagnosticsText;
+  });
+}
+
+document.getElementById('btn-copy').addEventListener('click', () => {
+  if (window.fitbError) window.fitbError.copyDiagnostics();
+});
+
+document.getElementById('btn-close').addEventListener('click', () => {
+  if (window.fitbError) window.fitbError.close();
+});

--- a/packages/electron/assets/progress.html
+++ b/packages/electron/assets/progress.html
@@ -138,41 +138,6 @@ details[open] .diag-arrow { transform: rotate(90deg); }
   </details>
 </div>
 
-<script>
-const STEPS = [
-  'Checking system',
-  'Setting up Docker',
-  'Pulling container image',
-  'Starting container',
-  'Waiting for Fox to be ready',
-  'Opening Fox',
-];
-
-let currentIdx = 0;
-
-function render(idx) {
-  currentIdx = idx;
-  document.getElementById('steps').innerHTML = STEPS.map((label, i) => {
-    let iconHtml, cls;
-    if (i < idx)       { iconHtml = '<span style="color:#4CAF50;font-size:15px;">✓</span>'; cls = 'done'; }
-    else if (i === idx) { iconHtml = '<div class="spinner"></div>'; cls = 'active'; }
-    else               { iconHtml = '<span style="opacity:0.35;font-size:11px;">○</span>'; cls = 'pending'; }
-    return `<div class="step ${cls}"><div class="icon">${iconHtml}</div><span>${label}</span></div>`;
-  }).join('');
-}
-
-function appendLog(line) {
-  const el = document.getElementById('diag-body');
-  el.textContent = el.textContent ? el.textContent + '\n' + line : line;
-  el.scrollTop = el.scrollHeight;
-}
-
-render(currentIdx);
-
-if (window.fitb) {
-  window.fitb.onStepUpdate((idx) => render(idx));
-  window.fitb.onLogLine((line) => appendLog(line));
-}
-</script>
+<script src="progress.js"></script>
 </body>
 </html>

--- a/packages/electron/assets/progress.js
+++ b/packages/electron/assets/progress.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const STEPS = [
+  'Checking system',
+  'Setting up Docker',
+  'Pulling container image',
+  'Starting container',
+  'Waiting for Fox to be ready',
+  'Opening Fox',
+];
+
+let currentIdx = 0;
+
+function render(idx) {
+  currentIdx = idx;
+  document.getElementById('steps').innerHTML = STEPS.map((label, i) => {
+    let iconHtml, cls;
+    if (i < idx)        { iconHtml = '<span style="color:#4CAF50;font-size:15px;">✓</span>'; cls = 'done'; }
+    else if (i === idx) { iconHtml = '<div class="spinner"></div>'; cls = 'active'; }
+    else                { iconHtml = '<span style="opacity:0.35;font-size:11px;">○</span>'; cls = 'pending'; }
+    return `<div class="step ${cls}"><div class="icon">${iconHtml}</div><span>${label}</span></div>`;
+  }).join('');
+}
+
+function appendLog(line) {
+  const el = document.getElementById('diag-body');
+  el.textContent = el.textContent ? el.textContent + '\n' + line : line;
+  el.scrollTop = el.scrollHeight;
+}
+
+render(currentIdx);
+
+if (window.fitb) {
+  window.fitb.onStepUpdate((idx) => render(idx));
+  window.fitb.onLogLine((line) => appendLog(line));
+}


### PR DESCRIPTION
## Root cause

`progress.html` and `error.html` both carry this CSP meta tag:

```
default-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self';
```

`default-src 'self'` sets `script-src 'self'` — which blocks inline `<script>` blocks (no `'unsafe-inline'`). Chromium enforces this even for `file://` content loaded via Electron's `loadFile()`. Every time the progress window opened, `render()` never ran, `ipcRenderer` listeners were never registered, and all `progress:step` / `progress:log` IPC messages were silently dropped.

The same bug was present in `error.html`: error details, copy button, and close button were all wired up in the blocked inline script.

## Fix

Extract each inline script to a same-directory `.js` file (`progress.js`, `error.js`) and load via `<script src="...">`. The existing `'self'` directive allows same-origin external scripts — no CSP change needed.

## Test plan

- [ ] Launch Fox on a clean system — verify progress window shows all 6 steps with spinner on active step
- [ ] Open Diagnostics disclosure — verify log lines appear as each phase starts
- [ ] Trigger an error condition — verify error window shows session ID, phase, error code, message, and remediation text
- [ ] Verify Copy diagnostics and Close buttons work on the error window