### PR TITLE
fix(ollama): deduplicate picker groups and persist wizard model selection

### DIFF
--- a/packages/fox-overlay/fox_overlay/webui_modules/ollama.py
+++ b/packages/fox-overlay/fox_overlay/webui_modules/ollama.py
@@ -469,6 +469,7 @@ def use_model(model_name: str) -> dict[str, Any]:
     model_cfg = {
         "provider": "ollama",
         "base_url": base_url,
+        "default": name,
         "name": name,
     }
     cfg["model"] = model_cfg

--- a/packages/fox-overlay/fox_overlay/webui_patches/config.py
+++ b/packages/fox-overlay/fox_overlay/webui_patches/config.py
@@ -183,6 +183,28 @@ def _splice_ollama_group(result: dict) -> None:
             "label": "Install Ollama from ollama.com/download",
         }]
 
+    # #389: upstream's alias resolution maps "ollama" → "custom", so it builds
+    # a "Custom" group containing the same Ollama models.  Remove overlapping
+    # model IDs from other groups so each model appears exactly once (under
+    # the OLLAMA heading).
+    ollama_ids = {m["id"] for m in models if not m["id"].startswith("__ollama_hint:")}
+    if ollama_ids:
+        surviving = []
+        for g in groups:
+            if not isinstance(g, dict):
+                surviving.append(g)
+                continue
+            g_models = g.get("models")
+            if not isinstance(g_models, list):
+                surviving.append(g)
+                continue
+            filtered = [m for m in g_models if not (isinstance(m, dict) and m.get("id") in ollama_ids)]
+            if filtered:
+                g["models"] = filtered
+                surviving.append(g)
+            # else: group empty after removing Ollama dupes — drop it
+        groups[:] = surviving
+
     group: dict = {
         "provider": "Ollama",
         "provider_id": "ollama",


### PR DESCRIPTION
## Summary

- **Model doubling (#389 bug 1):** Ollama models appeared in both CUSTOM and OLLAMA groups because upstream's alias resolution maps `"ollama"` → `"custom"`, building a Custom group with the same models Fox splices into the Ollama group. The dedup guard only checked `provider_id == "ollama"`, missing the Custom group. Now compares model ID sets and removes overlapping entries from existing groups before adding the Ollama group.

- **Wizard model not preselected (#437):** `use_model()` wrote `model.name` but upstream's `get_effective_default_model()` reads `model.default`. The API response carried a stale cloud model as `default_model`, so the frontend never preselected the wizard-chosen Ollama model. Added the `"default"` key to the config write.

- **Model ID truncation (#389 bug 2):** Root-caused to upstream's `rsplit(":", 1)` / `lastIndexOf(":")` in `_split_provider_qualified_model`, `_providerFromModelValue`, and `_getOptionProviderId` — they split on the Ollama tag colon instead of the provider colon when models get `@provider:model:tag` format. This is a latent upstream bug that only fires in multi-provider setups (when `_apply_provider_prefix` adds the `@ollama:` prefix). Not patched here — noted on #389 for a future upstream contribution. The primary Ollama-only flow is unaffected because models stay bare (no `@` prefix).

Closes #389 (bug 1), closes #437.

## Test plan

- [ ] Container build succeeds with overlay patches
- [ ] With Ollama running: model picker shows models under OLLAMA only (not duplicated under CUSTOM)
- [ ] Wizard flow → select Ollama model → chat loads with that model preselected
- [ ] Chat with Ollama model sends correct full model ID (e.g. `llama3.1:latest`, not `latest`)
- [ ] Without Ollama: OLLAMA group shows install hint, no other groups affected