### PR TITLE
fix(deb): use python3.11 for venv on Ubuntu 22.04

### DIFF
--- a/packages/install-core/install-core.sh
+++ b/packages/install-core/install-core.sh
@@ -255,8 +255,10 @@ _pip_install() {
         # Create an isolated venv so Fox doesn't pollute system Python
         local venv="$FITB_APP_DIR/venv"
         if [ ! -f "$venv/bin/pip" ]; then
-            _log "Creating Python venv at $venv..."
-            python3 -m venv "$venv"
+            local py_bin
+            py_bin="$(command -v python3.11 || command -v python3)"
+            _log "Creating Python venv at $venv (using $py_bin)..."
+            "$py_bin" -m venv "$venv"
         fi
         pip_cmd="$venv/bin/pip"
     else


### PR DESCRIPTION
## Summary

- **Python 3.11 venv resolution** — on Ubuntu 22.04 the unversioned `python3` is 3.10, but `hermes-agent` requires `>=3.11`. The .deb already installs `python3.11` via Depends; this fix resolves `python3.11` first when creating the bare-metal venv.

### Deferred / out of scope

- Docker context unaffected (uses system pip, no venv creation)

## Test plan

- [x] Verified `command -v python3.11 || command -v python3` resolves correctly under `set -euo pipefail`
- [ ] On-target: .deb smoke test passes in release workflow (Ubuntu 22.04 container)

Fixes the `hermes-agent requires Python >=3.11` failure in the v0.7.45 release workflow.