### PR TITLE
fix(streaming): refresh substitution #1 anchor for v0.51.145

### DIFF
--- a/packages/fox-overlay/fox_overlay/webui_patches/streaming.py
+++ b/packages/fox-overlay/fox_overlay/webui_patches/streaming.py
@@ -105,15 +105,15 @@ def apply() -> None:
         function_name="_run_agent_streaming",
         substitutions=[
             # ── (1) FITB#9 local-fallback plumbing ──
-            # Insert the local-fallback block right BEFORE "Build kwargs
-            # defensively". Anchor includes 3 lines of context to remain
-            # unique within the function.
+            # Insert the local-fallback block right AFTER upstream sets
+            # _fallback_resolved, BEFORE "Build kwargs defensively".
+            # Anchor: the assignment + blank line + comment header.
             (
-                "                    }\n"
+                "            _fallback_resolved = _fallback_chain or None\n"
                 "\n"
                 "            # Build kwargs defensively — guard newer params so the WebUI\n",
 
-                "                    }\n"
+                "            _fallback_resolved = _fallback_chain or None\n"
                 "\n"
                 "            # FITB local AI fallback (issue #9) — opt-in toggle takes\n"
                 "            # precedence over any config-driven fallback_model.\n"


### PR DESCRIPTION
## Summary

- Streaming patch substitution #1 anchor was stale: expected closing `}` before "Build kwargs defensively" but v0.51.145 has `_fallback_resolved = _fallback_chain or None` there instead
- This caused 3 test failures + 3 errors in CI validate-overlay (runs with hermes-webui on PYTHONPATH)
- Local tests were unaffected because `api` module isn't importable without PYTHONPATH — bootstrap caught ImportError before reaching AssertionError
- Updated anchor to match v0.51.145 actual source

## Test plan

- [x] 165 unit tests pass (with hermes-webui on PYTHONPATH, matching CI)
- [x] `check-overlay-basis.sh` clean
- [x] `webui_patches.apply_all()` succeeds against real upstream source
- [ ] CI: validate-overlay passes
- [ ] CI: Playwright smoke passes