### PR TITLE
fix(deb): resolve code review warnings W1-W7 + apt repo setup guide

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
 
   release:
     name: Create GitHub Release
-    needs: [wait-for-container, wait-for-electron]
+    needs: [wait-for-container, wait-for-electron, deb-smoke-test]
     runs-on: ubuntu-latest
 
     permissions:
@@ -226,6 +226,13 @@ jobs:
           name: fox-macos
           path: release-artifacts/macos
 
+      - name: Download .deb artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: deb-*
+          path: release-artifacts/deb
+          merge-multiple: true
+
       - name: Extract release notes from CHANGELOG
         id: changelog
         run: |
@@ -249,5 +256,6 @@ jobs:
             release-artifacts/windows/*.exe
             release-artifacts/macos/*.dmg
             release-artifacts/macos/*.zip
+            release-artifacts/deb/*.deb
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/ops/apt-repo-setup.md
+++ b/docs/ops/apt-repo-setup.md
@@ -1,0 +1,175 @@
+# apt.foxinthebox.ai — Setup Instructions
+
+Instructions for configuring the GitHub CI pipeline and Cloudflare R2 bucket
+to publish `.deb` packages to `apt.foxinthebox.ai`.
+
+---
+
+## 1. Cloudflare R2 Bucket
+
+### Create the bucket
+
+1. Log in to Cloudflare Dashboard → R2 Object Storage
+2. Create bucket: `foxinthebox-apt`
+3. Region: auto (or closest to users)
+
+### Create R2 API token
+
+1. R2 → Manage R2 API Tokens → Create API Token
+2. Permissions: Object Read & Write
+3. Specify bucket: `foxinthebox-apt`
+4. Note the **Access Key ID** and **Secret Access Key**
+
+### Configure custom domain
+
+1. R2 bucket settings → Custom Domains → Add
+2. Enter: `apt.foxinthebox.ai`
+3. Cloudflare will auto-provision DNS + TLS
+4. Cache settings: cache everything, default TTL (R2 handles invalidation)
+
+---
+
+## 2. GPG Signing Key
+
+The apt repo needs a GPG key to sign package metadata. Users verify
+packages against this key.
+
+```bash
+# Generate a dedicated key (no passphrase — CI needs non-interactive signing)
+gpg --batch --gen-key <<EOF
+Key-Type: RSA
+Key-Length: 4096
+Name-Real: Fox in the Box
+Name-Email: security@foxinthebox.ai
+Expire-Date: 0
+%no-protection
+EOF
+
+# Export the private key (armored) for GitHub Secrets
+gpg --armor --export-secret-keys security@foxinthebox.ai > apt-signing-key.asc
+
+# Get the key ID
+gpg --list-keys --keyid-format long security@foxinthebox.ai
+# Note the 16-char key ID (e.g., ABCDEF1234567890)
+
+# Export the public key for the apt repo
+gpg --armor --export security@foxinthebox.ai > foxinthebox-apt.gpg.asc
+```
+
+Host the public key at `https://apt.foxinthebox.ai/gpg` (upload to R2 bucket
+root as `gpg`).
+
+---
+
+## 3. GitHub Secrets
+
+Add these secrets to the `fox-in-the-box` repository:
+
+| Secret Name | Value | Where from |
+|-------------|-------|-----------|
+| `APT_GPG_PRIVATE_KEY` | Contents of `apt-signing-key.asc` | Step 2 |
+| `APT_GPG_KEY_ID` | 16-char key ID (e.g., `ABCDEF1234567890`) | Step 2 |
+| `R2_ACCOUNT_ID` | Cloudflare account ID (Dashboard → Account Home → right sidebar) | Cloudflare |
+| `R2_ACCESS_KEY` | R2 API token Access Key ID | Step 1 |
+| `R2_SECRET_KEY` | R2 API token Secret Access Key | Step 1 |
+
+Path: Repository → Settings → Secrets and variables → Actions → New repository secret
+
+---
+
+## 4. How the Pipeline Works
+
+On tag push (`vX.Y.Z`), `release.yml` runs:
+
+```
+build-deb (amd64 + arm64)
+    ↓
+deb-smoke-test (dpkg install verification)
+    ↓
+publish-apt (reprepro → R2 sync)
+    ↓
+release (GitHub Release with .deb attached)
+```
+
+### publish-apt.sh flow
+
+1. Installs `reprepro`, `gpg`, `rclone` via apt
+2. Imports GPG private key from `APT_GPG_PRIVATE_KEY` secret
+3. Configures rclone for R2 via environment variables (no credentials on disk)
+4. Pulls current repo state from R2 (`rclone sync r2:foxinthebox-apt ./apt-repo`)
+5. Bootstraps reprepro config on first run (creates `conf/distributions`)
+6. Adds `.deb` files via `reprepro includedeb stable <file>`
+7. Pushes updated repo back to R2
+
+### What gets published
+
+```
+apt.foxinthebox.ai/
+├── dists/
+│   └── stable/
+│       └── main/
+│           ├── binary-amd64/Packages.gz
+│           └── binary-arm64/Packages.gz
+├── pool/
+│   └── main/
+│       └── f/foxinthebox/
+│           ├── foxinthebox_0.7.44_amd64.deb
+│           └── foxinthebox_0.7.44_arm64.deb
+├── gpg                              ← public signing key
+└── conf/                            ← reprepro metadata (not user-facing)
+```
+
+---
+
+## 5. User Install Instructions
+
+After the repo is live, users run:
+
+```bash
+# Add the GPG key
+curl -fsSL https://apt.foxinthebox.ai/gpg | sudo gpg --dearmor \
+    -o /usr/share/keyrings/foxinthebox.gpg
+
+# Add the repository
+echo "deb [signed-by=/usr/share/keyrings/foxinthebox.gpg] https://apt.foxinthebox.ai stable main" \
+    | sudo tee /etc/apt/sources.list.d/foxinthebox.list
+
+# Install
+sudo apt update && sudo apt install foxinthebox
+
+# Fox is now running at http://localhost:8787
+```
+
+Upgrade: `sudo apt update && sudo apt upgrade foxinthebox`
+
+---
+
+## 6. Verification Checklist
+
+After first setup, verify:
+
+- [ ] `curl -sf https://apt.foxinthebox.ai/gpg | head -1` returns `-----BEGIN PGP PUBLIC KEY BLOCK-----`
+- [ ] `curl -sf https://apt.foxinthebox.ai/dists/stable/main/binary-amd64/Packages.gz | gunzip | head` shows package metadata
+- [ ] On a clean Ubuntu 22.04 VM: install instructions above succeed
+- [ ] `dpkg -l foxinthebox` shows installed version
+- [ ] `systemctl status foxinthebox` shows active/running
+- [ ] `curl -sf http://localhost:8787/health` returns `{"status":"ok"}`
+- [ ] GitHub Release page shows `.deb` files attached alongside `.exe` and `.dmg`
+
+---
+
+## 7. Troubleshooting
+
+**`publish-apt` job fails with "GPG_PRIVATE_KEY not set":**
+The secret is not configured in the repository. See Step 3.
+
+**`reprepro: already in pool` error:**
+The same version `.deb` was already published. Bump VERSION before re-tagging.
+
+**Users get "NO_PUBKEY" on apt update:**
+The public GPG key at `apt.foxinthebox.ai/gpg` is missing or the R2 custom
+domain isn't configured. Check Step 1.
+
+**rclone sync hangs or 403:**
+R2 API token lacks write permission on the `foxinthebox-apt` bucket. Recreate
+the token with Object Read & Write on that specific bucket.

--- a/packages/deb/control/control
+++ b/packages/deb/control/control
@@ -6,6 +6,7 @@ Installed-Size: __SIZE_KB__
 Depends: python3.11 | python3 (>= 3.11),
          python3-pip,
          python3-venv,
+         supervisor,
          nodejs (>= 18),
          git,
          curl,

--- a/packages/deb/publish-apt.sh
+++ b/packages/deb/publish-apt.sh
@@ -27,25 +27,18 @@ _die() { echo "[publish-apt] ERROR: $*" >&2; exit 1; }
 
 # ── 1. Install tools ──────────────────────────────────────────────────────────
 _log "Installing tools..."
-sudo apt-get install -y -q reprepro gpg
-if ! command -v rclone &>/dev/null; then
-    curl -fsSL https://rclone.org/install.sh | sudo bash
-fi
+sudo apt-get install -y -q reprepro gpg rclone
 
 # ── 2. Import GPG key ─────────────────────────────────────────────────────────
 _log "Importing GPG key..."
 echo "$GPG_PRIVATE_KEY" | gpg --batch --import
 
-# ── 3. Configure rclone for R2 ───────────────────────────────────────────────
-mkdir -p ~/.config/rclone
-cat > ~/.config/rclone/rclone.conf << EOF
-[r2]
-type = s3
-provider = Cloudflare
-access_key_id = ${R2_ACCESS_KEY}
-secret_access_key = ${R2_SECRET_KEY}
-endpoint = ${ENDPOINT}
-EOF
+# ── 3. Configure rclone for R2 (env vars — no credentials written to disk) ───
+export RCLONE_CONFIG_R2_TYPE=s3
+export RCLONE_CONFIG_R2_PROVIDER=Cloudflare
+export RCLONE_CONFIG_R2_ACCESS_KEY_ID="$R2_ACCESS_KEY"
+export RCLONE_CONFIG_R2_SECRET_ACCESS_KEY="$R2_SECRET_KEY"
+export RCLONE_CONFIG_R2_ENDPOINT="$ENDPOINT"
 
 # ── 4. Pull current apt repo state ───────────────────────────────────────────
 _log "Pulling current repo state from R2..."

--- a/packages/deb/templates/foxinthebox-tailscale-serve.service.tmpl
+++ b/packages/deb/templates/foxinthebox-tailscale-serve.service.tmpl
@@ -1,0 +1,25 @@
+[Unit]
+Description=Fox in the Box — Tailscale Serve setup
+After=foxinthebox.service tailscaled.service
+Wants=foxinthebox.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/bash -c '\
+  for i in $(seq 1 120); do \
+    curl -fsS --connect-timeout 2 --max-time 6 http://127.0.0.1:8787/health >/dev/null 2>&1 && break; \
+    sleep 2; \
+  done; \
+  tailscale set --operator=foxinthebox 2>/dev/null || true; \
+  for i in $(seq 1 450); do \
+    if tailscale status --json 2>/dev/null | python3 -c "import json,sys; sys.exit(0 if json.load(sys.stdin).get(\"BackendState\")==\"Running\" else 1)" 2>/dev/null; then \
+      tailscale serve --bg 8787 2>/dev/null && echo "[tailscale-serve] Configured (https -> localhost:8787)." || true; \
+      exit 0; \
+    fi; \
+    sleep 2; \
+  done; \
+  echo "[tailscale-serve] No Running backend within timeout — OK for port-only."'
+
+[Install]
+WantedBy=foxinthebox.service

--- a/packages/install-core/preflight.sh
+++ b/packages/install-core/preflight.sh
@@ -112,59 +112,10 @@ sed -i "s|__BRAVE_API_KEY__|${BRAVE_API_KEY:-}|g" "$SUPERVISORD_CONF"
 mkdir -p /run/foxinthebox
 chmod 750 /run/foxinthebox
 
-# ── 10. Tailscale Serve (background — waits for WebUI and Tailscale login) ────
-# Mirrors the background subshell in entrypoint.sh.
-(
-    sleep 10
-    _health_dead=240
-    _hi=0
-    while [ "$_hi" -lt "$_health_dead" ]; do
-        if curl -fsS --connect-timeout 2 --max-time 6 "http://127.0.0.1:8787/health" >/dev/null 2>&1; then
-            _log "WebUI healthy — configuring Tailscale Serve..."
-            break
-        fi
-        _hi=$((_hi + 2))
-        sleep 2
-    done
-    if [ "$_hi" -ge "$_health_dead" ]; then
-        _log "Tailscale Serve helper: WebUI not ready within ${_health_dead}s — skipping."
-        exit 0
-    fi
-
-    # Grant operator access to foxinthebox user
-    _opi=0
-    while [ "$_opi" -lt 60 ]; do
-        if tailscale set --operator=foxinthebox 2>/dev/null; then
-            _log "Granted foxinthebox tailscale operator access."
-            break
-        fi
-        _opi=$((_opi + 2))
-        sleep 2
-    done
-
-    # Wait for Tailscale login (up to ~15 min)
-    _ts_iters=450
-    _ti=0
-    while [ "$_ti" -lt "$_ts_iters" ]; do
-        if tailscale status --json 2>/dev/null | python3 -c "
-import json, sys
-try:
-    d = json.load(sys.stdin)
-    sys.exit(0 if d.get('BackendState') == 'Running' else 1)
-except Exception:
-    sys.exit(1)
-" 2>/dev/null; then
-            if tailscale serve --bg 8787 2>/dev/null; then
-                _log "Tailscale Serve configured (https -> localhost:8787)."
-            else
-                _warn "tailscale serve failed — may need HTTPS enabled at https://login.tailscale.com/admin/dns."
-            fi
-            exit 0
-        fi
-        _ti=$((_ti + 1))
-        sleep 2
-    done
-    _log "Tailscale Serve not configured (no Running backend within timeout — OK for port-only)."
-) &
+# ── 10. Tailscale Serve ──────────────────────────────────────────────────────
+# Moved to foxinthebox-tailscale-serve.service (ExecStartPost= in the main
+# unit). Running a background subshell in ExecStartPre= is unsafe — systemd
+# may reap it when the pre-start phase completes.
+# See: packages/deb/templates/foxinthebox-tailscale-serve.service.tmpl
 
 _log "Preflight complete."

--- a/tests/container/test_deb_install.sh
+++ b/tests/container/test_deb_install.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
-# test_deb_install.sh — Smoke test: build .deb, install in ubuntu:22.04, assert /health
+# test_deb_install.sh — Smoke test: install .deb in ubuntu:22.04, verify package integrity
+#
+# Scope: verifies dpkg install succeeds, dependencies resolve, and installed
+# files are present. Does NOT verify service start — the test container has no
+# systemd, so foxinthebox.service cannot run. Full service testing requires a
+# VM or bare-metal machine.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -14,17 +19,26 @@ echo "[test-deb] Built: $DEB"
 echo "[test-deb] Installing in ubuntu:22.04 container..."
 docker run --rm \
     -v "$REPO_ROOT/dist:/debs:ro" \
-    ubuntu:22.04 bash -c "
+    ubuntu:22.04 bash -c '
         set -euo pipefail
         export DEBIAN_FRONTEND=noninteractive
         apt-get update -q
         apt-get install -y -q /debs/foxinthebox_*_amd64.deb
-        echo 'Install complete. Waiting for service...'
-        sleep 20
-        curl -sf http://localhost:8787/health && echo 'PASS: health check ok' || {
-            echo 'FAIL: health check failed'
-            exit 1
-        }
-    "
+
+        echo "--- Verify installed files ---"
+        [ -f /opt/foxinthebox/install-core.sh ] || { echo "FAIL: install-core.sh missing"; exit 1; }
+        [ -f /opt/foxinthebox/version.txt ]     || { echo "FAIL: version.txt missing"; exit 1; }
+        [ -d /opt/foxinthebox/fox-overlay ]      || { echo "FAIL: fox-overlay missing"; exit 1; }
+        [ -f /opt/foxinthebox/scripts/preflight.sh ] || { echo "FAIL: preflight.sh missing"; exit 1; }
+        [ -f /lib/systemd/system/foxinthebox.service ] || { echo "FAIL: systemd unit missing"; exit 1; }
+
+        echo "--- Verify foxinthebox user ---"
+        id foxinthebox || { echo "FAIL: foxinthebox user not created"; exit 1; }
+
+        echo "--- Verify supervisor available ---"
+        command -v supervisord || { echo "FAIL: supervisord not found"; exit 1; }
+
+        echo "PASS: package installed, files present, user created"
+    '
 
 echo "[test-deb] PASS"


### PR DESCRIPTION
## Summary

Addresses all 6 remaining code review warnings from PR #453:

| Warning | Fix |
|---------|-----|
| W1: rclone credentials in plaintext config | Use `RCLONE_CONFIG_R2_*` env vars — no credentials written to disk |
| W2: `curl \| sudo bash` for rclone install | `apt-get install rclone` instead |
| W3: supervisor missing from apt Depends | Added to `control` file |
| W5: background subshell in ExecStartPre | Moved to dedicated `foxinthebox-tailscale-serve.service` oneshot |
| W6: smoke test can't verify service start | Restructured to verify dpkg install + file presence + user creation |
| W7: release job doesn't depend on deb jobs | Added `deb-smoke-test` to `needs:`, .deb artifacts attached to GitHub Release |

Also adds `docs/ops/apt-repo-setup.md` — step-by-step instructions for:
- Cloudflare R2 bucket + custom domain
- GPG signing key generation
- GitHub Secrets configuration (5 secrets)
- Pipeline flow diagram
- User install instructions
- Verification checklist

## Test plan

- [ ] validate-overlay passes
- [ ] Playwright passes
- [ ] Build Container passes
- [ ] Review: `publish-apt.sh` uses env vars, not config file
- [ ] Review: `control` file includes `supervisor` in Depends
- [ ] Review: `release.yml` release job has `deb-smoke-test` in needs + .deb in files
- [ ] Review: `preflight.sh` no longer spawns background subshell