### PR TITLE
fix(ci): upgrade artifact-signing-action v1 → v2

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -117,12 +117,12 @@ jobs:
       # gate as the login step — only signs when bound to the signing environment.
       - name: Sign Windows installer (Azure Trusted Signing)
         if: runner.os == 'Windows' && inputs.signing-environment != ''
-        uses: azure/artifact-signing-action@b443cf8ea4124818d2ea9f043cba29fc3ec47b16 # v1
+        uses: azure/artifact-signing-action@c0ae2c1d0c1847ab81ac0ab8521bee597cfedd30 # v2
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           endpoint: https://eus.codesigning.azure.net/
-          trusted-signing-account-name: Icemint
+          signing-account-name: Icemint
           certificate-profile-name: fitb-exe-signing
           files-folder: packages/electron/dist
           files-folder-filter: exe


### PR DESCRIPTION
## Summary

- **Upgrade azure/artifact-signing-action from v1 to v2** — v1 uses the deprecated `TrustedSigning` PowerShell module and `Microsoft.Trusted.Signing.Client` NuGet package, whose signing dlib sends `api-version=2022-06-15-preview`. Azure retired that API version, causing 403 Forbidden on every signing attempt. v2 uses the current `ArtifactSigning` module with a supported API version.
- **Rename input** — `trusted-signing-account-name` → `signing-account-name` (v2 naming)

### Deferred / out of scope

- Post-sign `Get-AuthenticodeSignature` verification step (would catch silent signing failures)

## Test plan

- [ ] On-target: release workflow Windows signing step succeeds with v2 action

Fixes the silent Windows signing failure blocking v0.7.45 release.