### PR TITLE
fix(deb): guard systemctl calls in postinst

### DIFF
--- a/packages/deb/control/postinst
+++ b/packages/deb/control/postinst
@@ -18,7 +18,7 @@ bash /opt/foxinthebox/install-core.sh
 chown -R foxinthebox:foxinthebox /opt/foxinthebox
 
 # ── 4. Install and enable systemd units ──────────────────────────────────────
-if command -v systemctl &>/dev/null && systemctl is-system-running --quiet 2>/dev/null || true; then
+if command -v systemctl &>/dev/null && { systemctl is-system-running --quiet 2>/dev/null || true; }; then
     systemctl daemon-reload
     systemctl enable foxinthebox.service        || true
     systemctl enable foxinthebox-updater.path   || true


### PR DESCRIPTION
## Summary

- **Fix operator precedence in systemctl guard** — `(A && B) || true` is always true due to shell precedence, causing `systemctl daemon-reload` to run even in containers where systemctl is absent (`command not found`, exit 127). Fixed to `A && { B || true; }` so the block is only entered when systemctl exists.

### Deferred / out of scope

- No functional change on real systemd hosts — the guard only matters in Docker smoke tests

## Test plan

- [x] Verified with `bash -c 'set -e; ...'` that missing systemctl skips the block
- [ ] On-target: .deb smoke test passes in release workflow (Docker without systemd)

Fixes `systemctl: command not found` (exit 127) in the v0.7.45 .deb smoke test.