### PR TITLE
fix(deb): add python3.11-venv to Depends

### DIFF
--- a/packages/deb/control/control
+++ b/packages/deb/control/control
@@ -4,8 +4,8 @@ Architecture: __ARCH__
 Maintainer: Fox in the Box <support@foxinthebox.ai>
 Installed-Size: __SIZE_KB__
 Depends: python3.11 | python3 (>= 3.11),
+         python3.11-venv | python3-venv (>= 3.11),
          python3-pip,
-         python3-venv,
          supervisor,
          git,
          curl,


### PR DESCRIPTION
## Summary

- **python3.11-venv dependency** — `python3-venv` only provides the venv module for the default python3 (3.10 on Ubuntu 22.04). The previous fix (#490) correctly resolved `python3.11` for venv creation, but `python3.11 -m venv` fails without `python3.11-venv` installed. Adds `python3.11-venv | python3-venv (>= 3.11)` to Depends.

### Deferred / out of scope

- No changes to Docker context (uses system pip, no venv)

## Test plan

- [ ] On-target: .deb smoke test passes in release workflow (Ubuntu 22.04 container)

Fixes `ensurepip is not available` error during venv creation in the v0.7.45 .deb postinst.