### PR TITLE
feat(overlay): boot-time managed-mode invariant (#474)

### DIFF
--- a/packages/fox-overlay/fox_overlay/bootstrap.py
+++ b/packages/fox-overlay/fox_overlay/bootstrap.py
@@ -26,12 +26,56 @@ _INSTALLED = False
 _INSTALL_LOCK = threading.Lock()
 
 
+def _check_managed_mode_invariant() -> None:
+    """Refuse to boot if FOX_PLANE_AUTH_SECRET is set but upstream auth is disabled.
+
+    ENTERPRISE_ARCHITECTURE.md §5.4: managed-mode requires upstream auth
+    (password or passkeys) so that check_auth's PATH 4 rejects sessionless,
+    secretless callers. Without upstream auth, is_auth_enabled() returns
+    False and check_auth's PATH 1 bypasses ALL auth — making
+    FOX_PLANE_AUTH_SECRET meaningless and the instance wide-open.
+
+    Standalone mode (no FOX_PLANE_AUTH_SECRET) skips this check entirely.
+    """
+    secret = os.environ.get("FOX_PLANE_AUTH_SECRET", "")
+    if not secret:
+        return
+
+    try:
+        from api.auth import is_auth_enabled
+    except ImportError:
+        _log.warning(
+            "[fox-overlay] cannot import api.auth to check managed-mode invariant; "
+            "skipping (non-webui context)"
+        )
+        return
+
+    if not is_auth_enabled():
+        _msg = (
+            "[fox-overlay] FATAL: FOX_PLANE_AUTH_SECRET is set but upstream auth "
+            "is disabled (no password, no passkeys). Managed mode requires upstream "
+            "auth — without it, check_auth bypasses ALL authentication. Either set "
+            "HERMES_WEBUI_PASSWORD / configure passkeys, or remove "
+            "FOX_PLANE_AUTH_SECRET to run in standalone mode."
+        )
+        _log.critical(_msg)
+        try:
+            import sys
+            print(_msg, file=sys.stderr)
+        except Exception:
+            pass
+        raise SystemExit(1)
+
+
 def install() -> None:
     """Apply Fox overlay to a running hermes-webui process. Idempotent + thread-safe."""
     global _INSTALLED
     with _INSTALL_LOCK:
         if _INSTALLED:
             return
+
+        _check_managed_mode_invariant()
+
         # Phase 5: import webui_modules — each sub-module calls
         # dispatch.register_get/register_post() at module-load time. Wrap
         # in ImportError so a missing sub-module surfaces as a warning but

--- a/packages/fox-overlay/tests/test_boot_invariant.py
+++ b/packages/fox-overlay/tests/test_boot_invariant.py
@@ -1,0 +1,124 @@
+"""Regression tests for AUTH-02: managed-mode boot invariant.
+
+Covers:
+* FOX_PLANE_AUTH_SECRET set + auth disabled → SystemExit(1)
+* FOX_PLANE_AUTH_SECRET set + auth enabled → no error
+* Standalone mode (no secret) → no check performed
+* api.auth not importable → warning, no crash
+"""
+import importlib
+import sys
+
+import pytest
+
+
+_UPSTREAM_AUTH_ENABLED = '''\
+def is_auth_enabled() -> bool:
+    return True
+
+def is_password_auth_enabled():
+    return True
+
+def are_passkeys_enabled():
+    return False
+'''
+
+_UPSTREAM_AUTH_DISABLED = '''\
+def is_auth_enabled() -> bool:
+    return False
+
+def is_password_auth_enabled():
+    return False
+
+def are_passkeys_enabled():
+    return False
+'''
+
+
+def _install_auth_stub(tmp_path, source, monkeypatch):
+    api_dir = tmp_path / "api"
+    api_dir.mkdir(exist_ok=True)
+    (api_dir / "__init__.py").write_text("")
+    (api_dir / "auth.py").write_text(source)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    for name in list(sys.modules):
+        if name == "api" or name.startswith("api."):
+            del sys.modules[name]
+
+
+def _reload_bootstrap(monkeypatch):
+    monkeypatch.setenv("FOX_OVERLAY_AUTOINSTALL", "0")
+    import fox_overlay.bootstrap as b
+    importlib.reload(b)
+    return b
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_api_modules():
+    yield
+    for name in list(sys.modules):
+        if name == "api" or name.startswith("api."):
+            del sys.modules[name]
+
+
+def test_secret_set_auth_disabled_exits(tmp_path, monkeypatch):
+    """FOX_PLANE_AUTH_SECRET + auth disabled → SystemExit(1)."""
+    _install_auth_stub(tmp_path, _UPSTREAM_AUTH_DISABLED, monkeypatch)
+    monkeypatch.setenv("FOX_PLANE_AUTH_SECRET", "test-secret")
+    b = _reload_bootstrap(monkeypatch)
+
+    with pytest.raises(SystemExit) as exc_info:
+        b._check_managed_mode_invariant()
+    assert exc_info.value.code == 1
+
+
+def test_secret_set_auth_enabled_ok(tmp_path, monkeypatch):
+    """FOX_PLANE_AUTH_SECRET + auth enabled → no error."""
+    _install_auth_stub(tmp_path, _UPSTREAM_AUTH_ENABLED, monkeypatch)
+    monkeypatch.setenv("FOX_PLANE_AUTH_SECRET", "test-secret")
+    b = _reload_bootstrap(monkeypatch)
+
+    b._check_managed_mode_invariant()
+
+
+def test_standalone_no_secret_skips_check(monkeypatch):
+    """No FOX_PLANE_AUTH_SECRET → check is a no-op."""
+    monkeypatch.delenv("FOX_PLANE_AUTH_SECRET", raising=False)
+    b = _reload_bootstrap(monkeypatch)
+
+    b._check_managed_mode_invariant()
+
+
+def test_standalone_empty_secret_skips_check(monkeypatch):
+    """Empty FOX_PLANE_AUTH_SECRET → treated as unset."""
+    monkeypatch.setenv("FOX_PLANE_AUTH_SECRET", "")
+    b = _reload_bootstrap(monkeypatch)
+
+    b._check_managed_mode_invariant()
+
+
+def test_api_auth_not_importable_warns(tmp_path, monkeypatch, caplog):
+    """If api.auth can't be imported, warn but don't crash."""
+    for name in list(sys.modules):
+        if name == "api" or name.startswith("api."):
+            del sys.modules[name]
+    monkeypatch.setenv("FOX_PLANE_AUTH_SECRET", "test-secret")
+    b = _reload_bootstrap(monkeypatch)
+
+    import logging
+    with caplog.at_level(logging.WARNING, logger="fox_overlay.bootstrap"):
+        b._check_managed_mode_invariant()
+    assert any("cannot import api.auth" in r.message for r in caplog.records)
+
+
+def test_exit_message_mentions_remediation(tmp_path, monkeypatch, capsys):
+    """Error message should tell the operator how to fix the problem."""
+    _install_auth_stub(tmp_path, _UPSTREAM_AUTH_DISABLED, monkeypatch)
+    monkeypatch.setenv("FOX_PLANE_AUTH_SECRET", "test-secret")
+    b = _reload_bootstrap(monkeypatch)
+
+    with pytest.raises(SystemExit):
+        b._check_managed_mode_invariant()
+
+    captured = capsys.readouterr()
+    assert "HERMES_WEBUI_PASSWORD" in captured.err or "standalone mode" in captured.err

--- a/packages/fox-overlay/tests/test_boot_invariant.py
+++ b/packages/fox-overlay/tests/test_boot_invariant.py
@@ -97,13 +97,16 @@ def test_standalone_empty_secret_skips_check(monkeypatch):
     b._check_managed_mode_invariant()
 
 
-def test_api_auth_not_importable_warns(tmp_path, monkeypatch, caplog):
+def test_api_auth_not_importable_warns(monkeypatch, caplog):
     """If api.auth can't be imported, warn but don't crash."""
-    for name in list(sys.modules):
-        if name == "api" or name.startswith("api."):
-            del sys.modules[name]
     monkeypatch.setenv("FOX_PLANE_AUTH_SECRET", "test-secret")
     b = _reload_bootstrap(monkeypatch)
+
+    for name in list(sys.modules):
+        if name == "api" or name.startswith("api."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    monkeypatch.setitem(sys.modules, "api", None)
+    monkeypatch.setitem(sys.modules, "api.auth", None)
 
     import logging
     with caplog.at_level(logging.WARNING, logger="fox_overlay.bootstrap"):


### PR DESCRIPTION
## Summary

Implement ENTERPRISE_ARCHITECTURE §5.4 — when `FOX_PLANE_AUTH_SECRET` is set but upstream auth is disabled (`HERMES_WEBUI_PASSWORD` not set and passkeys not enabled), the instance refuses to boot with `SystemExit(1)`.

- **Invariant check** — `_check_managed_mode_invariant()` runs early in `bootstrap.install()`, before Phase 5 module loading. Prints the error to stderr and logs at CRITICAL level.
- **Graceful degradation** — if `api.auth` can't be imported (non-webui context like tests or REPL), logs a warning and continues rather than blocking.
- **Standalone no-op** — when `FOX_PLANE_AUTH_SECRET` is not set or empty, the check is skipped entirely.

### Deferred / out of scope

- The invariant error message includes remediation guidance (set HERMES_WEBUI_PASSWORD or remove FOX_PLANE_AUTH_SECRET)

## Test plan

- [x] 6 unit tests covering: secret+auth_disabled→exit, secret+auth_enabled→ok, no_secret→skip, empty_secret→skip, api.auth_not_importable→warn, exit_message_mentions_remediation
- [x] Full fox-overlay test suite green
- [ ] On-target verification:
  - Set FOX_PLANE_AUTH_SECRET without HERMES_WEBUI_PASSWORD: container should refuse to start
  - Set both: container starts normally
  - Unset FOX_PLANE_AUTH_SECRET: container starts normally (standalone)

Closes #474