### PR TITLE
fix(deb): split local declaration to fix unbound variable in install-core.sh

### DIFF
--- a/packages/install-core/install-core.sh
+++ b/packages/install-core/install-core.sh
@@ -104,7 +104,8 @@ _read_versions_toml() {
 }
 
 _sync_repo() {
-    local name="$1" url="$2" tag="$3" dest="$FITB_APP_DIR/$name"
+    local name="$1" url="$2" tag="$3"
+    local dest="$FITB_APP_DIR/$name"
     if [ -d "$dest/.git" ]; then
         _log "$name exists — fetching tag $tag..."
         git -C "$dest" fetch --depth=1 origin "refs/tags/$tag:refs/tags/$tag" 2>/dev/null || \


### PR DESCRIPTION
## Summary

- **Split `local` declaration in `_sync_repo()`** — `local name="$1" dest="$FITB_APP_DIR/$name"` references `$name` before the `local` statement completes. With `set -u`, bash raises `name: unbound variable` at runtime. Fixed by splitting into two `local` lines.

This was previously masked because the `.deb` smoke test never reached `_sync_repo` — the spurious `nodejs (>= 18)` dependency (removed in #488) blocked `apt-get install` before the `postinst` script ran. Now that the .deb installs cleanly, this bug surfaces.

### Deferred / out of scope

- Azure Trusted Signing 403 on Windows Electron builds — separate infrastructure issue, not related to .deb packaging.

## Test plan

- [x] Local: `bash -c 'set -euo pipefail; foo() { local n="$1"; local d="/app/$n"; echo "$d"; }; foo test'` → `/app/test`
- [ ] On-target: CI .deb smoke test passes — `_sync_repo` no longer errors
- [ ] On-target: release workflow `deb-smoke-test` job goes green

Follow-up to #488. Required for v0.7.45 release.