### PR TITLE
fix(ci): add continue-on-error to signing diagnostic steps

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -114,6 +114,7 @@ jobs:
 
       - name: Pre-sign diagnostics
         if: runner.os == 'Windows' && inputs.signing-environment != ''
+        continue-on-error: true
         shell: pwsh
         run: |
           Write-Host "::group::Azure identity"
@@ -148,6 +149,7 @@ jobs:
 
       - name: Post-sign diagnostics
         if: runner.os == 'Windows' && inputs.signing-environment != '' && steps.sign-windows.outcome != 'success'
+        continue-on-error: true
         shell: pwsh
         run: |
           Write-Host "::warning::Signing step outcome: ${{ steps.sign-windows.outcome }}"


### PR DESCRIPTION
## Summary

Follow-up to #495. The pre-sign diagnostics step failed because the `az trustedsigning` CLI extension isn't available on GitHub-hosted runners, which cascaded to skip both the signing step and the artifact upload — defeating the purpose of `continue-on-error` on the signing step.

- **`continue-on-error: true`** added to both diagnostic steps (pre-sign and post-sign) so they can never block the `.exe` upload

## Test plan

- [ ] On-target: next `v*` tag push should upload the `.exe` even if all three signing-related steps fail

Refs #494