### PR TITLE
chore: update LICENSE copyright to Vulpy Inc., add DCO to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,32 @@ See [AGENTS.md](AGENTS.md) for the full development workflow used by coding agen
 
 ---
 
+## Developer Certificate of Origin (DCO)
+
+All contributions must be signed off to certify you have the right to submit
+them under the project's open-source license. Add a `Signed-off-by` line to
+every commit:
+
+```bash
+git commit -s -m "feat: add widget support"
+```
+
+This adds a trailer like:
+
+```
+Signed-off-by: Jane Doe <jane@example.com>
+```
+
+By signing off, you agree to the [DCO](https://developercertificate.org/).
+CI checks for this trailer on every PR. If you forget, amend and force-push:
+
+```bash
+git commit --amend -s
+git push --force-with-lease
+```
+
+---
+
 ## Coding standards
 
 - Python: match the style of the existing codebase in `forks/hermes-webui/`

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 fox-in-the-box-ai
+Copyright (c) 2026 Vulpy Inc. (operating as Fox in the Box)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

Governance and compliance updates for enterprise readiness.

- **LICENSE copyright holder** — changed from `fox-in-the-box-ai` to `Vulpy Inc. (operating as Fox in the Box)` to match the commercial entity. Closes #403
- **DCO in CONTRIBUTING.md** — added Developer Certificate of Origin section with sign-off instructions and the `--amend -s` recovery pattern. Closes #404

### Deferred / out of scope

- Commit signing enforcement (#401) — requires repo settings change, handled separately
- Trademark/brand usage policy (#410) — separate scope

## Test plan

- [x] LICENSE has exactly one changed line (copyright holder)
- [x] CONTRIBUTING.md section order: header → How to contribute → Development setup → DCO (new) → Coding standards
- [ ] On-target verification:
  - LICENSE renders correctly on GitHub
  - CONTRIBUTING.md renders correctly with nested code blocks

Closes #403, #404