### PR TITLE
feat(overlay): check_auth substitution for X-Fox-Auth gate (#475)

### DIFF
--- a/packages/fox-overlay/fox_overlay/webui_patches/__init__.py
+++ b/packages/fox-overlay/fox_overlay/webui_patches/__init__.py
@@ -39,4 +39,6 @@ def apply_all() -> None:
     # guard natively. See git history for the dropped patches.
     from . import streaming
     streaming.apply()
-    _log.warning("[fox-overlay] webui_patches.apply_all() complete (%d patch modules)", 2)
+    from . import auth
+    auth.apply()
+    _log.warning("[fox-overlay] webui_patches.apply_all() complete (%d patch modules)", 3)

--- a/packages/fox-overlay/fox_overlay/webui_patches/auth.py
+++ b/packages/fox-overlay/fox_overlay/webui_patches/auth.py
@@ -1,0 +1,95 @@
+"""Fox webui patch: auth.py — X-Fox-Auth shared-secret gate (AUTH-01).
+
+Substitutes ``check_auth`` in ``api/auth.py`` to add PATH 5: a valid
+``X-Fox-Auth`` header grants access before the session-cookie check.
+This is the management-plane auth path — Fleet's ``fox-control`` sends
+this header on every request to a managed instance.
+
+## How it works
+
+One substitution inserts a block BEFORE ``cookie_val = parse_cookie(handler)``
+(after public-path checks, before session-cookie checks). The block:
+
+1. Reads ``FOX_PLANE_AUTH_SECRET`` from the environment (cached at
+   patch time — the secret doesn't change at runtime).
+2. If the env var is unset or empty, skips (standalone mode — no-op).
+3. Reads ``X-Fox-Auth`` from the request headers.
+4. Compares with ``hmac.compare_digest`` (constant-time).
+5. Returns ``True`` on match → request is authorized.
+
+Standalone instances (no ``FOX_PLANE_AUTH_SECRET``) are byte-identical
+in behavior to vanilla Hermes — the injected block exits immediately.
+
+## Contract references
+
+* INSTANCE_CONTRACT.md §3.1 — X-Fox-Auth shared secret
+* ENTERPRISE_ARCHITECTURE.md §5.3 — check_auth substitution mechanism
+* DEMO_TIER.md — managed-mode auth model
+"""
+import inspect
+import logging
+import os
+
+from ._helpers import substitute_function
+
+_log = logging.getLogger("fox_overlay.webui_patches.auth")
+
+_CHECK_AUTH_SENTINEL = "_fox_patched_check_auth"
+_EXPECTED_CHECK_AUTH_SIG = "(handler, parsed) -> bool"
+
+
+def _check_signature(callable_obj, expected: str, label: str) -> None:
+    actual = str(inspect.signature(callable_obj))
+    if actual != expected:
+        raise AssertionError(
+            "[fox-overlay] auth patch: %s signature drift.\n"
+            "  expected: %s\n"
+            "  actual:   %s\n"
+            "Refresh both the expected signature and the substitution "
+            "anchors in fox_overlay/webui_patches/auth.py." % (label, expected, actual)
+        )
+
+
+def apply() -> None:
+    from api import auth as _u
+
+    if getattr(_u.check_auth, _CHECK_AUTH_SENTINEL, False):
+        return
+
+    _check_signature(_u.check_auth, _EXPECTED_CHECK_AUTH_SIG, "check_auth")
+
+    substitute_function(
+        upstream_module=_u,
+        function_name="check_auth",
+        substitutions=[
+            (
+                "    # Check session cookie\n"
+                "    cookie_val = parse_cookie(handler)\n",
+
+                "    # PATH 5 (Fox managed mode): X-Fox-Auth shared secret.\n"
+                "    # Fleet's fox-control sends this header on every request.\n"
+                "    # Standalone (no FOX_PLANE_AUTH_SECRET) skips this block.\n"
+                "    _fox_plane_secret = _fox_get_plane_secret()\n"
+                "    if _fox_plane_secret:\n"
+                "        _fox_auth_header = handler.headers.get('X-Fox-Auth', '')\n"
+                "        if _fox_auth_header and _hmac_compare(_fox_auth_header, _fox_plane_secret):\n"
+                "            return True\n"
+                "    # Check session cookie\n"
+                "    cookie_val = parse_cookie(handler)\n",
+            ),
+        ],
+        sentinel=_CHECK_AUTH_SENTINEL,
+        extra_globals={
+            "_fox_get_plane_secret": _fox_get_plane_secret,
+            "_hmac_compare": _hmac_compare,
+        },
+    )
+
+
+def _fox_get_plane_secret() -> str:
+    return os.environ.get("FOX_PLANE_AUTH_SECRET", "")
+
+
+def _hmac_compare(a: str, b: str) -> bool:
+    import hmac
+    return hmac.compare_digest(a.encode("utf-8"), b.encode("utf-8"))

--- a/packages/fox-overlay/tests/test_auth_patch.py
+++ b/packages/fox-overlay/tests/test_auth_patch.py
@@ -1,0 +1,287 @@
+"""Regression tests for fox_overlay.webui_patches.auth (AUTH-01).
+
+Covers:
+* Module load + structural sanity (sentinel, signature constant, helpers)
+* Signature drift fails fast with diagnostic
+* Substitution anchor present and unique
+* apply() patches check_auth correctly against a stub
+* X-Fox-Auth grants access with valid secret (constant-time comparison)
+* X-Fox-Auth rejected with wrong secret
+* Standalone mode (no FOX_PLANE_AUTH_SECRET) — injected block is a no-op
+* Idempotency — re-apply is a no-op
+"""
+import importlib
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+
+_UPSTREAM_AUTH_SOURCE = '''\
+PUBLIC_PATHS = {"/health"}
+
+def is_auth_enabled():
+    return True
+
+def parse_cookie(handler):
+    return None
+
+def verify_session(cookie_val):
+    return False
+
+def check_auth(handler, parsed) -> bool:
+    """Check if request is authorized. Returns True if OK.
+    If not authorized, sends 401 (API) or 302 redirect (page) and returns False."""
+    if not is_auth_enabled():
+        return True
+    # Public paths don't require auth
+    if parsed.path in PUBLIC_PATHS or parsed.path.startswith('/static/') or parsed.path.startswith('/session/static/'):
+        return True
+    # Check session cookie
+    cookie_val = parse_cookie(handler)
+    if cookie_val and verify_session(cookie_val):
+        return True
+    # Not authorized
+    if parsed.path.startswith('/api/'):
+        handler._sent_status = 401
+    else:
+        handler._sent_status = 302
+    return False
+'''
+
+
+def _install_stub(tmp_path, source, monkeypatch):
+    api_dir = tmp_path / "api"
+    api_dir.mkdir(exist_ok=True)
+    (api_dir / "__init__.py").write_text("")
+    (api_dir / "auth.py").write_text(source)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    for name in list(sys.modules):
+        if name == "api" or name.startswith("api."):
+            del sys.modules[name]
+    import api.auth as fake_auth  # noqa: F401
+    return sys.modules["api.auth"]
+
+
+def _make_handler(headers=None):
+    h = SimpleNamespace(_sent_status=None)
+    _headers = headers or {}
+    h.headers = SimpleNamespace(get=lambda key, default='': _headers.get(key, default))
+    return h
+
+
+def _parsed(path):
+    return SimpleNamespace(path=path)
+
+
+@pytest.fixture
+def fresh_auth(tmp_path, monkeypatch):
+    fake_auth = _install_stub(tmp_path, _UPSTREAM_AUTH_SOURCE, monkeypatch)
+    import fox_overlay.webui_patches.auth as patch_mod
+    importlib.reload(patch_mod)
+    yield fake_auth, patch_mod
+    importlib.reload(patch_mod)
+    for name in list(sys.modules):
+        if name == "api" or name.startswith("api."):
+            del sys.modules[name]
+
+
+# ── Module load + structural sanity ──────────────────────────────────────────
+
+def test_module_loads_without_error(fresh_auth):
+    _u, patch_mod = fresh_auth
+    assert hasattr(patch_mod, "_CHECK_AUTH_SENTINEL")
+    assert hasattr(patch_mod, "_EXPECTED_CHECK_AUTH_SIG")
+    assert hasattr(patch_mod, "_check_signature")
+    assert hasattr(patch_mod, "apply")
+
+
+# ── Signature drift detection ────────────────────────────────────────────────
+
+def test_signature_drift_fails_fast(tmp_path, monkeypatch):
+    drifted = _UPSTREAM_AUTH_SOURCE.replace(
+        "def check_auth(handler, parsed) -> bool:",
+        "def check_auth(handler, parsed, extra=None) -> bool:",
+    )
+    _install_stub(tmp_path, drifted, monkeypatch)
+    import fox_overlay.webui_patches.auth as patch_mod
+    importlib.reload(patch_mod)
+    with pytest.raises(AssertionError, match="check_auth signature drift"):
+        patch_mod.apply()
+    importlib.reload(patch_mod)
+    for name in list(sys.modules):
+        if name == "api" or name.startswith("api."):
+            del sys.modules[name]
+
+
+def test_signature_check_helper_directly():
+    import fox_overlay.webui_patches.auth as patch_mod
+    def _fake(): pass
+    with pytest.raises(AssertionError, match="signature drift"):
+        patch_mod._check_signature(_fake, "(x, y)", "fake")
+
+
+# ── Anchor presence ──────────────────────────────────────────────────────────
+
+def test_substitution_anchor_present():
+    import inspect
+    import fox_overlay.webui_patches.auth as patch_mod
+    src = inspect.getsource(patch_mod.apply)
+    assert "cookie_val = parse_cookie(handler)" in src
+    assert "X-Fox-Auth" in src
+    assert "_hmac_compare" in src
+    assert "_fox_get_plane_secret" in src
+
+
+# ── apply() patches check_auth ───────────────────────────────────────────────
+
+def test_apply_patches_check_auth(fresh_auth, monkeypatch):
+    fake_auth, patch_mod = fresh_auth
+    monkeypatch.setenv("FOX_PLANE_AUTH_SECRET", "test-secret-42")
+    patch_mod.apply()
+    assert getattr(fake_auth.check_auth, patch_mod._CHECK_AUTH_SENTINEL, False)
+
+
+def test_apply_idempotent(fresh_auth, monkeypatch):
+    fake_auth, patch_mod = fresh_auth
+    monkeypatch.setenv("FOX_PLANE_AUTH_SECRET", "test-secret-42")
+    patch_mod.apply()
+    patch_mod.apply()
+    assert getattr(fake_auth.check_auth, patch_mod._CHECK_AUTH_SENTINEL, False)
+
+
+# ── X-Fox-Auth grants access with valid secret ──────────────────────────────
+
+def test_valid_x_fox_auth_grants_access(fresh_auth, monkeypatch):
+    fake_auth, patch_mod = fresh_auth
+    monkeypatch.setenv("FOX_PLANE_AUTH_SECRET", "my-plane-secret")
+    patch_mod.apply()
+
+    handler = _make_handler({"X-Fox-Auth": "my-plane-secret"})
+    result = fake_auth.check_auth(handler, _parsed("/api/sessions"))
+    assert result is True
+    assert handler._sent_status is None
+
+
+# ── X-Fox-Auth rejected with wrong secret ────────────────────────────────────
+
+def test_invalid_x_fox_auth_rejected(fresh_auth, monkeypatch):
+    fake_auth, patch_mod = fresh_auth
+    monkeypatch.setenv("FOX_PLANE_AUTH_SECRET", "my-plane-secret")
+    patch_mod.apply()
+
+    handler = _make_handler({"X-Fox-Auth": "wrong-secret"})
+    result = fake_auth.check_auth(handler, _parsed("/api/sessions"))
+    assert result is False
+    assert handler._sent_status == 401
+
+
+def test_empty_x_fox_auth_rejected(fresh_auth, monkeypatch):
+    fake_auth, patch_mod = fresh_auth
+    monkeypatch.setenv("FOX_PLANE_AUTH_SECRET", "my-plane-secret")
+    patch_mod.apply()
+
+    handler = _make_handler({"X-Fox-Auth": ""})
+    result = fake_auth.check_auth(handler, _parsed("/api/sessions"))
+    assert result is False
+    assert handler._sent_status == 401
+
+
+def test_missing_x_fox_auth_header_rejected(fresh_auth, monkeypatch):
+    fake_auth, patch_mod = fresh_auth
+    monkeypatch.setenv("FOX_PLANE_AUTH_SECRET", "my-plane-secret")
+    patch_mod.apply()
+
+    handler = _make_handler({})
+    result = fake_auth.check_auth(handler, _parsed("/api/sessions"))
+    assert result is False
+    assert handler._sent_status == 401
+
+
+# ── Standalone mode (no FOX_PLANE_AUTH_SECRET) ───────────────────────────────
+
+def test_standalone_mode_no_secret_falls_through(fresh_auth, monkeypatch):
+    fake_auth, patch_mod = fresh_auth
+    monkeypatch.delenv("FOX_PLANE_AUTH_SECRET", raising=False)
+    patch_mod.apply()
+
+    handler = _make_handler({})
+    result = fake_auth.check_auth(handler, _parsed("/api/sessions"))
+    assert result is False
+    assert handler._sent_status == 401
+
+
+def test_standalone_with_x_fox_auth_header_ignored(fresh_auth, monkeypatch):
+    """Without FOX_PLANE_AUTH_SECRET set, even a X-Fox-Auth header is ignored."""
+    fake_auth, patch_mod = fresh_auth
+    monkeypatch.delenv("FOX_PLANE_AUTH_SECRET", raising=False)
+    patch_mod.apply()
+
+    handler = _make_handler({"X-Fox-Auth": "anything"})
+    result = fake_auth.check_auth(handler, _parsed("/api/sessions"))
+    assert result is False
+    assert handler._sent_status == 401
+
+
+# ── Public paths still bypass auth ───────────────────────────────────────────
+
+def test_public_path_bypasses_auth_after_patch(fresh_auth, monkeypatch):
+    fake_auth, patch_mod = fresh_auth
+    monkeypatch.setenv("FOX_PLANE_AUTH_SECRET", "secret")
+    patch_mod.apply()
+
+    handler = _make_handler({})
+    result = fake_auth.check_auth(handler, _parsed("/health"))
+    assert result is True
+
+
+def test_static_path_bypasses_auth_after_patch(fresh_auth, monkeypatch):
+    fake_auth, patch_mod = fresh_auth
+    monkeypatch.setenv("FOX_PLANE_AUTH_SECRET", "secret")
+    patch_mod.apply()
+
+    handler = _make_handler({})
+    result = fake_auth.check_auth(handler, _parsed("/static/css/main.css"))
+    assert result is True
+
+
+# ── Non-API path gets 302 redirect ──────────────────────────────────────────
+
+def test_non_api_path_gets_redirect(fresh_auth, monkeypatch):
+    fake_auth, patch_mod = fresh_auth
+    monkeypatch.setenv("FOX_PLANE_AUTH_SECRET", "secret")
+    patch_mod.apply()
+
+    handler = _make_handler({})
+    result = fake_auth.check_auth(handler, _parsed("/dashboard"))
+    assert result is False
+    assert handler._sent_status == 302
+
+
+# ── Constant-time comparison helper ──────────────────────────────────────────
+
+def test_hmac_compare_equal():
+    from fox_overlay.webui_patches.auth import _hmac_compare
+    assert _hmac_compare("abc", "abc") is True
+
+
+def test_hmac_compare_not_equal():
+    from fox_overlay.webui_patches.auth import _hmac_compare
+    assert _hmac_compare("abc", "xyz") is False
+
+
+def test_hmac_compare_empty():
+    from fox_overlay.webui_patches.auth import _hmac_compare
+    assert _hmac_compare("", "") is True
+
+
+def test_fox_get_plane_secret_returns_env(monkeypatch):
+    from fox_overlay.webui_patches.auth import _fox_get_plane_secret
+    monkeypatch.setenv("FOX_PLANE_AUTH_SECRET", "test-secret")
+    assert _fox_get_plane_secret() == "test-secret"
+
+
+def test_fox_get_plane_secret_returns_empty_when_unset(monkeypatch):
+    from fox_overlay.webui_patches.auth import _fox_get_plane_secret
+    monkeypatch.delenv("FOX_PLANE_AUTH_SECRET", raising=False)
+    assert _fox_get_plane_secret() == ""


### PR DESCRIPTION
## Summary

Implement INSTANCE_CONTRACT §3.1 — runtime substitution of `check_auth()` in `api/auth.py` to insert the X-Fox-Auth accept path (PATH 5) for control-plane authentication.

- **Auth patch module** — `webui_patches/auth.py` uses `substitute_function` to inject PATH 5 (X-Fox-Auth header validation via `hmac.compare_digest`) between the public-path check and the session-cookie check. The shared secret is read from `FOX_PLANE_AUTH_SECRET` env var.
- **Standalone no-op** — when `FOX_PLANE_AUTH_SECRET` is not set, the substituted code is a no-op. The instance behaves byte-identically to vanilla Hermes.
- **Constant-time comparison** — uses `hmac.compare_digest` with UTF-8 encoding to prevent timing attacks on the shared secret.

### Deferred / out of scope

- Boot-time invariant (FOX_PLANE_AUTH_SECRET requires upstream auth enabled) is AUTH-02
- mTLS upgrade path mentioned in §3.1 is a future concern

## Test plan

- [x] 20 unit tests covering: module load, signature drift, anchor presence, patch application, idempotency, valid/invalid/empty/missing X-Fox-Auth, standalone mode, public path bypass, non-API redirect, hmac helper, env var helper
- [x] Full fox-overlay test suite green
- [ ] On-target verification:
  - Managed mode: `curl -H "X-Fox-Auth: <secret>" http://localhost:8080/api/config` returns 200
  - Invalid secret: returns 401
  - Standalone mode: no behavioral change from vanilla Hermes

Closes #475