### PR TITLE
fix(electron): post-reboot Docker setup no longer hangs at Launching 24s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
+## [0.7.39] - 2026-05-25
+
+**Post-reboot Docker setup no longer hangs at “Launching… 24s”.**
+
+### Fixed
+- Windows post-reboot install (`RunOnce` + `--resume-setup`): skip the 25s `tasklist` loop that could block indefinitely and freeze the UI at “Launching Docker Desktop… 24s” while Docker’s terms/sign-in wizard ran. Fox now spawns Docker once and polls the engine API for up to 6 minutes with a monotonic “Waiting for Docker engine…” status line.
+- All startup shell probes (`tasklist`, `wsl`, `reg query`, etc.) use exec timeouts so a stuck command cannot silence daemon polling for tens of minutes.
+- `diagnoseWindowsDocker` is capped at 15s so WSL probes cannot block the poll loop during first-run Docker boot.
+- Progress window shows live status text under the active step; Docker step auto-expands diagnostics. Closing the setup window during install prompts before quitting.
+
+---
+
 ## [0.7.38] - 2026-05-25
 
 **Larger launcher window, selectable diagnostics, Docker detection fallback.**

--- a/packages/electron/assets/progress.js
+++ b/packages/electron/assets/progress.js
@@ -20,6 +20,11 @@ function render(idx) {
     else                { iconHtml = '<span style="opacity:0.35;font-size:11px;">○</span>'; cls = 'pending'; }
     return `<div class="step ${cls}"><div class="icon">${iconHtml}</div><span>${label}</span></div>`;
   }).join('');
+
+  const diag = document.getElementById('diag');
+  if (diag && idx === 1) {
+    diag.open = true;
+  }
 }
 
 function appendLog(line) {

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fox-in-the-box/electron",
   "productName": "fox-in-the-box",
-  "version": "0.7.38",
+  "version": "0.7.39",
   "description": "Fox in the box desktop app",
   "author": "Vulpy, Inc.",
   "main": "src/main.js",

--- a/packages/electron/src/main.js
+++ b/packages/electron/src/main.js
@@ -23,6 +23,11 @@ const APP_ICON = process.platform === 'win32'
   ? path.join(__dirname, '..', 'assets', 'icon.ico')
   : path.join(__dirname, '..', 'assets', 'icon.png');
 let _fatalStartup = false;
+let _setupInProgress = false;
+
+/** Set when Fox is launched via HKCU RunOnce after a Docker-install reboot. */
+const resumeAfterReboot = process.platform === 'win32'
+  && process.argv.some((arg) => arg === '--resume-setup' || arg === '--resume-setup=true');
 
 // Prevent multiple instances
 if (!app.requestSingleInstanceLock()) {
@@ -110,6 +115,15 @@ function _activeStepIndex(title) {
   return 0;
 }
 
+/** Human-readable line for the diagnostics pane (strip orchestrator step prefix). */
+function progressDiagnosticsLine(title, explicitDetail) {
+  if (typeof explicitDetail === 'string' && explicitDetail.trim().length > 0) {
+    return explicitDetail.trim();
+  }
+  const m = String(title || '').match(/^Step \d+\/\d+ - [^:]+: (.+)$/);
+  return m ? m[1].trim() : String(title || '').trim();
+}
+
 function showProgress(message) {
   const update = (typeof message === 'object' && message !== null)
     ? message
@@ -122,12 +136,12 @@ function showProgress(message) {
   }
 
   const idx = _activeStepIndex(_progressState.title);
+  const logLine = progressDiagnosticsLine(_progressState.title, update.detail);
 
   if (_progressWin) {
-    _progressWin.webContents.send('progress:step', idx, _progressState.detail || '');
-    _progressWin.webContents.send('progress:log', _progressState.title);
-    if (_progressState.detail) {
-      _progressWin.webContents.send('progress:log', _progressState.detail);
+    _progressWin.webContents.send('progress:step', idx);
+    if (logLine) {
+      _progressWin.webContents.send('progress:log', logLine);
     }
     return;
   }
@@ -150,8 +164,26 @@ function showProgress(message) {
     },
   });
 
-  _progressWin.on('closed', () => {
+  _progressWin.on('closed', async () => {
     _progressWin = null;
+    if (_setupInProgress && !_fatalStartup) {
+      log.info('[startup] Setup progress window closed during installation');
+      const parent = getDialogParent();
+      const { response } = await dialog.showMessageBox(parent, {
+        type: 'warning',
+        title: 'Quit setup?',
+        message: 'Fox in the box setup is still in progress.',
+        detail:
+          'Docker may still be starting in the background. If you quit now, reopen Fox from the Start menu to continue.',
+        buttons: ['Quit setup', 'Keep waiting'],
+        defaultId: 1,
+        cancelId: 1,
+      });
+      if (response !== 0) {
+        showProgress(_progressState.title || 'Setting up…');
+        return;
+      }
+    }
     app.quit();
   });
 
@@ -163,10 +195,10 @@ function showProgress(message) {
   _progressWin.webContents.once('did-finish-load', () => {
     if (!_progressWin || _progressWin.isDestroyed()) return;
     const currentIdx = _activeStepIndex(_progressState.title);
-    _progressWin.webContents.send('progress:step', currentIdx, _progressState.detail || '');
-    _progressWin.webContents.send('progress:log', _progressState.title);
-    if (_progressState.detail) {
-      _progressWin.webContents.send('progress:log', _progressState.detail);
+    _progressWin.webContents.send('progress:step', currentIdx);
+    const logLine = progressDiagnosticsLine(_progressState.title, _progressState.detail);
+    if (logLine) {
+      _progressWin.webContents.send('progress:log', logLine);
     }
   });
 }
@@ -317,20 +349,24 @@ async function ensureDockerWindows(progressCb = showProgress) {
 
   return _ensureDockerWindows({
     isDaemonRunning: () => docker.isDaemonRunning(),
-    waitForDaemon: (ms, sp) => _waitForDaemon(
+    waitForDaemon: (ms, sp, phaseStartedAt) => _waitForDaemon(
       () => docker.isDaemonRunning(),
       ms || 90_000,
       1_000,
       Date.now,
       (t) => new Promise((r) => setTimeout(r, t)),
-      sp || progressCb
+      sp || progressCb,
+      phaseStartedAt
     ),
-    runCommand: (cmd, opts) => _runCommandVerbose(cmd, opts, (line) => showProgress({ detail: line })),
+    runCommand: (cmd, opts) => _runCommandVerbose(cmd, { windowsHide: true, ...opts }, (line) => {
+      showProgress({ detail: line });
+    }),
     spawnDetached,
     showProgress: progressCb,
     showRebootRequired: () => showDaemonRecoveryRequired('win32'),
     showError,
     setForegroundYield,
+    resumeAfterReboot,
   });
 }
 
@@ -580,7 +616,11 @@ async function handleStartupError(err) {
 
 async function main() {
   log.info('Fox in the box starting up');
+  if (resumeAfterReboot) {
+    log.info('[startup] Post-reboot resume (--resume-setup)');
+  }
 
+  _setupInProgress = true;
   try {
     const startupOutcome = await runStartup({
       docker,
@@ -603,13 +643,16 @@ async function main() {
       platform: process.platform,
     });
     if (startupOutcome && startupOutcome.outcome === 'reboot-required') {
+      _setupInProgress = false;
       app.quit();
       return;
     }
   } catch (err) {
+    _setupInProgress = false;
     await handleStartupError(err);
     return;
   }
+  _setupInProgress = false;
 
   createTray(true, {
     startFlow: startFromTray,

--- a/packages/electron/src/preload-progress.js
+++ b/packages/electron/src/preload-progress.js
@@ -2,8 +2,8 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('fitb', {
-  // Receives step index (0-based) + latest detail string from main process.
-  onStepUpdate: (cb) => ipcRenderer.on('progress:step', (_e, idx, detail) => cb(idx, detail)),
+  // Receives step index (0-based) from main process.
+  onStepUpdate: (cb) => ipcRenderer.on('progress:step', (_e, idx) => cb(idx)),
   // Receives a single log line to append to the diagnostics area.
   onLogLine: (cb) => ipcRenderer.on('progress:log', (_e, line) => cb(line)),
 });

--- a/packages/electron/src/startup.js
+++ b/packages/electron/src/startup.js
@@ -12,13 +12,34 @@ const log = require('electron-log');
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
+const SHELL_TIMEOUTS = {
+  tasklist: 5_000,
+  scQuery: 10_000,
+  wsl: 30_000,
+  regQuery: 10_000,
+  whereDocker: 10_000,
+  ifExist: 10_000,
+  startCmd: 15_000,
+  dockerContext: 10_000,
+};
+
 function runCommand(cmd, opts = {}) {
   return new Promise((resolve, reject) => {
-    exec(cmd, opts, (error, stdout, stderr) => {
-      if (error) reject(new Error(stderr || error.message));
-      else resolve(stdout);
+    exec(cmd, { windowsHide: true, ...opts }, (error, stdout, stderr) => {
+      if (error) {
+        const err = new Error(stderr || error.message);
+        if (error.killed && error.signal === 'SIGTERM') err.code = 'ETIMEDOUT';
+        reject(err);
+      } else resolve(stdout);
     });
   });
+}
+
+function formatElapsedSeconds(totalSec) {
+  if (totalSec < 60) return `${totalSec}s`;
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+  return s > 0 ? `${m}m ${s}s` : `${m}m`;
 }
 
 /**
@@ -69,14 +90,24 @@ async function waitForDaemon(
   intervalMs = 1_000,
   _now   = () => Date.now(),
   _sleep = (ms) => new Promise((r) => setTimeout(r, ms)),
-  showProgress = null
+  showProgress = null,
+  phaseStartedAt = null
 ) {
   const deadline = _now() + timeoutMs;
-  const start = _now();
+  const phaseStart = phaseStartedAt != null ? phaseStartedAt : _now();
+  let lastHeartbeatSec = -1;
   while (_now() < deadline) {
     if (await isDaemonRunning()) return true;
-    const elapsed = Math.round((_now() - start) / 1000);
-    if (showProgress) showProgress(`Starting Docker Desktop… ${elapsed}s`);
+    const totalSec = Math.round((_now() - phaseStart) / 1000);
+    if (showProgress) {
+      showProgress(
+        `Waiting for Docker engine… ${formatElapsedSeconds(totalSec)} — finish Docker Desktop setup if its window is open`
+      );
+    }
+    if (totalSec >= 15 && totalSec - lastHeartbeatSec >= 15) {
+      log.info('[docker-wait] elapsed=%ds engine=not-ready', totalSec);
+      lastHeartbeatSec = totalSec;
+    }
     await _sleep(intervalMs);
   }
   return false;
@@ -88,10 +119,17 @@ async function waitForDaemon(
  */
 async function isDockerDesktopProcessRunning(_run = runCommand) {
   try {
-    const out = await _run('tasklist /FI "IMAGENAME eq Docker Desktop.exe" /NH', { shell: true });
+    const out = await _run('tasklist /FI "IMAGENAME eq Docker Desktop.exe" /NH', {
+      shell: true,
+      timeout: SHELL_TIMEOUTS.tasklist,
+    });
     return out.includes('Docker Desktop.exe');
   } catch (err) {
-    log.debug('Docker Desktop process check failed:', err.message);
+    if (err.code === 'ETIMEDOUT') {
+      log.warn('Docker Desktop process check timed out (tasklist)');
+    } else {
+      log.debug('Docker Desktop process check failed:', err.message);
+    }
     return false;
   }
 }
@@ -115,7 +153,7 @@ async function waitForDesktopProcessStart(
   return false;
 }
 
-async function diagnoseWindowsDocker(_run = runCommand) {
+async function diagnoseWindowsDockerInner(_run = runCommand) {
   const diagnostics = {
     issueCode: 'UNKNOWN',
     message: 'Docker daemon did not become available.',
@@ -135,7 +173,7 @@ async function diagnoseWindowsDocker(_run = runCommand) {
   }
 
   try {
-    const out = await _run('sc query com.docker.service', { shell: true });
+    const out = await _run('sc query com.docker.service', { shell: true, timeout: SHELL_TIMEOUTS.scQuery });
     diagnostics.serviceExists = true;
     diagnostics.serviceRunning = /STATE\s*:\s*\d+\s+RUNNING/i.test(out);
   } catch (_) {
@@ -143,20 +181,23 @@ async function diagnoseWindowsDocker(_run = runCommand) {
   }
 
   try {
-    diagnostics.wslStatus = await _run('wsl --status', { shell: true });
+    diagnostics.wslStatus = await _run('wsl --status', { shell: true, timeout: SHELL_TIMEOUTS.wsl });
   } catch (err) {
     diagnostics.errors.push(`wsl-status: ${err.message}`);
   }
 
   let wslListRaw = null;
   try {
-    wslListRaw = await _run('wsl -l -v', { shell: true });
+    wslListRaw = await _run('wsl -l -v', { shell: true, timeout: SHELL_TIMEOUTS.wsl });
   } catch (err) {
     diagnostics.errors.push(`wsl-list: ${err.message}`);
   }
 
   try {
-    diagnostics.dockerContext = (await _run('docker context show', { shell: true })).trim();
+    diagnostics.dockerContext = (await _run('docker context show', {
+      shell: true,
+      timeout: SHELL_TIMEOUTS.dockerContext,
+    })).trim();
   } catch (err) {
     diagnostics.errors.push(`docker-context: ${err.message}`);
   }
@@ -167,11 +208,11 @@ async function diagnoseWindowsDocker(_run = runCommand) {
   let wslList = (wslListRaw || '').trim();
   if (diagnostics.desktopProcessRunning && wslList && !/no installed distributions/i.test(wslList)) {
     let retries = 0;
-    while (retries < 6 && !/docker-desktop/i.test(wslList)) {
+    while (retries < 3 && !/docker-desktop/i.test(wslList)) {
       await new Promise((r) => setTimeout(r, 1_000));
       retries++;
       try {
-        wslListRaw = await _run('wsl -l -v', { shell: true });
+        wslListRaw = await _run('wsl -l -v', { shell: true, timeout: SHELL_TIMEOUTS.wsl });
         wslList = (wslListRaw || '').trim();
       } catch (err) {
         diagnostics.errors.push(`wsl-list-retry-${retries}: ${err.message}`);
@@ -200,6 +241,36 @@ async function diagnoseWindowsDocker(_run = runCommand) {
   diagnostics.issueCode = 'DAEMON_NOT_READY';
   diagnostics.message = 'Docker Desktop is running but daemon pipe is unavailable.';
   return diagnostics;
+}
+
+const DIAGNOSE_WINDOWS_DOCKER_CEILING_MS = 15_000;
+
+async function diagnoseWindowsDocker(_run = runCommand) {
+  const fallback = {
+    issueCode: 'DAEMON_NOT_READY',
+    message: 'Diagnostic probe timed out; still waiting for Docker engine.',
+    desktopProcessRunning: false,
+    serviceExists: false,
+    serviceRunning: false,
+    wslStatus: null,
+    wslList: null,
+    dockerContext: null,
+    errors: ['diagnose-ceiling-timeout'],
+  };
+  try {
+    return await Promise.race([
+      diagnoseWindowsDockerInner(_run),
+      new Promise((resolve) => {
+        setTimeout(() => {
+          log.warn('[docker-diagnose] timed out after %ds', DIAGNOSE_WINDOWS_DOCKER_CEILING_MS / 1000);
+          resolve({ ...fallback });
+        }, DIAGNOSE_WINDOWS_DOCKER_CEILING_MS);
+      }),
+    ]);
+  } catch (err) {
+    fallback.errors.push(err.message);
+    return fallback;
+  }
 }
 
 async function attemptRecoverWindowsDocker(_run = runCommand, showProgress = null) {
@@ -323,7 +394,7 @@ async function findDockerDesktopExe(_run = runCommand) {
   try {
     const out = await _run(
       'reg query "HKLM\\SOFTWARE\\Docker Inc.\\Docker Desktop" /v "InstallPath"',
-      { shell: true }
+      { shell: true, timeout: SHELL_TIMEOUTS.regQuery }
     );
     const match = out.match(/InstallPath\s+REG_SZ\s+(.+)/);
     if (match) {
@@ -341,7 +412,7 @@ async function findDockerDesktopExe(_run = runCommand) {
   ];
   for (const c of candidates) {
     try {
-      await _run(`if exist "${c}" (exit 0) else (exit 1)`, { shell: true });
+      await _run(`if exist "${c}" (exit 0) else (exit 1)`, { shell: true, timeout: SHELL_TIMEOUTS.ifExist });
       return c;
     } catch (err) {
       log.debug(`Docker candidate path not found: ${c}`, err.message);
@@ -350,7 +421,8 @@ async function findDockerDesktopExe(_run = runCommand) {
 
   // Check if docker CLI is in PATH — means Desktop is installed somewhere
   try {
-    const dockerPath = (await _run('where docker', { shell: true })).trim().split('\n')[0];
+    const dockerPath = (await _run('where docker', { shell: true, timeout: SHELL_TIMEOUTS.whereDocker }))
+      .trim().split('\n')[0];
     // Derive Desktop exe: docker.exe is usually in <install>\resources\bin\docker.exe
     const derived = dockerPath.replace(/\\resources\\bin\\docker\.exe$/i, '\\Docker Desktop.exe');
     if (derived !== dockerPath) return derived;
@@ -361,13 +433,39 @@ async function findDockerDesktopExe(_run = runCommand) {
 
   // Check for Mirantis Docker Engine (Windows service)
   try {
-    await _run('sc query com.docker.service', { shell: true });
+    await _run('sc query com.docker.service', { shell: true, timeout: SHELL_TIMEOUTS.scQuery });
     return 'service';
   } catch (err) {
     log.debug('Mirantis service probe failed:', err.message);
   }
 
   return null;
+}
+
+/** Spawn or shell-start Docker Desktop (shared by normal and post-reboot resume paths). */
+async function launchDockerDesktop(state, deps) {
+  const { spawnDetached, runCommand: _run, showProgress } = deps;
+  if (state.action === 'start-service') {
+    try {
+      await _run('net start com.docker.service', { shell: true, timeout: SHELL_TIMEOUTS.startCmd });
+    } catch (err) {
+      log.warn('Failed to start com.docker.service:', err.message);
+    }
+    return;
+  }
+  if (state.exe) {
+    try {
+      spawnDetached(state.exe);
+    } catch (err) {
+      log.warn('Failed to spawn Docker Desktop executable:', err.message);
+    }
+  } else {
+    try {
+      await _run('start "" "Docker Desktop"', { shell: true, timeout: SHELL_TIMEOUTS.startCmd });
+    } catch (err) {
+      log.warn('Failed to start Docker Desktop via shell fallback:', err.message);
+    }
+  }
 }
 /**
  * Determine what Windows Docker setup action is needed.
@@ -424,6 +522,7 @@ async function ensureDockerWindows(deps) {
     // covered by the FITB spinner. No-op when omitted (tests).
     setForegroundYield = () => {},
     _sleep = (ms) => new Promise((r) => setTimeout(r, ms)),
+    resumeAfterReboot = false,
   } = deps;
 
   const state = await detectWindowsDockerState(isDaemonRunning, _findExe);
@@ -440,74 +539,58 @@ async function ensureDockerWindows(deps) {
   };
 
   if (state.action === 'start' || state.action === 'start-service') {
-    showProgress('Starting Docker Desktop… this can take up to 3 minutes on first launch.');
-    setForegroundYield(true);
-    if (state.action === 'start-service') {
-      try {
-        await _run('net start com.docker.service', { shell: true });
-      } catch (err) {
-        log.warn('Failed to start com.docker.service:', err.message);
-      }
-    } else if (state.exe) {
-      try {
-        spawnDetached(state.exe);
-      } catch (err) {
-        log.warn('Failed to spawn Docker Desktop executable:', err.message);
-      }
+    const phaseStartedAt = Date.now();
+    const engineWaitMs = 360_000;
+    const launchDeps = { spawnDetached, runCommand: _run, showProgress };
+
+    if (resumeAfterReboot) {
+      log.info('[docker-wait] Post-reboot resume — skipping tasklist, polling engine API');
+      showProgress(
+        'Resuming after reboot — starting Docker Desktop. Complete its setup window (terms/sign-in) if shown.'
+      );
     } else {
-      try {
-        await _run('start "" "Docker Desktop"', { shell: true });
-      } catch (err) {
-        log.warn('Failed to start Docker Desktop via shell fallback:', err.message);
+      showProgress('Starting Docker Desktop… this can take several minutes on first launch.');
+    }
+
+    setForegroundYield(true);
+    await launchDockerDesktop(state, launchDeps);
+
+    if (!resumeAfterReboot) {
+      // tasklist can hang on Win11 during boot; each probe is timeboxed (see isDockerDesktopProcessRunning).
+      let desktopRunning = await waitForDesktopStart(
+        isDesktopProcessRunning, 25_000, 1_000, _sleep, showProgress
+      );
+      if (!desktopRunning && state.action === 'start') {
+        try {
+          if (state.exe) {
+            await _run(`start "" /min "${state.exe}"`, { shell: true, timeout: SHELL_TIMEOUTS.startCmd });
+          } else {
+            await _run('start "" /min "Docker Desktop"', { shell: true, timeout: SHELL_TIMEOUTS.startCmd });
+          }
+        } catch (err) {
+          log.warn('Fallback Docker Desktop launch command failed:', err.message);
+        }
+        desktopRunning = await waitForDesktopStart(
+          isDesktopProcessRunning, 15_000, 1_000, _sleep, showProgress
+        );
+        if (!desktopRunning) {
+          log.warn('Docker Desktop process not detected via tasklist — falling through to engine wait');
+          showProgress('Docker Desktop process not confirmed — waiting for Docker engine…');
+        }
       }
     }
 
-    // Allow a grace window for delayed process spawn before declaring launch failure.
-    let desktopRunning = await waitForDesktopStart(isDesktopProcessRunning, 25_000, 1_000, undefined, showProgress);
-    if (!desktopRunning && state.action === 'start') {
-      try {
-        if (state.exe) {
-          await _run(`start "" /min "${state.exe}"`, { shell: true });
-        } else {
-          await _run('start "" /min "Docker Desktop"', { shell: true });
-        }
-      } catch (err) {
-        log.warn('Fallback Docker Desktop launch command failed:', err.message);
-      }
-      desktopRunning = await waitForDesktopStart(isDesktopProcessRunning, 15_000, 1_000, undefined, showProgress);
-      if (!desktopRunning) {
-        // Process name check (tasklist) failed, but Docker may still be running
-        // under a different name or with a permission mismatch. Fall through to
-        // the daemon wait loop — if Docker is genuinely up, the ping succeeds
-        // within seconds. If it's not, the 360s daemon wait surfaces the real error.
-        log.warn('Docker Desktop process not detected via tasklist — falling through to daemon wait');
-        showProgress('Docker Desktop process not confirmed — waiting for daemon…');
-      }
-    }
-    // Docker Desktop process is up; its setup dialog (if any) has had its
-    // shot at the foreground. Reclaim alwaysOnTop on the FITB spinner so
-    // the user can see daemon-ready progress.
     setForegroundYield(false);
 
-    // v0.7.20 #361: extended from 180s → 240s. Fresh-Docker-install on reboot
-    // (RunOnce path) can take longer than 3 min on slower hardware as Docker
-    // Desktop initializes its WSL2 distros for the first time. @bsgdigital
-    // hit this on Win11 — Fox was bailing before Docker finished starting.
-    //
-    // v0.7.30 @bsgdigital (Stan): Docker process is alive and all named pipes
-    // exist, but the daemon pipe isn't answering yet on reboot. The RunOnce
-    // path fires Fox immediately after login while Docker Desktop is still
-    // initializing its WSL distros. Give Docker a 15s head start before the
-    // first probe so we don't waste the first polling slice on a guaranteed miss.
-    showProgress('Docker Desktop is starting up — waiting for it to initialize…');
-    await _sleep(15_000);
-    let remainingMs = 360_000;  // 240s → 360s: covers slower hardware on reboot
+    showProgress('Docker Desktop is starting up — waiting for the engine (API) to respond…');
+    await _sleep(resumeAfterReboot ? 10_000 : 15_000);
+
+    let remainingMs = engineWaitMs;
     let diagnostics = null;
     let wslBackendMissingStreak = 0;
     while (remainingMs > 0) {
-      // Shorter slices re-run diagnosis sooner when the daemon is stuck (WSL / relaunch paths).
       const sliceMs = Math.min(12_000, remainingMs);
-      const cameUpSlice = await _waitForDaemon(sliceMs, showProgress);
+      const cameUpSlice = await _waitForDaemon(sliceMs, showProgress, phaseStartedAt);
       if (cameUpSlice) return _dockerReady('started');
       remainingMs -= sliceMs;
       diagnostics = await diagnoseDocker();
@@ -516,8 +599,11 @@ async function ensureDockerWindows(deps) {
       if (diagnostics.issueCode === 'DOCKER_DESKTOP_NOT_RUNNING' && state.action === 'start') {
         showProgress('Docker Desktop not detected yet — relaunching quietly…');
         try {
-          if (state.exe) await _run(`start "" /min "${state.exe}"`, { shell: true });
-          else await _run('start "" /min "Docker Desktop"', { shell: true });
+          if (state.exe) {
+            await _run(`start "" /min "${state.exe}"`, { shell: true, timeout: SHELL_TIMEOUTS.startCmd });
+          } else {
+            await _run('start "" /min "Docker Desktop"', { shell: true, timeout: SHELL_TIMEOUTS.startCmd });
+          }
         } catch (err) {
           log.warn('Proactive Docker Desktop relaunch failed:', err.message);
         }
@@ -561,7 +647,7 @@ async function ensureDockerWindows(deps) {
       const recovery = await attemptRecover(showProgress);
       if (recovery.attempted && recovery.backendReady) {
         showProgress('WSL repaired — retrying Docker daemon startup…');
-        const recovered = await _waitForDaemon(120_000, showProgress);
+        const recovered = await _waitForDaemon(120_000, showProgress, phaseStartedAt);
         if (recovered) return _dockerReady('started-after-recovery');
       }
       if (await isDaemonRunning()) return _dockerReady('started-after-recovery');
@@ -637,8 +723,13 @@ module.exports = {
   waitForDaemon,
   waitForDesktopProcessStart,
   diagnoseWindowsDocker,
+  diagnoseWindowsDockerInner,
   attemptRecoverWindowsDocker,
   findDockerDesktopExe,
   detectWindowsDockerState,
   ensureDockerWindows,
+  launchDockerDesktop,
+  SHELL_TIMEOUTS,
+  DIAGNOSE_WINDOWS_DOCKER_CEILING_MS,
+  formatElapsedSeconds,
 };

--- a/packages/electron/src/windows-run-once.js
+++ b/packages/electron/src/windows-run-once.js
@@ -28,7 +28,7 @@ async function registerWindowsRunOnceResume(exePath, opts = {}) {
   }
 
   const inner = normalized.replace(/"/g, '');
-  const regData = `"${inner}"`;
+  const regData = `"${inner}" --resume-setup`;
 
   try {
     await run(

--- a/tests/electron/startup.test.js
+++ b/tests/electron/startup.test.js
@@ -11,6 +11,7 @@ const {
   detectWindowsDockerState,
   ensureDockerWindows,
   diagnoseWindowsDocker,
+  DIAGNOSE_WINDOWS_DOCKER_CEILING_MS,
 } = require('../../packages/electron/src/startup');
 
 // ─── waitForDaemon ────────────────────────────────────────────────────────────
@@ -375,5 +376,56 @@ describe('ensureDockerWindows', () => {
     });
     // Should bail FAST when process is gone — no patient retry, no streak built up
     expect(deps.diagnoseDocker).toHaveBeenCalledTimes(1);
+  });
+
+  test('resumeAfterReboot skips tasklist wait and still polls daemon', async () => {
+    const waitForDesktopStart = jest.fn().mockResolvedValue(true);
+    const waitForDaemon = jest.fn().mockResolvedValue(true);
+    const deps = makeDeps({
+      resumeAfterReboot: true,
+      _findExe: jest.fn().mockResolvedValue('C:\\Docker\\Docker Desktop.exe'),
+      waitForDesktopStart,
+      waitForDaemon,
+    });
+    const result = await ensureDockerWindows(deps);
+    expect(result).toEqual({ result: 'started' });
+    expect(waitForDesktopStart).not.toHaveBeenCalled();
+    expect(waitForDaemon).toHaveBeenCalled();
+    expect(deps.spawnDetached).toHaveBeenCalled();
+  });
+});
+
+describe('diagnoseWindowsDocker timeout ceiling', () => {
+  test('returns DAEMON_NOT_READY when inner diagnose exceeds ceiling', async () => {
+    jest.useFakeTimers();
+    try {
+      const hang = () => new Promise(() => {});
+      const pending = diagnoseWindowsDocker(hang);
+      await jest.advanceTimersByTimeAsync(DIAGNOSE_WINDOWS_DOCKER_CEILING_MS);
+      const diagnostics = await pending;
+      expect(diagnostics.issueCode).toBe('DAEMON_NOT_READY');
+      expect(diagnostics.errors).toContain('diagnose-ceiling-timeout');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+describe('waitForDaemon progress copy', () => {
+  test('reports total elapsed from phaseStartedAt', async () => {
+    const isDaemonRunning = jest.fn().mockResolvedValue(false);
+    const showProgress = jest.fn();
+    let calls = 0;
+    const now = () => {
+      calls += 1;
+      if (calls === 1) return 0;
+      if (calls === 2) return 45_000;
+      if (calls === 3) return 46_000;
+      return 121_000;
+    };
+    const sleep = jest.fn().mockResolvedValue(undefined);
+    await waitForDaemon(isDaemonRunning, 120_000, 1000, now, sleep, showProgress, 0);
+    const messages = showProgress.mock.calls.map((c) => c[0]);
+    expect(messages.some((m) => /Waiting for Docker engine… (45s|46s)/.test(m))).toBe(true);
   });
 });

--- a/tests/electron/windows-run-once.test.js
+++ b/tests/electron/windows-run-once.test.js
@@ -34,7 +34,7 @@ describe('registerWindowsRunOnceResume', () => {
       '/t',
       'REG_SZ',
       '/d',
-      '"C:\\Program Files\\Fox\\app.exe"',
+      '"C:\\Program Files\\Fox\\app.exe" --resume-setup',
       '/f',
     ]);
     expect(run.mock.calls[0][2]).toMatchObject({ windowsHide: true });


### PR DESCRIPTION
RunOnce resume (--resume-setup) skips the tasklist loop that could block indefinitely while Docker Desktop shows terms/sign-in. Fox polls the engine API for up to 6 minutes with bounded shell timeouts and diagnose ceiling.

Progress window shows six steps only; detailed status lines go to Diagnostics.