### PR TITLE
chore(security): CodeQL, Dependabot, expanded SECURITY.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Default — all PRs require review from a maintainer
+* @bsgdigital
+
+# CI/CD and security-sensitive files
+.github/ @bsgdigital
+SECURITY.md @bsgdigital
+packages/integration/Dockerfile @bsgdigital
+packages/fox-overlay/ @bsgdigital

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: npm
+    directory: /packages/electron
+    schedule:
+      interval: weekly
+    groups:
+      electron-deps:
+        patterns: ["*"]
+
+  - package-ecosystem: npm
+    directory: /qa/playwright
+    schedule:
+      interval: weekly
+    groups:
+      playwright-deps:
+        patterns: ["*"]
+
+  - package-ecosystem: pip
+    directory: /packages/fox-overlay
+    schedule:
+      interval: weekly
+    groups:
+      overlay-deps:
+        patterns: ["*"]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,6 +17,8 @@ jobs:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     permissions:
+      actions: read
+      contents: read
       security-events: write
     strategy:
       fail-fast: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript, python]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -28,7 +28,7 @@ jobs:
         run: docker pull ghcr.io/fox-in-the-box-ai/cloud:stable
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ghcr.io/fox-in-the-box-ai/cloud:stable
           format: sarif
@@ -44,7 +44,7 @@ jobs:
           category: trivy-container
 
       - name: Trivy summary (table)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ghcr.io/fox-in-the-box-ai/cloud:stable
           format: table

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,51 @@
+name: Trivy Container Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 5 * * 1'
+
+concurrency:
+  group: trivy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: Scan container image
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Pull :stable image
+        run: docker pull ghcr.io/fox-in-the-box-ai/cloud:stable
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ghcr.io/fox-in-the-box-ai/cloud:stable
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          exit-code: 0
+
+      - name: Upload Trivy results to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-container
+
+      - name: Trivy summary (table)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ghcr.io/fox-in-the-box-ai/cloud:stable
+          format: table
+          severity: CRITICAL,HIGH

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ packages/electron/node_modules/
 __pycache__/
 *.py[cod]
 CLAUDE.md
+docs/architecture/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey)](https://github.com/fox-in-the-box-ai/fox-in-the-box/releases)
 [![Release](https://img.shields.io/github/v/release/fox-in-the-box-ai/fox-in-the-box)](https://github.com/fox-in-the-box-ai/fox-in-the-box/releases/latest)
+[![Playwright](https://github.com/fox-in-the-box-ai/fox-in-the-box/actions/workflows/playwright.yml/badge.svg)](https://github.com/fox-in-the-box-ai/fox-in-the-box/actions/workflows/playwright.yml)
+[![CodeQL](https://github.com/fox-in-the-box-ai/fox-in-the-box/actions/workflows/codeql.yml/badge.svg)](https://github.com/fox-in-the-box-ai/fox-in-the-box/actions/workflows/codeql.yml)
 
 > A private AI assistant that runs on your computer. No subscriptions, no cloud lock-in, no data leaving your machine without your say-so.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,13 +11,15 @@ Only the latest release receives security fixes.
 
 ## Reporting a vulnerability
 
-Please do not report security vulnerabilities through public GitHub issues.
+**Preferred:** Use [GitHub's private vulnerability reporting](https://github.com/fox-in-the-box-ai/fox-in-the-box/security/advisories/new) to create a private security advisory. This keeps the report, discussion, and fix private until disclosure.
 
-Send a description of the issue to **security@foxinthebox.io**. Include:
+**Alternative:** Send a description to **security@foxinthebox.io**.
 
-- a description of the vulnerability and its potential impact
-- steps to reproduce or proof-of-concept if available
-- any relevant environment details (OS, version, configuration)
+Include:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce or proof-of-concept if available
+- Any relevant environment details (OS, version, configuration)
 
 **What to expect:**
 
@@ -25,17 +27,67 @@ Send a description of the issue to **security@foxinthebox.io**. Include:
 - A status update within 7 days
 - A patch or mitigation within 14 days for confirmed issues
 - Credit in the release notes if you wish (opt-in)
+- A CVE identifier for confirmed vulnerabilities (via GitHub Security Advisory)
 
 We ask that you do not publicly disclose the vulnerability until a fix has been released. We will coordinate the disclosure timeline with you.
 
+## Threat model
+
+Fox in the Box is a self-hosted AI assistant. The primary deployment modes and their trust boundaries:
+
+### Standalone (desktop / single user)
+
+The instance runs on `127.0.0.1:8787`. The trust boundary is the local machine. The LAN is treated as trusted (inherited from upstream Hermes). Network-adjacent attackers on the same LAN can reach the port if the user selects access mode 1 or 3 (`0.0.0.0`).
+
+**Assumed trusted:** The local user, processes on the same machine.
+**Not trusted:** Remote network callers (mitigated by binding to localhost in access mode 2).
+
+### Managed (control plane)
+
+The instance is provisioned by a control plane with authentication enforced via `check_auth` substitution (`FOX_PLANE_AUTH_SECRET`). Upstream session auth is required (managed-mode invariant). The trust boundary shifts to the control plane's auth layer.
+
+**Assumed trusted:** Authenticated control-plane callers (`X-Fox-Auth`), session-bearing browser users.
+**Not trusted:** Unauthenticated callers (rejected by `check_auth` PATH 4).
+
+### Key security properties
+
+| Property | Mechanism |
+|----------|-----------|
+| No credential storage in agent context | API keys in `hermes.env`, sourced by `entrypoint.sh`, never in chat history |
+| Session auth | Upstream Hermes `check_auth` with HMAC-signed session cookies |
+| Control-plane auth | `X-Fox-Auth` shared secret via `hmac.compare_digest` (constant-time) |
+| CSRF protection | Upstream `_check_csrf` for browser callers; managed mode closes the non-browser bypass via the auth invariant |
+| Container isolation | All services run inside a single container; host access only via bind-mounted `/data` volume |
+| Overlay integrity | `validate-overlay.yml` CI gate verifies patch anchors; `check-overlay-basis.sh` detects upstream drift |
+| Image provenance | Digest-pinned images via `versions.toml`; container builds gated by CI |
+
+### Known limitations
+
+- Standalone mode trusts the LAN (upstream Hermes design choice). See `ENTERPRISE_ARCHITECTURE.md` section 0.5 for the ratification question.
+- The shared secret (`FOX_PLANE_AUTH_SECRET`) is symmetric. All components that know it are equally trusted. mTLS upgrade path is documented but not yet implemented.
+- LLM provider API keys are stored as plaintext environment variables in `hermes.env` on the `/data` volume. Access to the volume means access to the keys.
+
 ## Scope
 
-In scope:
-- The Docker container and its bundled components
-- The Electron desktop apps
+**In scope:**
+- The Docker container and its bundled components (Hermes Agent, Hermes WebUI, Fox overlay, Qdrant, Tailscale)
+- The Electron desktop apps (Windows, macOS)
+- The `.deb` bare-metal installer
 - The web-based onboarding wizard and setup flow
+- The fox-overlay Python package (patches, dispatcher, substitutions)
+- CI/CD pipeline security (workflow permissions, signing, artifact integrity)
 
-Out of scope:
+**Out of scope:**
 - Vulnerabilities in upstream dependencies (Hermes Agent, Hermes WebUI, Qdrant, Tailscale) — please report those to their respective maintainers
 - Issues requiring physical access to the host machine
 - Social engineering attacks
+- Denial-of-service against the LLM provider (rate limiting is the provider's responsibility)
+
+## Security CI
+
+| Check | Workflow | Frequency |
+|-------|----------|-----------|
+| CodeQL static analysis | `codeql.yml` | Every PR + weekly |
+| Overlay anchor integrity | `validate-overlay.yml` | Every PR |
+| Upstream drift detection | `upstream-watch.yml` + `upstream-tripwires.yml` | Nightly |
+| Dependency updates | Dependabot | Weekly |

--- a/docs/explorations/do-marketplace.md
+++ b/docs/explorations/do-marketplace.md
@@ -1,0 +1,238 @@
+# DigitalOcean Marketplace — Path Assessment
+
+*Exploration only. No code changes. 2026-06-01.*
+
+---
+
+## 1. Current Distribution Inventory
+
+### 1.1 How Fox packages and provisions today
+
+Fox ships as a **desktop app** (Electron for Windows/macOS) that manages a
+**single Docker container** per user. The container runs the full stack:
+Hermes Agent, Hermes WebUI, Qdrant, mem0, Tailscale, and llama-server.
+
+**Container build pipeline:**
+
+| File | Purpose |
+|------|---------|
+| `packages/integration/Dockerfile` | Multi-stage build: python:3.11-slim base, downloads qdrant + llama-server binaries, COPYs hermes-agent + hermes-webui + fox-overlay, applies patch series, pip installs |
+| `packages/integration/entrypoint.sh` | Container startup: first-run bootstrap, /data directory tree, app symlinks, version migration, Tailscale Serve setup, hands off to supervisord |
+| `packages/integration/supervisord.conf` | Process manager: tailscaled, ts-operator-watchdog, qdrant, hermes-gateway, hermes-webui, llama-server (autostart=false) |
+| `packages/integration/default-configs/` | hermes.yaml (agent config), qdrant.yaml, onboarding.json |
+| `packages/integration/scripts/` | migrate.sh, run-with-env.sh, tailscale-operator-watchdog.sh, dev-init.sh |
+| `.github/workflows/build-container.yml` | Multi-arch build (linux/amd64 + linux/arm64), manifest-list publish to ghcr.io |
+| `.github/workflows/release.yml` | Tag-driven release: SMOKE_LOG gate, builds container + Electron + .deb, creates GitHub Release |
+
+**Desktop provisioning (Electron → Docker):**
+
+| File | Purpose |
+|------|---------|
+| `packages/electron/src/docker-manager.js` (725 lines) | Dockerode wrapper: container create/start/stop/remove, image pull with progress, socket auto-detection, diagnostics |
+| `packages/electron/src/startup-orchestrator.js` (326 lines) | 7-phase startup state machine: check_system → docker_install → docker_start → download_image → start_container → wait_services → connect_network |
+| `packages/electron/src/health-check.js` (133 lines) | Poll GET /health until 200 + `{"status":"ok"}`, configurable timeout/interval, failFastCheck callback |
+| `packages/electron/src/app-urls.js` | Hardcoded `APP_ORIGIN = http://127.0.0.1:8787` |
+
+**Headless install paths (no desktop):**
+
+| File | Purpose |
+|------|---------|
+| `packages/scripts/install.sh` | Non-interactive Linux/macOS installer: installs Docker, pulls image, creates systemd units, supports FOX_ACCESS_MODE=1\|2\|3 |
+| `packages/install-core/install-core.sh` | Shared install logic (Docker + .deb): binary downloads, repo sync, patch application, pip install, supervisord.conf generation |
+| `packages/install-core/preflight.sh` | Bare-metal pre-start: directory bootstrap, config seeding, version migration, Tailscale Serve |
+| `packages/deb/` | .deb packaging: build.sh, control scripts, systemd templates |
+
+### 1.2 What's single-instance-able today vs. desktop-tied
+
+**Already headless-capable (works on a VPS without modification):**
+- The container image (`ghcr.io/fox-in-the-box-ai/cloud:stable`) — runs standalone with `docker run -d -p 8787:8787 -v /data:/data`
+- `install.sh` — non-interactive, supports `FOX_ACCESS_MODE=1` (bind 0.0.0.0)
+- `install-core.sh` + `preflight.sh` — bare-metal path, systemd units
+- All config injection via env vars in `hermes.env`
+- `/data` volume mount for persistence
+
+**Tied to desktop host (would not ship to Marketplace):**
+- `packages/electron/` (entire directory) — Windows/macOS desktop wrapper
+- `docker-manager.js`, `startup-orchestrator.js` — Electron-specific orchestration
+- `app-urls.js` — hardcoded `127.0.0.1:8787`
+- `electron-builder.yml`, signing configs, NSIS installer
+
+**Needs adaptation for public-network VPS:**
+- Auth: standalone mode trusts the LAN (§0.5 of ENTERPRISE_ARCHITECTURE.md). On a public DO Droplet, port 8787 is internet-exposed. Upstream Hermes password auth (`HERMES_WEBUI_PASSWORD`) is the only gate — it works but was designed for trusted networks.
+- First-boot config: onboarding wizard runs in the browser at `:8787/setup`. On a Droplet, the user must reach this page over the internet to complete setup. This works if the port is open, but there's no HTTPS by default.
+- Tailscale: optional, works as-is. Useful for private access without exposing 8787.
+
+### 1.3 File count
+
+| Category | Files | Headless-ready |
+|----------|-------|---------------|
+| Container build + runtime | 12 | 12 |
+| Desktop app (Electron) | 18 | 0 |
+| Install scripts (headless) | 10 | 10 |
+| CI/CD workflows | 10 | N/A |
+| Config/versioning | 4 | 4 |
+| **Total** | **54** | **26** |
+
+---
+
+## 2. DO Marketplace Vendor Requirements
+
+### 2.1 Listing types
+
+| Type | Format | Monetizable | Fit for Fox |
+|------|--------|-------------|-------------|
+| **Droplet 1-Click** | Packer-built snapshot (Ubuntu LTS) | No (infra billing only) | High — all AI tools on DO use this |
+| **Kubernetes 1-Click** | Helm chart + deploy/upgrade/uninstall scripts | No | Medium — Fox isn't K8s-native yet |
+| **License Add-On** | Attached to Droplet 1-Click | Yes (75/25 rev share) | High — monetization path |
+| **SaaS Add-On** | External SaaS, OIDC SSO | Yes (75/25 rev share) | Low — Fox is self-hosted, not SaaS |
+| **Blueprint** | Terraform HCL | No | Low — single Droplet is simpler |
+| **1-Click Model** | GPU Droplet snapshot | No | Low — Fox isn't a model server |
+
+### 2.2 Droplet 1-Click build process
+
+1. **Packer template** builds on DO builder plugin (v1.4.1+)
+2. **Base image**: Ubuntu 24.04 LTS (recommended)
+3. **Provisioning scripts**: install Docker, pull Fox image, configure systemd, write first-boot scripts
+4. **First-boot scripts**: placed in `/var/lib/cloud/scripts/per-instance/` — run once via cloud-init on Droplet creation. Generate random admin password, configure UFW, write MOTD.
+5. **`img_check.sh` validation** (mandatory): OS check, cloud-init installed, firewall active, no root password/SSH keys, bash history cleared, logs cleared, no DO agent present. Exit 0 = pass, 2 = fail (blocks submission).
+6. **Cleanup**: security updates, delete history/keys, enable UFW
+
+### 2.3 Security/hardening checklist
+
+| Requirement | Fox status |
+|-------------|-----------|
+| UFW firewall enabled | Must add: open SSH (22) + Fox (8787) only |
+| No root password | Must clear during image build |
+| No SSH keys in image | Must clear during image build |
+| cloud-init installed | Included in DO base images |
+| Security updates applied | Must run during image build |
+| Logs cleared | Must clear during image build |
+| No DO agent in snapshot | Must remove during image build |
+
+### 2.4 Monetization mechanics
+
+- **License Add-On**: vendor attaches license tiers (Free, Pro, Enterprise) to their Droplet 1-Click app in the Vendor Portal. Customer selects tier at Droplet creation. License injected into Droplet.
+- **Revenue share**: vendor receives **75%** of net collected add-on revenue. DO retains 25%.
+- **Payment**: within 60 days after month-end. Wire or ACH.
+- **Pricing changes**: 90 days advance notice required.
+- **Tax**: vendor responsible. W-9 (US) or W8-BEN-E (non-US) required.
+
+### 2.5 Existing comparable listings
+
+| App | Type | Notes |
+|-----|------|-------|
+| **Open WebUI** | Droplet 1-Click | Listed at `marketplace.digitalocean.com/apps/open-webui` |
+| **Ollama with Open WebUI** | Droplet 1-Click | Bundle listing |
+| **OpenClaw** | Droplet 1-Click | Personal AI assistant, WhatsApp/Telegram |
+| **n8n** | Droplet 1-Click | Workflow automation with AI |
+| **Hermes Agent** | **Not listed** | Does not exist on DO Marketplace |
+
+**Pattern**: all self-hosted AI tools use Droplet 1-Click. None use K8s 1-Click or SaaS Add-On.
+
+### 2.6 Vendor onboarding
+
+- Portal: `cloud.digitalocean.com/vendorportal`
+- Apply: `marketplace.digitalocean.com/vendors`
+- Contact: `one-clicks-team@digitalocean.com`
+- Legal: accept Marketplace Vendor Terms, provide tax forms, grant trademark license for promotion
+- Vendor API: `PATCH /api/v1/vendor-portal/apps/<id>` for CI/CD image updates
+
+**Sources:**
+- https://github.com/digitalocean/marketplace-partners
+- https://github.com/digitalocean/droplet-1-clicks
+- https://github.com/digitalocean/droplet-1-clicks/blob/master/DEVELOPER-GUIDE.md
+- https://github.com/digitalocean/marketplace-kubernetes
+- https://marketplace.digitalocean.com/vendors/getting-started-as-a-digitalocean-marketplace-vendor
+- https://www.digitalocean.com/legal/marketplace-vendor-terms
+- https://www.digitalocean.com/blog/introducing-software-license-subscriptions-on-digitalocean-marketplace
+
+---
+
+## 3. Gap Analysis
+
+### 3.1 Droplet 1-Click App
+
+**What Fox needs to add/change:**
+
+| Gap | Effort | Description |
+|-----|--------|-------------|
+| Packer template | S (1 day) | `packer/do-marketplace.pkr.hcl` — Ubuntu 24.04, install Docker, pull `:stable`, install systemd units, configure UFW, write first-boot script |
+| First-boot script | S (1 day) | `/var/lib/cloud/scripts/per-instance/001_fox_setup` — generate random `HERMES_WEBUI_PASSWORD`, write to `/data/config/hermes.env`, start Fox, print credentials in MOTD |
+| UFW configuration | XS (hours) | Open ports 22 (SSH) + 8787 (Fox). Close everything else. |
+| MOTD / getting-started | XS (hours) | `/etc/update-motd.d/99-fox` — print Fox URL + generated password on SSH login |
+| img_check.sh compliance | XS (hours) | Cleanup script: clear history, keys, logs, remove DO agent |
+| Vendor Portal listing | S (1 day) | App name, description, logo, getting-started doc, support URL, min Droplet size |
+| **Trusted-LAN assumption** | **BLOCKER** | Port 8787 on a public Droplet is internet-exposed. Upstream `HERMES_WEBUI_PASSWORD` provides password-based auth, which works but was not hardened for public internet. Need: (a) generate strong random password at first boot, (b) force password setup before any other access, (c) consider Caddy/nginx reverse proxy with auto-TLS. |
+
+**Total effort**: ~3-4 days for a basic listing (no TLS). ~1 week with a Caddy reverse proxy for HTTPS.
+
+### 3.2 Kubernetes 1-Click App
+
+**What Fox needs to add/change:**
+
+| Gap | Effort | Description |
+|-----|--------|-------------|
+| Helm chart | M (3-5 days) | Deployment, PVC, Service, ConfigMap, Ingress. Fox is a single container so the chart is straightforward, but no Helm chart exists today. |
+| deploy/upgrade/uninstall scripts | S (1 day) | Wrapper scripts per DO K8s 1-Click convention |
+| Persistent storage | S (1 day) | PVC for `/data` volume |
+| Health probes | XS | Already has `/health` endpoint |
+| Ingress + TLS | M (2-3 days) | Need cert-manager + Ingress for public access |
+
+**Total effort**: ~1-2 weeks. More work than Droplet 1-Click, and no K8s AI tools exist on DO Marketplace yet — unproven category.
+
+### 3.3 License Add-On (monetization)
+
+**What Fox needs to add/change (on top of Droplet 1-Click):**
+
+| Gap | Effort | Description |
+|-----|--------|-------------|
+| License tier definition | S (1 day) | Free (single user, local models only) vs. Pro (cloud providers, Tailscale) vs. Enterprise (control plane) — ties to ADR-0001 |
+| License validation | M (2-3 days) | First-boot script reads injected license, writes capability flags. Fox's existing `CapabilityFlags` system (INSTANCE_CONTRACT.md §4.4) is the enforcement mechanism. |
+| License-gated features | M (2-3 days) | Map license tiers to capability toggles. The `.fox-removals` + `CapabilityFlags` machinery already supports this. |
+| Vendor Portal config | S (1 day) | Define tiers, pricing, attach to 1-Click listing |
+
+**Total effort**: ~1-2 weeks on top of the Droplet 1-Click work. Requires ADR-0001 (licensing model) to be resolved first.
+
+---
+
+## 4. Decision Matrix
+
+| | Droplet 1-Click | K8s 1-Click | License Add-On |
+|---|---|---|---|
+| **Effort** | 3-4 days (no TLS) / 1 week (with TLS) | 1-2 weeks | 1-2 weeks (on top of Droplet) |
+| **Fit with control-plane thesis** | High — single-instance managed Fox, same as demo tier | Medium — K8s plugin exists in BACKLOG (PLUG-03) but not built | High — license tiers map to capability flags, forward-compatible with enterprise |
+| **Monetization** | None (DO bills infra only) | None | Yes (75/25 rev share) |
+| **Market precedent** | All AI tools use this | No AI tools on DO K8s | Plesk is the only vendor so far |
+| **Blocked on** | Trusted-LAN assumption (§0.5) | Helm chart + K8s plugin | ADR-0001 (licensing model) |
+| **Competitive** | Open WebUI already listed; Fox differentiates on memory + overlay + Tailscale | No competition | Novel — no AI assistant has license-gated 1-Click |
+
+### 4.1 Recommended path
+
+**Phase 1: Droplet 1-Click (free listing)**
+- Smallest viable milestone: Packer template + first-boot script + UFW + MOTD
+- Ship as "Fox in the Box" alongside the existing Open WebUI listing
+- Differentiation: persistent memory (mem0), local AI fallback (Ollama/llama-server), Tailscale remote access, Fox overlay (branding, silent failover, onboarding wizard) — all in one 1-Click
+- **Must resolve**: generate strong random password at first boot, force setup before access. Caddy reverse proxy with auto-TLS (Let's Encrypt) strongly recommended for public Droplets.
+- **Timeline**: 1 week to submission, ~1 week for DO review
+
+**Phase 2: License Add-On (monetization)**
+- Attach license tiers to the 1-Click listing after ADR-0001 resolves
+- Free tier: single user, local models, community support
+- Pro tier: cloud providers, Tailscale, priority support
+- Enterprise tier: control plane features (Phase 3/5 architecture)
+- **Blocked on**: ADR-0001 (licensing model)
+
+**Phase 3: K8s 1-Click (if demand)**
+- Only pursue if customers request K8s deployment
+- Depends on PLUG-03 (K8s deployment plugin) from the Phase 3 backlog
+
+### 4.2 Open questions / blockers
+
+| # | Question | Severity | Owner |
+|---|----------|----------|-------|
+| 1 | **Trusted-LAN assumption on public internet** — Port 8787 exposed on a Droplet. `HERMES_WEBUI_PASSWORD` auth works but was designed for LAN. Is password auth sufficient for v1, or must we ship with a TLS reverse proxy? | **BLOCKER** | Founders |
+| 2 | **ADR-0001 (licensing model)** — License Add-On tiers require knowing the open/commercial boundary. Droplet 1-Click (free) can ship without this. | Blocks Phase 2 | Founders |
+| 3 | **Hermes Agent not on DO Marketplace** — despite the user's assumption, it's NOT listed. Open WebUI IS listed. Fox would be adjacent to Open WebUI, not Hermes. | Informational | — |
+| 4 | **Vendor Portal access** — need to apply at `marketplace.digitalocean.com/vendors` and wait for credentials. Lead time unknown. | Process | Founders |
+| 5 | **Image update CI/CD** — DO Vendor API supports programmatic snapshot updates. Should integrate with `build-container.yml` so `:stable` bumps auto-update the Marketplace listing. | Phase 2 | Engineering |
+| 6 | **Droplet size recommendation** — Fox runs mem0 + Qdrant + llama-server. Minimum viable: 2 GB RAM / 1 vCPU for cloud-only providers. With local models (llama-server): 8 GB RAM / 4 vCPU. Need benchmarking. | TO RATIFY | Engineering |

--- a/docs/specs/do-droplet-1click.md
+++ b/docs/specs/do-droplet-1click.md
@@ -1,0 +1,414 @@
+# DO Droplet 1-Click — Spec (Free Listing)
+
+*Decision-ready. No monetization — decoupled from ADR-0001. 2026-06-01.*
+
+*Builds on: `docs/explorations/do-marketplace.md`*
+
+---
+
+## 0. Scope
+
+Ship Fox in the Box as a free DigitalOcean Droplet 1-Click App. A user clicks
+"Create Droplet," picks Fox, and gets a running instance with TLS and
+password auth — no terminal required beyond the initial SSH to retrieve
+the generated password.
+
+**Not in scope:** License Add-On (requires ADR-0001), K8s 1-Click (requires
+Helm chart + PLUG-03), Tailscale integration in the Marketplace image (users
+who want Tailscale can configure it after deploy — it works as-is).
+
+---
+
+## 1. Verified Repo Inventory
+
+### 1.1 Container build + launch (12 files, all headless-capable)
+
+| # | File | Purpose | Headless? |
+|---|------|---------|-----------|
+| 1 | `packages/integration/Dockerfile` | Multi-stage build: python:3.11-slim, qdrant, llama-server, hermes-agent+webui, fox-overlay, supervisord. `EXPOSE 8787 6333` (line 164). | Yes |
+| 2 | `packages/integration/entrypoint.sh` (296 lines) | First-run bootstrap: /data tree, app symlinks, version migration, loads `hermes.env` (line 161–167), Tailscale Serve (line 220–280), exec supervisord. Does NOT set or generate `HERMES_WEBUI_PASSWORD`. | Yes |
+| 3 | `packages/integration/supervisord.conf` | 6 services: tailscaled (:10), ts-operator-watchdog (:15), qdrant (:20), hermes-gateway (:30), hermes-webui (:40), llama-server (:50, autostart=false). WebUI env: `HERMES_WEBUI_HOST="0.0.0.0"` (line 142). | Yes |
+| 4 | `packages/integration/default-configs/hermes.yaml` | Agent config: `server.host: 0.0.0.0`, `server.port: 8787` (lines 9–11). | Yes |
+| 5 | `packages/integration/default-configs/qdrant.yaml` | `host: 0.0.0.0`, `http_port: 6333`, `grpc_port: 6334` (lines 5–8). Internal only — not host-mapped. | Yes |
+| 6 | `packages/integration/default-configs/onboarding.json` | First-run marker `{"completed": false}`. | Yes |
+| 7 | `packages/integration/scripts/migrate.sh` | Version migration helper. | Yes |
+| 8 | `packages/integration/scripts/run-with-env.sh` | Env loader for supervised processes. | Yes |
+| 9 | `packages/integration/scripts/tailscale-operator-watchdog.sh` | Grants foxinthebox Tailscale operator access. | Yes |
+| 10 | `packages/integration/scripts/dev-init.sh` | Dev-mode helper. | Yes |
+| 11 | `.github/workflows/build-container.yml` | Multi-arch build (amd64 + arm64), manifest-list push to `ghcr.io/fox-in-the-box-ai/cloud`. | CI |
+| 12 | `.github/workflows/release.yml` | Tag-driven: SMOKE_LOG gate, builds container + Electron + .deb, creates GitHub Release. | CI |
+
+### 1.2 HERMES_WEBUI_PASSWORD path (verified, 6 files)
+
+| # | File | Line(s) | Behavior |
+|---|------|---------|----------|
+| 1 | `forks/hermes-webui/api/auth.py` | 292 | `os.getenv("HERMES_WEBUI_PASSWORD")` — env var checked first, overrides settings.json |
+| 2 | `forks/hermes-webui/api/auth.py` | 303–305 | `is_password_auth_enabled()` — returns True if `get_password_hash() is not None` |
+| 3 | `forks/hermes-webui/api/auth.py` | 353–355 | `is_auth_enabled()` — returns `is_password_auth_enabled() or are_passkeys_enabled()` |
+| 4 | `forks/hermes-webui/server.py` | 529–539 | Warning on startup if binding to non-loopback without password |
+| 5 | `forks/hermes-webui/api/routes.py` | 6439–6451 | Settings UI locked (409) when env var is set |
+| 6 | `forks/hermes-webui/.env.docker.example` | 48 | `# HERMES_WEBUI_PASSWORD=change-me-to-something-strong` — commented example only |
+
+**Confirmed: no default value shipped anywhere.** Password is unset unless explicitly
+provided. When unset, `is_auth_enabled()` returns False and auth is bypassed entirely.
+On a public Droplet this means open access — the blocker the exploration identified.
+
+### 1.3 Port binding (verified)
+
+**Only port 8787 reaches the host.** All other services are container-internal.
+
+| Service | Container bind | Host exposure | Cite |
+|---------|---------------|---------------|------|
+| Hermes WebUI | `0.0.0.0:8787` | Mode-dependent: `127.0.0.1:8787` (mode 2) or `0.0.0.0:8787` (modes 1/3) | `docker-manager.js:407–414` |
+| Qdrant HTTP | `0.0.0.0:6333` | NOT mapped to host | `qdrant.yaml:5–8`, Dockerfile EXPOSE only |
+| Qdrant gRPC | `0.0.0.0:6334` | NOT mapped to host | `qdrant.yaml:5–8` |
+| llama-server | `127.0.0.1:8643` | NOT mapped to host, autostart=false | `supervisord.conf:162–174` |
+| supervisord | `/run/fitb/supervisor.sock` (AF_UNIX) | NOT accessible from host | `supervisord.conf:10–16` |
+| Tailscale | WireGuard tunnel | External (tailnet) if configured | `entrypoint.sh:269` |
+
+### 1.4 X-Fox-Auth gate + managed-mode invariant
+
+**Not applicable for this listing.** The `X-Fox-Auth` substitution
+(`ENTERPRISE_ARCHITECTURE.md` §5.3) and the managed-mode boot invariant
+(`FOX_PLANE_AUTH_SECRET` requires upstream auth, §5.4) are control-plane
+features for managed deployments. A standalone DO Droplet runs without
+`FOX_PLANE_AUTH_SECRET` — the substitution is a no-op, the invariant is
+not triggered. The auth layer for the Marketplace listing is upstream's
+`HERMES_WEBUI_PASSWORD` enforced via `check_auth()` at `auth.py:489–540`.
+
+### 1.5 Desktop-host assumptions that leak into provisioning
+
+| Assumption | Where | Headless replacement |
+|------------|-------|---------------------|
+| Access mode selection dialog | `docker-manager.js:370–394` | Hardcode mode 1 (`0.0.0.0`) — Caddy sits in front |
+| `APP_ORIGIN = http://127.0.0.1:8787` | `app-urls.js` | Not used — Electron-only file, not in container |
+| Docker socket auto-detection | `docker-manager.js:125–130` | Not used — container runs via `docker run`, not Dockerode |
+| Docker Desktop install prompts | `startup-orchestrator.js:steps 1–3` | Not used — Docker pre-installed in Packer image |
+| Workspace at `$HOME/Fox in the Box` | `preflight.sh:77` | Keep — foxinthebox user's home works for this |
+| Tailscale browser auth | `entrypoint.sh:252–278` | Not applicable — Tailscale is opt-in post-deploy |
+
+**Count: 6 assumptions.** 4 are Electron-only (irrelevant to container path).
+2 are in the container/install path and either work as-is or are bypassed.
+**No code changes needed in the container image itself.**
+
+---
+
+## 2. Image Build
+
+### 2.1 Build tooling
+
+DO requires Packer with the `digitalocean` builder plugin (v1.4.1+).
+
+**Source:** https://github.com/digitalocean/marketplace-partners (official
+image-build repo), https://github.com/digitalocean/droplet-1-clicks/blob/master/DEVELOPER-GUIDE.md
+
+```
+packer/
+├── do-marketplace.pkr.hcl          # Packer template
+├── scripts/
+│   ├── 010-docker.sh               # Install Docker CE
+│   ├── 020-fox.sh                   # Pull Fox image, write systemd unit + first-boot script
+│   ├── 030-caddy.sh                 # Install Caddy reverse proxy
+│   ├── 040-ufw.sh                   # Configure firewall: allow 22, 80, 443 only
+│   └── 900-cleanup.sh              # DO img_check.sh compliance: clear history/keys/logs
+├── files/
+│   ├── etc/update-motd.d/99-fox    # Getting-started MOTD
+│   └── var/lib/cloud/scripts/per-instance/001-fox-firstboot  # First-boot hardening
+└── img_check.sh                    # DO's validation script (copied from marketplace-partners)
+```
+
+### 2.2 What goes in the snapshot vs. configured at first boot
+
+**In the snapshot (immutable, baked at Packer build time):**
+- Ubuntu 24.04 LTS base
+- Docker CE installed and enabled
+- Fox `:stable` image pre-pulled (`ghcr.io/fox-in-the-box-ai/cloud:stable`)
+- Caddy installed (apt repo)
+- UFW configured: allow 22/tcp, 80/tcp, 443/tcp — deny everything else
+- Systemd unit: `foxinthebox.service` (manages the Docker container)
+- Systemd unit: `caddy.service` (reverse proxy)
+- First-boot script at `/var/lib/cloud/scripts/per-instance/001-fox-firstboot`
+- MOTD at `/etc/update-motd.d/99-fox`
+- DO compliance: no root password, no SSH keys, history cleared, logs cleared
+
+**At first boot (per-instance, dynamic):**
+- Generate 32-char random password → write to `/data/config/hermes.env` as `HERMES_WEBUI_PASSWORD`
+- Write Caddy config: reverse proxy `https://<droplet-ip>:443` → `http://127.0.0.1:8787`
+- Start Fox container (bound to `127.0.0.1:8787` — NOT 0.0.0.0)
+- Verify `/health` returns 200
+- Write password to `/root/.fox-credentials` (readable only by root)
+- Update MOTD with the generated password
+
+### 2.3 Reproducible build
+
+- No secrets baked into the snapshot. Password generated per-instance at first boot.
+- No credentials in the Packer template. `DIGITALOCEAN_API_TOKEN` is a build-time env var, never in the image.
+- Fox image referenced by digest pin (`:stable` resolves to a content-addressed digest via `versions.toml`).
+- Packer build is deterministic: same template → same image (minus timestamps).
+
+---
+
+## 3. First-Boot Hardening
+
+### 3.1 Password generation
+
+```bash
+#!/bin/bash
+# /var/lib/cloud/scripts/per-instance/001-fox-firstboot
+# Runs once per Droplet via cloud-init. Generates admin password,
+# configures Caddy TLS, starts Fox.
+set -euo pipefail
+
+DATA_DIR="/mnt/foxdata"
+HERMES_ENV="$DATA_DIR/config/hermes.env"
+
+# ── 1. Generate strong random password ──────────────────────────────────────
+FOX_PASSWORD=$(openssl rand -base64 24 | tr -d '/+=' | head -c 32)
+if [ -z "$FOX_PASSWORD" ] || [ ${#FOX_PASSWORD} -lt 24 ]; then
+    echo "FATAL: password generation failed — refusing to start" >&2
+    exit 1  # fail closed
+fi
+
+# ── 2. Write to hermes.env ──────────────────────────────────────────────────
+mkdir -p "$DATA_DIR/config"
+echo "HERMES_WEBUI_PASSWORD=$FOX_PASSWORD" > "$HERMES_ENV"
+chmod 600 "$HERMES_ENV"
+
+# ── 3. Configure Caddy (auto-TLS via Let's Encrypt) ────────────────────────
+DROPLET_IP=$(curl -sf http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address)
+cat > /etc/caddy/Caddyfile << EOF
+$DROPLET_IP {
+    reverse_proxy 127.0.0.1:8787
+}
+EOF
+systemctl restart caddy
+
+# ── 4. Start Fox container (localhost-only — Caddy in front) ────────────────
+docker run -d --name fox-in-the-box \
+    --restart unless-stopped \
+    --cap-add=NET_ADMIN --device /dev/net/tun \
+    --sysctl net.ipv4.ip_forward=1 \
+    -p 127.0.0.1:8787:8787 \
+    -v "$DATA_DIR":/data \
+    --env-file "$HERMES_ENV" \
+    ghcr.io/fox-in-the-box-ai/cloud:stable
+
+# ── 5. Wait for health ─────────────────────────────────────────────────────
+for i in $(seq 1 60); do
+    if curl -sf http://127.0.0.1:8787/health > /dev/null; then
+        break
+    fi
+    sleep 2
+done
+
+# ── 6. Surface credentials ─────────────────────────────────────────────────
+cat > /root/.fox-credentials << EOF
+Fox in the Box — Admin Credentials
+URL:      https://$DROPLET_IP
+Password: $FOX_PASSWORD
+EOF
+chmod 600 /root/.fox-credentials
+```
+
+**Convention source:** DO recommends first-boot scripts in
+`/var/lib/cloud/scripts/per-instance/` (cloud-init) and credentials surfaced
+via MOTD on first SSH login.
+Source: https://github.com/digitalocean/droplet-1-clicks/blob/master/DEVELOPER-GUIDE.md
+
+### 3.2 Caddy reverse proxy + automatic TLS
+
+Caddy provides automatic HTTPS via Let's Encrypt. No manual cert management.
+
+**Config:**
+```
+$DROPLET_IP {
+    reverse_proxy 127.0.0.1:8787
+}
+```
+
+**Note on IP-based TLS:** Let's Encrypt issues certs for domain names, not
+bare IPs. For IP-only access, Caddy will use a self-signed cert (browser
+warning). For proper TLS, the user must point a domain at the Droplet IP and
+update the Caddyfile. The MOTD should document this.
+
+**Alternative:** ZeroSSL supports IP certificates. Caddy can use ZeroSSL as
+an ACME provider. This is a configuration option, not a code change.
+TO RATIFY: ship with self-signed (IP) or require domain setup.
+
+### 3.3 Boot-time invariant
+
+**In the Marketplace context, the invariant is simpler than the control-plane
+invariant (§5.4):** Fox MUST NOT start with auth disabled on a public Droplet.
+
+The first-boot script enforces this by:
+1. Generating the password BEFORE starting the container.
+2. Passing it via `--env-file` so `HERMES_WEBUI_PASSWORD` is set in the
+   container's environment from the first process start.
+3. `is_auth_enabled()` (`auth.py:353–355`) returns True because
+   `is_password_auth_enabled()` returns True (env var is set).
+4. `server.py:529–539` does NOT print the "no password" warning.
+
+**Fail-closed:** If password generation fails (`openssl rand` returns empty),
+the script exits 1 and the container never starts. The user SSHs in, sees the
+MOTD explaining the failure, and can re-run or debug.
+
+### 3.4 Attack surface of a public Droplet
+
+| Surface | Exposure | Mitigation | Status |
+|---------|----------|------------|--------|
+| **Port 22 (SSH)** | Open (UFW allow) | DO SSH keys injected at Droplet creation. No root password in image. | Covered by img_check.sh |
+| **Port 80 (HTTP)** | Open (UFW allow) | Caddy: redirects HTTP → HTTPS | To build |
+| **Port 443 (HTTPS)** | Open (UFW allow) | Caddy: TLS termination → reverse proxy to 127.0.0.1:8787 | To build |
+| **Port 8787 (Fox WebUI)** | CLOSED (UFW deny) | Not directly accessible. Caddy proxies to it via localhost. | To build |
+| **Port 6333 (Qdrant)** | Container-internal only | Not host-mapped. Not in UFW. | Already covered |
+| **Port 6334 (Qdrant gRPC)** | Container-internal only | Not host-mapped. Not in UFW. | Already covered |
+| **Port 8643 (llama-server)** | Container-internal, localhost-only, autostart=false | Triple isolation: not host-mapped, binds 127.0.0.1, disabled by default. | Already covered |
+| **Tailscale WireGuard** | Disabled by default | User opts in post-deploy. Not configured in Marketplace image. | Already covered |
+| **`/data` volume** | Filesystem (Droplet disk) | Owned by foxinthebox user. `hermes.env` is chmod 600. | To build |
+| **`/health` endpoint** | Unauthenticated (by design) | Returns `{"status":"ok"}` only. No secrets, no recon value. | Already covered |
+| **`/readyz` endpoint** | Unauthenticated | Subsystem status. No secrets. | Already covered |
+| **`/version`, `/capabilities`** | Behind `check_auth` in managed mode, open in standalone | Standalone (Marketplace) mode: open. Leaks version/overlay info. Acceptable — same as upstream Hermes. | Already covered |
+| **Onboarding wizard (`/setup`)** | Behind `check_auth` (password required) | User must authenticate before configuring API keys. | Already covered |
+| **CSRF bypass (non-browser callers)** | `_check_csrf` passes non-browser callers (`routes.py:1317–1324`) | With `HERMES_WEBUI_PASSWORD` set, `check_auth` requires a valid session cookie regardless of CSRF. Non-browser callers without a session are rejected at `auth.py:489–540` (PATH 4: 401/302). | Already covered |
+
+**Ports open to the internet: 3** (22, 80, 443). Port 8787 is localhost-only
+behind Caddy. All other services are container-internal.
+
+---
+
+## 4. Headless Config
+
+### 4.1 Desktop assumptions replaced
+
+| # | Desktop assumption | File | Headless replacement |
+|---|-------------------|------|---------------------|
+| 1 | User picks access mode via dialog | `docker-manager.js:370–394` | Hardcoded: `127.0.0.1:8787` (Caddy in front). No dialog. |
+| 2 | Electron manages container lifecycle | `docker-manager.js`, `startup-orchestrator.js` | Systemd `foxinthebox.service` manages the container via `docker run`. |
+| 3 | Health check polls from Electron | `health-check.js` | First-boot script polls `/health` before writing credentials. Caddy provides ongoing upstream health via reverse proxy. |
+| 4 | `APP_ORIGIN = http://127.0.0.1:8787` | `app-urls.js` | Not used — this is an Electron-only file. |
+| 5 | Docker Desktop install/start | `startup-orchestrator.js:steps 1–3` | Docker CE pre-installed in Packer image. |
+| 6 | Tailscale auth via browser popup | `entrypoint.sh:252–278` | Disabled by default. User configures post-deploy if desired. |
+
+**Container image: unchanged.** The same `ghcr.io/fox-in-the-box-ai/cloud:stable`
+image runs on a Droplet as on a desktop. The Packer image wraps it with systemd,
+Caddy, UFW, and the first-boot script. No Fox code changes.
+
+### 4.2 Data persistence
+
+- `/mnt/foxdata` on the Droplet maps to `/data` in the container.
+- Survives container restart and image upgrade (`docker pull` + recreate).
+- DO Block Storage can be attached for additional space (user's responsibility).
+- `hermes.env`, `config.yaml`, `settings.json`, conversation history, mem0 data,
+  Qdrant vectors all persist in `/mnt/foxdata`.
+
+---
+
+## 5. DO Submission Checklist
+
+### 5.1 img_check.sh requirements (12 checks)
+
+Source: https://github.com/digitalocean/marketplace-partners/blob/master/scripts/99-img-check.sh
+
+| # | Requirement | Status | How |
+|---|-------------|--------|-----|
+| 1 | Supported OS | To build | Ubuntu 24.04 LTS |
+| 2 | cloud-init installed | Done | Pre-installed in DO base image |
+| 3 | Firewall active (UFW) | To build | `040-ufw.sh`: allow 22, 80, 443; deny all |
+| 4 | Security updates applied | To build | `900-cleanup.sh`: `apt-get upgrade` |
+| 5 | No root password | To build | `900-cleanup.sh`: `passwd -d root` |
+| 6 | No root SSH authorized_keys | To build | `900-cleanup.sh`: `truncate -s 0 /root/.ssh/authorized_keys` |
+| 7 | No root SSH private keys | To build | `900-cleanup.sh`: `rm -f /root/.ssh/id_*` |
+| 8 | Root bash history cleared | To build | `900-cleanup.sh`: `truncate -s 0 /root/.bash_history` |
+| 9 | Non-system users clean | To build | foxinthebox user: no password, no SSH keys, history cleared |
+| 10 | Log files cleared | To build | `900-cleanup.sh`: `find /var/log -type f -exec truncate -s 0 {} \;` |
+| 11 | DO agent removed | To build | `900-cleanup.sh`: `rm -rf /opt/digitalocean` |
+| 12 | GPU support (optional) | N/A | Fox doesn't require GPU for cloud-provider mode |
+
+**Status: 0 of 11 applicable checks done. All addressed by Packer scripts.**
+
+### 5.2 Vendor Portal metadata
+
+| Field | Value | Status |
+|-------|-------|--------|
+| App name | Fox in the Box | Ready |
+| Version | 0.7.44 (or current at submission) | Ready |
+| OS | Ubuntu 24.04 LTS | Ready |
+| Software included | Docker CE, Caddy, Fox in the Box (list with versions) | To build |
+| Short description | Private AI assistant with memory, local AI, and secure remote access | Ready |
+| Getting-started doc | SSH → read MOTD → open URL → enter password → paste API key | To write |
+| Logo | Fox logo (512x512 PNG) | Ready (exists in `packages/electron/assets/`) |
+| Support URL | `https://github.com/fox-in-the-box-ai/fox-in-the-box/issues` | Ready |
+| Documentation URL | `https://github.com/fox-in-the-box-ai/fox-in-the-box` | Ready |
+| Min Droplet size | 2 GB RAM / 1 vCPU / 50 GB disk (TO RATIFY — needs benchmarking) | TO RATIFY |
+| Category | AI Agents | Ready |
+
+### 5.3 Listing assets
+
+| Asset | Status |
+|-------|--------|
+| Logo (512x512 PNG) | Extract from `packages/electron/assets/icon.png` |
+| Getting-started markdown | To write |
+| Support/docs URLs | Ready |
+
+---
+
+## 6. Build Sequence (ordered)
+
+**8 deliverables, ~5 days estimated.**
+
+```
+1. Packer template (do-marketplace.pkr.hcl)           → can build test images
+2. 010-docker.sh (Docker CE install)                   → Docker on the Droplet
+3. 020-fox.sh (pull :stable, systemd unit)             → Fox runs headless
+4. 030-caddy.sh (install Caddy)                        → reverse proxy ready
+5. 001-fox-firstboot (password + Caddy config + start) → secure first boot
+6. 040-ufw.sh (firewall)                               → attack surface closed
+7. 900-cleanup.sh (img_check compliance)               → image submittable
+8. 99-fox MOTD + getting-started doc                   → user sees credentials
+```
+
+**Dependencies:** 1 → 2 → 3 → 4 → 5 → 6 → 7 → 8 (linear — each builds on prior).
+
+**Smallest viable first deliverable:** Steps 1–7 produce a submittable image.
+Step 8 (MOTD/docs) can be written in parallel.
+
+---
+
+## 7. Validation Plan
+
+### 7.1 Hardening tests (pass/fail criteria)
+
+| # | Test | Pass | Fail |
+|---|------|------|------|
+| 1 | **Password unguessable** | `wc -c /root/.fox-credentials` shows password >= 24 chars, no dictionary words. Run against image 10 times — all passwords unique. | Any duplicate, any password < 24 chars, any dictionary word |
+| 2 | **Password generation failure = no start** | Set `openssl` to fail (e.g., `chmod 000 /usr/bin/openssl`), create Droplet. Fox container must NOT be running. | Container running without password |
+| 3 | **TLS cert issued** | `curl -v https://<droplet-ip>` returns a valid cert (self-signed for IP, or Let's Encrypt for domain). No cleartext on port 80 (redirect to HTTPS). | Cleartext HTTP serves Fox content |
+| 4 | **Port 8787 not reachable from internet** | `nmap -p 8787 <droplet-ip>` returns filtered/closed. | Port 8787 open |
+| 5 | **Only ports 22, 80, 443 open** | `nmap -p- <droplet-ip>` returns exactly 3 open ports. | Any other port open |
+| 6 | **Auth required on /setup** | `curl -s https://<droplet-ip>/setup` returns 302 → /login (not the setup page content). | Setup page accessible without auth |
+| 7 | **Auth required on /api/models** | `curl -s https://<droplet-ip>/api/models` returns 401. | 200 with model data |
+| 8 | **Auth NOT required on /health** | `curl -s https://<droplet-ip>/health` returns 200 `{"status":"ok"}`. | 401 or connection refused |
+| 9 | **CSRF bypass closed** | `curl -X POST https://<droplet-ip>/api/chat -H "Content-Type: application/json" -d '{}'` returns 401 (no session). | 200 or any non-401 response |
+| 10 | **img_check.sh passes** | Run `bash img_check.sh` on the snapshot. Exit code 0. | Exit code 2 (FAIL) |
+| 11 | **Droplet survives reboot** | `reboot`, wait 2 min, Fox accessible at HTTPS with same password. | Fox not running after reboot |
+| 12 | **Data persists across container recreate** | Chat, send message, `docker stop fox-in-the-box && docker rm fox-in-the-box`, re-run container with same `/mnt/foxdata` volume. Previous conversation visible. | Data lost |
+
+### 7.2 Functional tests
+
+| # | Test | Pass |
+|---|------|------|
+| 13 | Onboarding wizard completes | Paste OpenRouter API key → chat works |
+| 14 | Memory persists | Ask "remember my name is Alice", new session, ask "what's my name" → "Alice" |
+| 15 | Local fallback toggle | Enable local fallback in Settings → llama-server starts (check supervisorctl) |
+
+---
+
+## 8. Open Questions / Residual Blockers
+
+| # | Question | Severity | Notes |
+|---|----------|----------|-------|
+| 1 | **IP-based TLS** — Let's Encrypt doesn't issue certs for bare IPs. Self-signed cert (browser warning) or require domain setup? ZeroSSL supports IP certs but adds a dependency. | TO RATIFY | Recommend: ship with Caddy's auto self-signed for IPs; document domain setup for proper TLS |
+| 2 | **Droplet size** — 2 GB RAM / 1 vCPU is the minimum for cloud-provider mode. Local models (llama-server) need 8 GB+. Which size do we list as minimum? | TO RATIFY | Recommend: list 2 GB as minimum, note 8 GB for local models in getting-started doc |
+| 3 | **Image update automation** — DO Vendor API supports programmatic snapshot updates. Should `build-container.yml` trigger a Packer rebuild + API push on `:stable` bump? | Phase 2 | Not needed for initial listing |
+| 4 | **Vendor Portal access** — need to apply at `marketplace.digitalocean.com/vendors`. Lead time unknown. Start now, build in parallel. | Process | Founder action |
+| 5 | **Onboarding wizard on HTTPS** — the wizard at `/setup` works but was designed for `http://localhost:8787`. Verify it renders correctly when accessed via `https://<ip>`. | Verify | Likely works — it's standard HTML/JS, no localhost assumptions in the UI |


### PR DESCRIPTION
## Summary

- **CodeQL** static analysis workflow for JavaScript/TypeScript + Python — runs on every PR and weekly (closes #399)
- **Dependabot** configuration covering GitHub Actions, npm (electron + playwright), and pip (fox-overlay) — weekly grouped updates (closes #414)
- **SECURITY.md** expanded with threat model (standalone vs managed deployment modes), security properties table, known limitations, GitHub private advisory link, and security CI summary (closes #402)

## Test plan

- [ ] CodeQL workflow appears in Actions tab after merge
- [ ] Dependabot starts opening grouped PRs within a week
- [ ] SECURITY.md renders correctly on GitHub
- [ ] Existing CI checks still pass (no workflow interference)