### PR TITLE
chore: release v0.7.45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
+## [0.7.45] - 2026-06-07
+
+### Added
+- Bare-metal `.deb` package with apt repository and CI. Supports both amd64 and arm64 Debian/Ubuntu installs with systemd service management and automated updates.
+- SBOM (CycloneDX) generation attached to GitHub Releases.
+- CODE_OF_CONDUCT.md (Contributor Covenant v2.1).
+- DCO (Developer Certificate of Origin) section in CONTRIBUTING.md.
+- Star history badge in README.
+
+### Changed
+- Upstream bump: hermes-webui v0.51.145 → v0.51.293 (148 upstream releases absorbed), hermes-agent v2026.5.16 → v2026.6.5.
+- All GitHub Actions pinned by commit SHA for supply-chain hardening — mutable version tags replaced with immutable SHAs across 12 workflow files.
+- LICENSE copyright updated to Vulpy Inc. (operating as Fox in the Box).
+- Expanded SECURITY.md with vulnerability disclosure process.
+
+### Fixed
+- Docker build: install script now prefers `requirements.txt` over bare `pyproject.toml` for hermes-webui, fixing build failure introduced by upstream v0.51.293 adding a tooling-only `pyproject.toml` with no `[build-system]` section.
+- Patch 007 (colon-split fix) refreshed for upstream v0.51.293 line numbers. All 8 webui patches apply cleanly.
+- Agent overlay anchor refreshed for v2026.5.29.2.
+- Streaming patch substitution #1 anchor refreshed for v0.51.145.
+- `.deb` package: resolved 6 code review warnings, added apt repo setup guide.
+- Playwright CI: fixed nightly full matrix model-picker test drift and missing Chromium.
+- CI: pnpm/action-setup v4 version conflict resolved — explicit `version: 9` dropped in favor of `packageManager` field in package.json.
+
+### Security
+- CodeQL code scanning and Dependabot alerts enabled.
+- GitHub Actions pinned by SHA across all workflows.
+- SBOM attestation added to release artifacts.
+
+---
+
 ## [0.7.44] - 2026-05-27
 
 ### Fixed

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fox-in-the-box/electron",
   "productName": "fox-in-the-box",
-  "version": "0.7.44",
+  "version": "0.7.45",
   "description": "Fox in the box desktop app",
   "author": "Vulpy, Inc.",
   "main": "src/main.js",

--- a/qa/SMOKE_LOG.md
+++ b/qa/SMOKE_LOG.md
@@ -25,6 +25,20 @@ Skipped sections are OK as long as they're explicitly noted with reason. Empty e
 
 ---
 
+## v0.7.45 — 2026-06-07 (DV — upstream v0.51.293 bump + supply-chain + governance)
+
+- [x] (a) Upstream bump: hermes-webui v0.51.185→v0.51.293, hermes-agent v2026.5.29.2→v2026.6.5 — submodule pointers verified against versions.toml
+- [x] (b) Patch 007 (colon-split fix) refreshed for v0.51.293 line numbers — all 8 webui patches apply cleanly (`check-overlay-basis.sh` returns 0)
+- [x] (c) Docker build: install script `requirements.txt` preference fix verified — amd64 and arm64 Build & Push CI green
+- [x] (d) GitHub Actions SHA-pinned: 12 workflow files updated, Electron smoke (macOS/Windows) green after pnpm version conflict fix
+- [x] (e) SBOM workflow: CycloneDX generation configured for release events
+- [x] (f) Governance: LICENSE copyright Vulpy Inc., DCO in CONTRIBUTING.md, CODE_OF_CONDUCT.md
+- [x] (g) All CI checks green: CodeQL, Trivy, container smoke, option-b-diff-guard, Electron smoke
+- [ ] (h) **POST-RELEASE:** On-device Docker container start with v0.51.293 upstream — verify model picker + Ollama routing intact
+- [ ] (i) **POST-RELEASE:** .deb package install + apt repo update cycle on Debian/Ubuntu
+
+---
+
 ## v0.7.44 — 2026-05-27 (DV — cleanup + upstream drift + installer fix)
 
 - [x] (a) Dead code removed: streaming.py substitution 0 (FITB#278 keyless fallback) deleted — `_is_local_server_provider("custom")` returned False, never fired


### PR DESCRIPTION
## Summary

Release v0.7.45 — upstream bump, supply-chain hardening, governance.

- **Version bump** — 0.7.44 → 0.7.45 in `packages/electron/package.json`
- **CHANGELOG** — full entry covering all changes since v0.7.44
- **SMOKE_LOG** — engineer-side verification recorded

### Changes included in this release

**Added:** bare-metal .deb package, SBOM generation, CODE_OF_CONDUCT.md, DCO, star history badge

**Changed:** upstream hermes-webui v0.51.293, hermes-agent v2026.6.5, Actions SHA-pinned, LICENSE copyright Vulpy Inc.

**Fixed:** Docker build install script, patch 007 refresh, pnpm version conflict, .deb code review warnings, Playwright CI drift

**Security:** CodeQL, Dependabot alerts, SHA-pinned Actions, SBOM attestation

## Test plan

- [x] CHANGELOG section heads will be extracted by release.yml — verified format matches awk pattern
- [x] SMOKE_LOG entry present — release workflow gate will pass
- [x] Version in package.json matches tag to be created post-merge