### PR TITLE
feat(overlay): add GET /readyz readiness probe (#476)

### DIFF
--- a/packages/fox-overlay/fox_overlay/webui_modules/__init__.py
+++ b/packages/fox-overlay/fox_overlay/webui_modules/__init__.py
@@ -18,4 +18,5 @@ from . import tailscale  # noqa: F401  -- registers /api/tailscale/ at import
 from . import local_fallback  # noqa: F401  -- registers /api/local-fallback/ at import
 from . import models_download  # noqa: F401  -- registers /api/local-models (bare) at import
 from . import hostname  # noqa: F401  -- registers /api/settings/hostname (bare); imports _write_env_key from onboarding
+from . import readyz  # noqa: F401  -- registers GET /readyz (bare); always auth-exempt per INSTANCE_CONTRACT §4.5
 from . import test_hooks  # noqa: F401  -- (v0.7.7 #264) registers POST /test/* ONLY when FITB_TEST_MODE=1; production builds = no-op

--- a/packages/fox-overlay/fox_overlay/webui_modules/readyz.py
+++ b/packages/fox-overlay/fox_overlay/webui_modules/readyz.py
@@ -1,0 +1,111 @@
+"""GET /readyz — readiness probe (INSTANCE_CONTRACT §4.2).
+
+Returns a structured readiness snapshot: ``ready`` (bool) is true iff
+every check passes; ``checks`` is a dict of ``{ok, detail?}`` entries
+whose keys are runtime-specific.
+
+Auth position (§4.5): always unauthenticated.  At import time this
+module adds ``/readyz`` to upstream ``api.auth.PUBLIC_PATHS`` so
+``check_auth`` lets the request through before the dispatch hook runs.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import urllib.error
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+_GATEWAY_PROGRAM = "hermes-gateway"
+_QDRANT_HEALTH_URL = "http://127.0.0.1:6333/healthz"
+_SUPERVISOR_CONF = "/etc/supervisor/supervisord.conf"
+
+
+def _check_http_server() -> dict:
+    return {"ok": True}
+
+
+def _supervisorctl_status(program: str) -> str | None:
+    if not shutil.which("supervisorctl"):
+        return None
+    try:
+        result = subprocess.run(
+            ["supervisorctl", "-c", _SUPERVISOR_CONF, "status", program],
+            capture_output=True, text=True, timeout=5.0,
+        )
+        for line in (result.stdout or "").splitlines():
+            parts = line.split()
+            if parts and parts[0] == program and len(parts) >= 2:
+                return parts[1]
+    except (subprocess.TimeoutExpired, OSError):
+        pass
+    return None
+
+
+def _check_agent_runtime() -> dict:
+    status = _supervisorctl_status(_GATEWAY_PROGRAM)
+    if status is None:
+        return {"ok": True, "detail": "supervisor unavailable (standalone)"}
+    if status == "RUNNING":
+        return {"ok": True, "detail": f"{_GATEWAY_PROGRAM} {status}"}
+    return {"ok": False, "detail": f"{_GATEWAY_PROGRAM} {status}"}
+
+
+def _check_vector_store() -> dict:
+    try:
+        with urllib.request.urlopen(_QDRANT_HEALTH_URL, timeout=2) as resp:
+            if resp.status == 200:
+                return {"ok": True, "detail": "qdrant :6333 reachable"}
+    except (urllib.error.URLError, OSError, ValueError):
+        pass
+    if not os.environ.get("QDRANT_URL") and not os.path.exists("/data/qdrant"):
+        return {"ok": True, "detail": "qdrant not configured (standalone)"}
+    return {"ok": False, "detail": "qdrant :6333 unreachable"}
+
+
+def _check_config_loaded() -> dict:
+    try:
+        from api.config import load_settings
+        settings = load_settings()
+        if isinstance(settings, dict):
+            return {"ok": True}
+        return {"ok": False, "detail": "settings returned non-dict"}
+    except Exception as exc:
+        return {"ok": False, "detail": str(exc)}
+
+
+def get_readiness() -> dict:
+    checks = {
+        "http_server": _check_http_server(),
+        "agent_runtime": _check_agent_runtime(),
+        "vector_store": _check_vector_store(),
+        "config_loaded": _check_config_loaded(),
+    }
+    ready = all(c["ok"] for c in checks.values())
+    return {"ready": ready, "checks": checks}
+
+
+# ── Dispatcher integration ─────────────────────────────────────────────
+# Expand PUBLIC_PATHS so check_auth lets /readyz through (§4.5).
+try:
+    import api.auth as _auth
+    if "/readyz" not in _auth.PUBLIC_PATHS:
+        _auth.PUBLIC_PATHS = _auth.PUBLIC_PATHS | frozenset({"/readyz"})
+except ImportError:
+    pass
+
+from fox_overlay import dispatch  # noqa: E402
+
+
+def _handle_get(handler, parsed) -> bool:
+    if parsed.path != "/readyz":
+        return False
+    from api.helpers import j
+    j(handler, get_readiness())
+    return True
+
+
+dispatch.register_get("/readyz", _handle_get, allow_bare=True)

--- a/packages/fox-overlay/tests/test_readyz.py
+++ b/packages/fox-overlay/tests/test_readyz.py
@@ -1,0 +1,248 @@
+"""Tests for fox_overlay.webui_modules.readyz — /readyz endpoint (INST-01)."""
+from __future__ import annotations
+
+import json
+import sys
+import types
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+
+# ── Upstream stubs (no real hermes-webui in test environment) ──────────
+
+def _stub_upstream():
+    """Inject minimal api.auth, api.config, api.helpers stubs."""
+    api = types.ModuleType("api")
+    auth = types.ModuleType("api.auth")
+    auth.PUBLIC_PATHS = frozenset({"/login", "/health"})
+    config = types.ModuleType("api.config")
+    config.load_settings = lambda: {"theme": "dark"}
+    helpers = types.ModuleType("api.helpers")
+
+    def _j(handler, data, status=200):
+        body = json.dumps(data).encode()
+        handler.send_response(status)
+        handler.send_header("Content-Type", "application/json")
+        handler.end_headers()
+        handler._body = body
+
+    helpers.j = _j
+    api.auth = auth
+    api.config = config
+    api.helpers = helpers
+    sys.modules.setdefault("api", api)
+    sys.modules.setdefault("api.auth", auth)
+    sys.modules.setdefault("api.config", config)
+    sys.modules.setdefault("api.helpers", helpers)
+    return auth
+
+
+@pytest.fixture(autouse=True)
+def _upstream(monkeypatch):
+    _stub_upstream()
+    # Reset PUBLIC_PATHS on the actual module in sys.modules so
+    # expansion tests see the before state.
+    auth = sys.modules["api.auth"]
+    auth.PUBLIC_PATHS = frozenset({"/login", "/health"})
+    # Reset dispatch state so each test starts clean.
+    from fox_overlay import dispatch
+    dispatch._GET_TABLE.clear()
+    dispatch._POST_TABLE.clear()
+    dispatch._BootstrapState.frozen = False
+    yield auth
+    # Clean up readyz module so next test re-imports fresh.
+    sys.modules.pop("fox_overlay.webui_modules.readyz", None)
+
+
+def _load_readyz():
+    """(Re)import the readyz module, triggering registration."""
+    sys.modules.pop("fox_overlay.webui_modules.readyz", None)
+    import fox_overlay.webui_modules as _pkg
+    if hasattr(_pkg, "readyz"):
+        delattr(_pkg, "readyz")
+    from fox_overlay.webui_modules import readyz
+    return readyz
+
+
+def _make_handler():
+    """Minimal handler stub with send_response / send_header / end_headers."""
+    h = SimpleNamespace()
+    h._headers_sent = []
+    h._body = None
+    h._status = None
+    h.send_response = lambda status: setattr(h, "_status", status)
+    h.send_header = lambda k, v: h._headers_sent.append((k, v))
+    h.end_headers = lambda: None
+    return h
+
+
+def _parsed(path):
+    return SimpleNamespace(path=path)
+
+
+# ── Registration tests ─────────────────────────────────────────────────
+
+class TestRegistration:
+    def test_registers_get_handler(self):
+        _load_readyz()
+        from fox_overlay.dispatch import GET_TABLE
+        assert "/readyz" in GET_TABLE
+
+    def test_no_post_handler(self):
+        _load_readyz()
+        from fox_overlay.dispatch import POST_TABLE
+        assert "/readyz" not in POST_TABLE
+
+    def test_expands_public_paths(self):
+        auth_mod = sys.modules["api.auth"]
+        assert "/readyz" not in auth_mod.PUBLIC_PATHS
+        _load_readyz()
+        assert "/readyz" in auth_mod.PUBLIC_PATHS
+
+    def test_preserves_existing_public_paths(self):
+        _load_readyz()
+        auth_mod = sys.modules["api.auth"]
+        assert "/login" in auth_mod.PUBLIC_PATHS
+        assert "/health" in auth_mod.PUBLIC_PATHS
+
+
+# ── Handler tests ──────────────────────────────────────────────────────
+
+class TestHandler:
+    def test_handles_readyz_path(self):
+        readyz = _load_readyz()
+        handler = _make_handler()
+        result = readyz._handle_get(handler, _parsed("/readyz"))
+        assert result is True
+
+    def test_declines_non_readyz(self):
+        readyz = _load_readyz()
+        handler = _make_handler()
+        assert readyz._handle_get(handler, _parsed("/readyzXYZ")) is False
+        assert readyz._handle_get(handler, _parsed("/readyz/extra")) is False
+        assert readyz._handle_get(handler, _parsed("/health")) is False
+
+    def test_response_shape(self):
+        readyz = _load_readyz()
+        handler = _make_handler()
+        with mock.patch.object(readyz, "get_readiness", return_value={
+            "ready": True,
+            "checks": {"http_server": {"ok": True}},
+        }):
+            readyz._handle_get(handler, _parsed("/readyz"))
+        body = json.loads(handler._body)
+        assert body["ready"] is True
+        assert "checks" in body
+        assert body["checks"]["http_server"]["ok"] is True
+
+
+# ── Readiness logic tests ─────────────────────────────────────────────
+
+class TestGetReadiness:
+    def test_all_checks_pass(self):
+        readyz = _load_readyz()
+        with mock.patch.object(readyz, "_check_http_server", return_value={"ok": True}), \
+             mock.patch.object(readyz, "_check_agent_runtime", return_value={"ok": True}), \
+             mock.patch.object(readyz, "_check_vector_store", return_value={"ok": True}), \
+             mock.patch.object(readyz, "_check_config_loaded", return_value={"ok": True}):
+            result = readyz.get_readiness()
+        assert result["ready"] is True
+        assert len(result["checks"]) == 4
+
+    def test_one_check_fails(self):
+        readyz = _load_readyz()
+        with mock.patch.object(readyz, "_check_http_server", return_value={"ok": True}), \
+             mock.patch.object(readyz, "_check_agent_runtime", return_value={"ok": False, "detail": "FATAL"}), \
+             mock.patch.object(readyz, "_check_vector_store", return_value={"ok": True}), \
+             mock.patch.object(readyz, "_check_config_loaded", return_value={"ok": True}):
+            result = readyz.get_readiness()
+        assert result["ready"] is False
+        assert result["checks"]["agent_runtime"]["ok"] is False
+
+    def test_check_keys_match_contract(self):
+        readyz = _load_readyz()
+        with mock.patch.object(readyz, "_check_http_server", return_value={"ok": True}), \
+             mock.patch.object(readyz, "_check_agent_runtime", return_value={"ok": True}), \
+             mock.patch.object(readyz, "_check_vector_store", return_value={"ok": True}), \
+             mock.patch.object(readyz, "_check_config_loaded", return_value={"ok": True}):
+            result = readyz.get_readiness()
+        expected_keys = {"http_server", "agent_runtime", "vector_store", "config_loaded"}
+        assert set(result["checks"].keys()) == expected_keys
+
+
+# ── Individual check tests ─────────────────────────────────────────────
+
+class TestHttpServerCheck:
+    def test_always_ok(self):
+        readyz = _load_readyz()
+        assert readyz._check_http_server() == {"ok": True}
+
+
+class TestAgentRuntimeCheck:
+    def test_running(self):
+        readyz = _load_readyz()
+        with mock.patch.object(readyz, "_supervisorctl_status", return_value="RUNNING"):
+            result = readyz._check_agent_runtime()
+        assert result["ok"] is True
+
+    def test_fatal(self):
+        readyz = _load_readyz()
+        with mock.patch.object(readyz, "_supervisorctl_status", return_value="FATAL"):
+            result = readyz._check_agent_runtime()
+        assert result["ok"] is False
+
+    def test_no_supervisor(self):
+        readyz = _load_readyz()
+        with mock.patch.object(readyz, "_supervisorctl_status", return_value=None):
+            result = readyz._check_agent_runtime()
+        assert result["ok"] is True
+        assert "standalone" in result.get("detail", "")
+
+
+class TestVectorStoreCheck:
+    def test_reachable(self):
+        readyz = _load_readyz()
+        mock_resp = mock.MagicMock()
+        mock_resp.status = 200
+        mock_resp.__enter__ = mock.Mock(return_value=mock_resp)
+        mock_resp.__exit__ = mock.Mock(return_value=False)
+        with mock.patch("urllib.request.urlopen", return_value=mock_resp):
+            result = readyz._check_vector_store()
+        assert result["ok"] is True
+
+    def test_unreachable_with_qdrant_configured(self):
+        readyz = _load_readyz()
+        with mock.patch("urllib.request.urlopen", side_effect=OSError("refused")), \
+             mock.patch.dict("os.environ", {"QDRANT_URL": "http://qdrant:6333"}):
+            result = readyz._check_vector_store()
+        assert result["ok"] is False
+
+    def test_unreachable_standalone(self):
+        readyz = _load_readyz()
+        with mock.patch("urllib.request.urlopen", side_effect=OSError("refused")), \
+             mock.patch.dict("os.environ", {}, clear=True), \
+             mock.patch("os.path.exists", return_value=False):
+            result = readyz._check_vector_store()
+        assert result["ok"] is True
+        assert "standalone" in result.get("detail", "")
+
+
+class TestConfigLoadedCheck:
+    def test_config_ok(self):
+        readyz = _load_readyz()
+        result = readyz._check_config_loaded()
+        assert result["ok"] is True
+
+    def test_config_error(self):
+        readyz = _load_readyz()
+        config_mod = sys.modules["api.config"]
+        original = config_mod.load_settings
+        config_mod.load_settings = mock.Mock(side_effect=RuntimeError("corrupt"))
+        try:
+            result = readyz._check_config_loaded()
+            assert result["ok"] is False
+            assert "corrupt" in result.get("detail", "")
+        finally:
+            config_mod.load_settings = original

--- a/packages/fox-overlay/tests/test_readyz.py
+++ b/packages/fox-overlay/tests/test_readyz.py
@@ -32,10 +32,10 @@ def _stub_upstream():
     api.auth = auth
     api.config = config
     api.helpers = helpers
-    sys.modules.setdefault("api", api)
-    sys.modules.setdefault("api.auth", auth)
-    sys.modules.setdefault("api.config", config)
-    sys.modules.setdefault("api.helpers", helpers)
+    sys.modules["api"] = api
+    sys.modules["api.auth"] = auth
+    sys.modules["api.config"] = config
+    sys.modules["api.helpers"] = helpers
     return auth
 
 


### PR DESCRIPTION
## Summary

Implement INSTANCE_CONTRACT §4.2 `/readyz` readiness endpoint — a structured probe that returns `{ready, checks}` where `ready` is `true` iff all subsystem checks pass.

- **Readyz handler** — registered as a bare-path GET handler via the Fox dispatch mechanism. Returns JSON with four checks: `http_server`, `agent_runtime` (supervisor status), `vector_store` (Qdrant health), `config_loaded` (settings load).
- **Auth-exempt** — expands `api.auth.PUBLIC_PATHS` at import time so `check_auth` lets `/readyz` through before the dispatch hook runs, per INSTANCE_CONTRACT §4.5.
- **Standalone graceful degradation** — when supervisor or Qdrant are absent (standalone/desktop mode), reports `ok: true` with detail explaining the context, rather than failing.

### Deferred / out of scope

- `/version` and `/capabilities` endpoints are separate tickets (INST-02, INST-03)
- Qdrant health check does not verify collection readiness — just port reachability

## Test plan

- [x] 19 unit tests covering: registration, PUBLIC_PATHS expansion, handler routing, boundary rejection (`/readyzXYZ`, `/readyz/extra`), readiness logic (all pass / one fails), contract check keys, individual check functions (supervisor running/fatal/absent, Qdrant reachable/unreachable/standalone, config ok/error)
- [x] Full fox-overlay test suite green (184 passed, 1 skipped, 0 failures)
- [ ] On-target verification:
  - Container smoke: `curl http://localhost:8080/readyz` returns `{"ready": true, ...}`
  - Standalone desktop: endpoint returns ok with graceful degradation details
  - Managed mode: endpoint accessible without auth credentials

Closes #476