### PR TITLE
chore: restore CODE_OF_CONDUCT.md, add star history badge

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,38 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a welcoming experience for everyone, regardless of background or
+identity.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive feedback
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- Trolling, personal attacks, or deliberately inflammatory remarks
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported to the project team at
+**roadhero@gmail.com**. All reports will be reviewed and investigated promptly
+and fairly. The project team is obligated to maintain confidentiality with
+regard to the reporter.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1,
+available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct/>.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Release](https://img.shields.io/github/v/release/fox-in-the-box-ai/fox-in-the-box)](https://github.com/fox-in-the-box-ai/fox-in-the-box/releases/latest)
 [![Playwright](https://github.com/fox-in-the-box-ai/fox-in-the-box/actions/workflows/playwright.yml/badge.svg)](https://github.com/fox-in-the-box-ai/fox-in-the-box/actions/workflows/playwright.yml)
 [![CodeQL](https://github.com/fox-in-the-box-ai/fox-in-the-box/actions/workflows/codeql.yml/badge.svg)](https://github.com/fox-in-the-box-ai/fox-in-the-box/actions/workflows/codeql.yml)
+[![Star History](https://img.shields.io/github/stars/fox-in-the-box-ai/fox-in-the-box?style=flat&label=Stars)](https://star-history.com/#fox-in-the-box-ai/fox-in-the-box&Date)
 
 > A private AI assistant that runs on your computer. No subscriptions, no cloud lock-in, no data leaving your machine without your say-so.
 
@@ -249,6 +250,7 @@ See **[docs/RESET.md](docs/RESET.md)** for the full reset procedure (Windows and
 ## Documentation
 
 - [CHANGELOG.md](CHANGELOG.md) — release history
+- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) — community standards
 - [CONTRIBUTING.md](CONTRIBUTING.md) — how to contribute
 - [SECURITY.md](SECURITY.md) — vulnerability reporting
 - [docs/DEV_MODE.md](docs/DEV_MODE.md) — local development with bind-mounted submodules


### PR DESCRIPTION
## Summary

Community hygiene pass.

- **CODE_OF_CONDUCT.md** — restored (was deleted as 0-byte placeholder in #347). Adapted from Contributor Covenant v2.1 with project contact. Closes #420
- **Star history badge** — added to README badge row, links to star-history.com chart. Closes #424

### Deferred / out of scope

- Screenshot/GIF (#419, #422) — no screenshot file exists yet; needs actual product screenshots
- Comparison table (#421) — separate scope, needs product positioning input
- Discord/Matrix channel (#430) — organizational decision, not a code change

## Test plan

- [x] CODE_OF_CONDUCT.md renders correctly
- [x] README badge row renders with new Stars badge
- [x] Documentation links section includes CODE_OF_CONDUCT

Closes #420, #424