### PR TITLE
fix(launcher): bigger window, selectable diagnostics, skip early Docker process-detection failure

### DIFF
--- a/packages/electron/assets/progress.html
+++ b/packages/electron/assets/progress.html
@@ -27,7 +27,7 @@ body {
   -webkit-user-select: none;
 }
 
-.wrap { width: 100%; max-width: 420px; }
+.wrap { width: 100%; max-width: 520px; }
 
 .brand-name {
   font-size: 17px;
@@ -117,10 +117,13 @@ details[open] .diag-arrow { transform: rotate(90deg); }
   font-size: 10.5px;
   color: rgba(255,248,220,0.32);
   line-height: 1.6;
-  max-height: 110px;
+  max-height: 200px;
   overflow-y: auto;
   white-space: pre-wrap;
   word-break: break-all;
+  user-select: text;
+  -webkit-user-select: text;
+  cursor: text;
 }
 .diag-body::-webkit-scrollbar { width: 3px; }
 .diag-body::-webkit-scrollbar-track { background: transparent; }

--- a/packages/electron/src/main.js
+++ b/packages/electron/src/main.js
@@ -133,8 +133,8 @@ function showProgress(message) {
   }
 
   _progressWin = new BrowserWindow({
-    width: 520,
-    height: 420,
+    width: 620,
+    height: 560,
     resizable: false,
     minimizable: false,
     maximizable: false,

--- a/packages/electron/src/startup.js
+++ b/packages/electron/src/startup.js
@@ -476,12 +476,12 @@ async function ensureDockerWindows(deps) {
       }
       desktopRunning = await waitForDesktopStart(isDesktopProcessRunning, 15_000, 1_000, undefined, showProgress);
       if (!desktopRunning) {
-        setForegroundYield(false);
-        const launchErr = new Error(
-          'Docker Desktop did not start. Please open Docker Desktop manually, wait until it is running, then retry.'
-        );
-        launchErr.code = 'DOCKER_DESKTOP_LAUNCH_FAILED';
-        throw launchErr;
+        // Process name check (tasklist) failed, but Docker may still be running
+        // under a different name or with a permission mismatch. Fall through to
+        // the daemon wait loop — if Docker is genuinely up, the ping succeeds
+        // within seconds. If it's not, the 360s daemon wait surfaces the real error.
+        log.warn('Docker Desktop process not detected via tasklist — falling through to daemon wait');
+        showProgress('Docker Desktop process not confirmed — waiting for daemon…');
       }
     }
     // Docker Desktop process is up; its setup dialog (if any) has had its

--- a/tests/electron/startup.test.js
+++ b/tests/electron/startup.test.js
@@ -289,15 +289,19 @@ describe('ensureDockerWindows', () => {
     expect(result).toEqual({ result: 'started' });
   });
 
-  test('fails fast when Docker Desktop process does not launch', async () => {
+  test('falls through to daemon wait when Desktop process detection fails', async () => {
+    // tasklist can miss Docker Desktop.exe due to process name differences or
+    // permissions. Rather than failing fast, Fox now falls through to the daemon
+    // wait loop. If the daemon never comes up, it surfaces DAEMON_NOT_READY.
     const deps = makeDeps({
       _findExe: jest.fn().mockResolvedValue('C:\\Docker\\Docker Desktop.exe'),
       waitForDesktopStart: jest.fn().mockResolvedValue(false),
       waitForDaemon: jest.fn().mockResolvedValue(false),
     });
     await expect(ensureDockerWindows(deps)).rejects.toMatchObject({
-      code: 'DOCKER_DESKTOP_LAUNCH_FAILED',
+      code: 'DAEMON_NOT_READY',
     });
+    expect(deps.showRebootRequired).not.toHaveBeenCalled();
   });
 
   test('diagnoses missing WSL backend and throws specific error', async () => {


### PR DESCRIPTION
## Summary

- **Progress window 20% wider + 33% taller** (520×420 → 620×560). Wrap max-width 420→520px, diagnostics pane max-height 110→200px. All six steps and the diagnostics section are visible without scrolling the outer pane; inner scroll on the log area is preserved.
- **Diagnostics text is now selectable.** `body` has `user-select: none` for the launcher as a whole, but `.diag-body` overrides with `user-select: text` so users can select and Ctrl+C log lines.
- **Docker process-detection failure no longer aborts startup.** `tasklist /FI "IMAGENAME eq Docker Desktop.exe"` can fail even when Docker is running (process name mismatch, permission, or timing). Previously Fox threw `DOCKER_DESKTOP_LAUNCH_FAILED` after the 25 s + 15 s waits — even when Docker was genuinely up. Now it falls through to the 360 s daemon wait loop. If Docker is up, `isDaemonRunning()` succeeds within a couple seconds. If it's genuinely not running, the daemon wait expires with a cleaner `DAEMON_NOT_READY` error.

## Test plan

- [ ] Verify progress window is noticeably larger and shows all 6 steps + diagnostics without overflow
- [ ] Open diagnostics, select text, Ctrl+C — should copy to clipboard
- [ ] On Windows with Docker running: verify Fox proceeds past step 2 instead of erroring with "Docker Desktop did not start"
- [ ] On Windows with Docker genuinely not installed: verify error is eventually shown (DAEMON_NOT_READY after timeout) rather than hanging forever