### PR TITLE
fix(ci): Playwright nightly full matrix — test drift + missing chromium

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -150,9 +150,9 @@ jobs:
         working-directory: qa/playwright
         run: pnpm install --frozen-lockfile=false
 
-      - name: Install Playwright browsers (${{ matrix.browser }})
+      - name: Install Playwright browsers (chromium + ${{ matrix.browser }})
         working-directory: qa/playwright
-        run: pnpm exec playwright install --with-deps ${{ matrix.browser }}
+        run: pnpm exec playwright install --with-deps chromium ${{ matrix.browser }}
 
       - name: Pull :stable container
         run: docker pull ghcr.io/fox-in-the-box-ai/cloud:stable

--- a/qa/playwright/tests/smoke/model-picker.spec.ts
+++ b/qa/playwright/tests/smoke/model-picker.spec.ts
@@ -85,7 +85,8 @@ test.describe('Phase 1 — #337 Ollama tile always present (v0.7.18+)', () => {
     const data = await res.json();
 
     const ollamaGroup = data.groups.find(
-      (g: { provider_id?: string }) => g.provider_id === 'ollama',
+      (g: { provider_id?: string; provider?: string }) =>
+        g.provider_id === 'ollama' || (g.provider || '').toLowerCase() === 'ollama',
     );
     expect(ollamaGroup, 'Ollama group missing — see prior test').toBeDefined();
 


### PR DESCRIPTION
## Summary

- **model-picker test**: v0.7.43 changed the Ollama group's `provider_id` from `"ollama"` to `"custom"` (correct routing fix in `config.py:210`). The second test's narrow finder (`provider_id === 'ollama'`) broke; the first test's broader matcher (which also checks `.provider` display name) kept passing. Aligned both tests.
- **full matrix chromium**: the nightly `full` job installs only the per-shard browser (`firefox`, `webkit`) but runs the `smoke` project, which is hardcoded to `Desktop Chrome`. Non-chromium shards failed with "Executable doesn't exist." Now installs chromium alongside the matrix browser.

Both failures have been present on `main` since v0.7.43 (model-picker) and Phase 0 (chromium). Neither is a regression from recent work.

## Test plan

- [ ] PR CI smoke job passes (chromium, same as before)
- [ ] Next nightly full run passes all 12 shards (3 browsers x 4 shards)