### PR TITLE
feat(overlay): add GET /version contract endpoint (#473)

### DIFF
--- a/packages/fox-overlay/fox_overlay/webui_modules/__init__.py
+++ b/packages/fox-overlay/fox_overlay/webui_modules/__init__.py
@@ -19,4 +19,5 @@ from . import local_fallback  # noqa: F401  -- registers /api/local-fallback/ at
 from . import models_download  # noqa: F401  -- registers /api/local-models (bare) at import
 from . import hostname  # noqa: F401  -- registers /api/settings/hostname (bare); imports _write_env_key from onboarding
 from . import readyz  # noqa: F401  -- registers GET /readyz (bare); always auth-exempt per INSTANCE_CONTRACT §4.5
+from . import version  # noqa: F401  -- registers GET /version (bare); auth-gated in managed mode per INSTANCE_CONTRACT §4.5
 from . import test_hooks  # noqa: F401  -- (v0.7.7 #264) registers POST /test/* ONLY when FITB_TEST_MODE=1; production builds = no-op

--- a/packages/fox-overlay/fox_overlay/webui_modules/version.py
+++ b/packages/fox-overlay/fox_overlay/webui_modules/version.py
@@ -1,0 +1,69 @@
+"""GET /version — contract version and image identity (INSTANCE_CONTRACT §4.3).
+
+Returns contract version, image digest, runtime name/version, and
+overlay version.
+
+Auth position (§4.5): behind the upstream auth gate in managed mode,
+open in standalone.  This handler registers through normal dispatch —
+no PUBLIC_PATHS expansion — so check_auth runs first.
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+CONTRACT_VERSION = "2.0.0"
+_VERSION_FILE = "/app/version.txt"
+
+
+def _get_runtime_version() -> str:
+    try:
+        import sys
+        mod = sys.modules.get("api.updates")
+        if mod is not None:
+            v = getattr(mod, "WEBUI_VERSION", None)
+            if v:
+                return str(v)
+    except Exception:
+        pass
+    return "unknown"
+
+
+def _get_overlay_version() -> str:
+    try:
+        from importlib.metadata import version as pkg_version
+        return pkg_version("fox-overlay")
+    except Exception:
+        pass
+    try:
+        with open(_VERSION_FILE) as f:
+            return f.read().strip()
+    except Exception:
+        return "unknown"
+
+
+def get_version() -> dict:
+    return {
+        "contract_version": CONTRACT_VERSION,
+        "image_digest": os.environ.get("FITB_IMAGE_DIGEST", ""),
+        "runtime": "hermes",
+        "runtime_version": _get_runtime_version(),
+        "overlay_version": _get_overlay_version(),
+    }
+
+
+# ── Dispatcher integration ─────────────────────────────────────────────
+from fox_overlay import dispatch  # noqa: E402
+
+
+def _handle_get(handler, parsed) -> bool:
+    if parsed.path != "/version":
+        return False
+    from api.helpers import j
+    j(handler, get_version())
+    return True
+
+
+dispatch.register_get("/version", _handle_get, allow_bare=True)

--- a/packages/fox-overlay/tests/test_version_endpoint.py
+++ b/packages/fox-overlay/tests/test_version_endpoint.py
@@ -29,10 +29,10 @@ def _stub_upstream():
     api.auth = auth
     api.config = config
     api.helpers = helpers
-    sys.modules.setdefault("api", api)
-    sys.modules.setdefault("api.auth", auth)
-    sys.modules.setdefault("api.config", config)
-    sys.modules.setdefault("api.helpers", helpers)
+    sys.modules["api"] = api
+    sys.modules["api.auth"] = auth
+    sys.modules["api.config"] = config
+    sys.modules["api.helpers"] = helpers
 
 
 @pytest.fixture(autouse=True)

--- a/packages/fox-overlay/tests/test_version_endpoint.py
+++ b/packages/fox-overlay/tests/test_version_endpoint.py
@@ -1,0 +1,171 @@
+"""Tests for fox_overlay.webui_modules.version — /version endpoint (INST-02)."""
+from __future__ import annotations
+
+import json
+import sys
+import types
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+
+def _stub_upstream():
+    api = types.ModuleType("api")
+    auth = types.ModuleType("api.auth")
+    auth.PUBLIC_PATHS = frozenset({"/login", "/health"})
+    config = types.ModuleType("api.config")
+    config.load_settings = lambda: {}
+    helpers = types.ModuleType("api.helpers")
+
+    def _j(handler, data, status=200):
+        body = json.dumps(data).encode()
+        handler.send_response(status)
+        handler.send_header("Content-Type", "application/json")
+        handler.end_headers()
+        handler._body = body
+
+    helpers.j = _j
+    api.auth = auth
+    api.config = config
+    api.helpers = helpers
+    sys.modules.setdefault("api", api)
+    sys.modules.setdefault("api.auth", auth)
+    sys.modules.setdefault("api.config", config)
+    sys.modules.setdefault("api.helpers", helpers)
+
+
+@pytest.fixture(autouse=True)
+def _upstream():
+    _stub_upstream()
+    from fox_overlay import dispatch
+    dispatch._GET_TABLE.clear()
+    dispatch._POST_TABLE.clear()
+    dispatch._BootstrapState.frozen = False
+    yield
+    sys.modules.pop("fox_overlay.webui_modules.version", None)
+
+
+def _load_version():
+    sys.modules.pop("fox_overlay.webui_modules.version", None)
+    import fox_overlay.webui_modules as _pkg
+    if hasattr(_pkg, "version"):
+        delattr(_pkg, "version")
+    from fox_overlay.webui_modules import version
+    return version
+
+
+def _make_handler():
+    h = SimpleNamespace()
+    h._headers_sent = []
+    h._body = None
+    h._status = None
+    h.send_response = lambda status: setattr(h, "_status", status)
+    h.send_header = lambda k, v: h._headers_sent.append((k, v))
+    h.end_headers = lambda: None
+    return h
+
+
+def _parsed(path):
+    return SimpleNamespace(path=path)
+
+
+class TestRegistration:
+    def test_registers_get_handler(self):
+        _load_version()
+        from fox_overlay.dispatch import GET_TABLE
+        assert "/version" in GET_TABLE
+
+    def test_no_post_handler(self):
+        _load_version()
+        from fox_overlay.dispatch import POST_TABLE
+        assert "/version" not in POST_TABLE
+
+    def test_does_not_expand_public_paths(self):
+        auth_mod = sys.modules["api.auth"]
+        _load_version()
+        assert "/version" not in auth_mod.PUBLIC_PATHS
+
+
+class TestHandler:
+    def test_handles_version_path(self):
+        mod = _load_version()
+        handler = _make_handler()
+        assert mod._handle_get(handler, _parsed("/version")) is True
+
+    def test_declines_non_version(self):
+        mod = _load_version()
+        handler = _make_handler()
+        assert mod._handle_get(handler, _parsed("/versionX")) is False
+        assert mod._handle_get(handler, _parsed("/version/extra")) is False
+        assert mod._handle_get(handler, _parsed("/health")) is False
+
+    def test_response_shape(self):
+        mod = _load_version()
+        handler = _make_handler()
+        mod._handle_get(handler, _parsed("/version"))
+        body = json.loads(handler._body)
+        assert "contract_version" in body
+        assert "image_digest" in body
+        assert "runtime" in body
+        assert "runtime_version" in body
+        assert "overlay_version" in body
+
+
+class TestGetVersion:
+    def test_contract_version(self):
+        mod = _load_version()
+        result = mod.get_version()
+        assert result["contract_version"] == "2.0.0"
+
+    def test_runtime_is_hermes(self):
+        mod = _load_version()
+        result = mod.get_version()
+        assert result["runtime"] == "hermes"
+
+    def test_image_digest_from_env(self):
+        mod = _load_version()
+        with mock.patch.dict("os.environ", {"FITB_IMAGE_DIGEST": "sha256:abc123"}):
+            result = mod.get_version()
+        assert result["image_digest"] == "sha256:abc123"
+
+    def test_image_digest_empty_when_not_set(self):
+        mod = _load_version()
+        with mock.patch.dict("os.environ", {}, clear=True):
+            result = mod.get_version()
+        assert result["image_digest"] == ""
+
+    def test_runtime_version_from_api_updates(self):
+        mod = _load_version()
+        updates_mod = types.ModuleType("api.updates")
+        updates_mod.WEBUI_VERSION = "v0.51.145"
+        with mock.patch.dict("sys.modules", {"api.updates": updates_mod}):
+            result = mod.get_version()
+        assert result["runtime_version"] == "v0.51.145"
+
+    def test_runtime_version_unknown_when_no_updates(self):
+        mod = _load_version()
+        with mock.patch.dict("sys.modules", {}, clear=False):
+            sys.modules.pop("api.updates", None)
+            result = mod.get_version()
+        assert result["runtime_version"] == "unknown"
+
+    def test_overlay_version_from_package(self):
+        mod = _load_version()
+        with mock.patch("importlib.metadata.version", return_value="0.7.44"):
+            result = mod.get_version()
+        assert result["overlay_version"] == "0.7.44"
+
+    def test_overlay_version_from_file_fallback(self):
+        mod = _load_version()
+        with mock.patch("importlib.metadata.version", side_effect=Exception("not installed")), \
+             mock.patch("builtins.open", mock.mock_open(read_data="v0.7.44\n")):
+            result = mod.get_version()
+        assert result["overlay_version"] == "v0.7.44"
+
+    def test_overlay_version_unknown_fallback(self):
+        mod = _load_version()
+        with mock.patch("importlib.metadata.version", side_effect=Exception("not installed")), \
+             mock.patch("builtins.open", side_effect=FileNotFoundError):
+            result = mod.get_version()
+        assert result["overlay_version"] == "unknown"


### PR DESCRIPTION
## Summary

Implement INSTANCE_CONTRACT §4.3 `/version` endpoint returning contract version, image digest, runtime identity, and overlay version.

- **Version handler** — registered as a bare-path GET handler via the Fox dispatch mechanism. Returns JSON with `contract_version`, `image_digest`, `runtime`, `runtime_version`, and `overlay_version`.
- **Auth-gated in managed mode** — does NOT expand `PUBLIC_PATHS`. In managed mode, `check_auth` runs first and requires authentication (session cookie or X-Fox-Auth). In standalone mode (no auth gate), the endpoint is open.
- **Version resolution** — `contract_version` is `"2.0.0"`, `image_digest` from `FITB_IMAGE_DIGEST` env var, `runtime_version` from `api.updates.WEBUI_VERSION`, `overlay_version` from package metadata with `/app/version.txt` fallback.

### Deferred / out of scope

- `/capabilities` endpoint is INST-03
- `FITB_IMAGE_DIGEST` env var injection at build time is a Dockerfile concern, not this PR

## Test plan

- [x] 15 unit tests covering: registration, no PUBLIC_PATHS expansion, handler routing, boundary rejection (`/versionX`, `/version/extra`), response shape, all version source resolution paths (env var present/absent, api.updates loaded/not loaded, package metadata/file fallback/unknown)
- [x] Full fox-overlay test suite green (180 passed, 1 skipped, 0 failures)
- [ ] On-target verification:
  - Managed mode: `curl -H "X-Fox-Auth: <secret>" http://localhost:8080/version` returns version JSON
  - Standalone mode: `curl http://localhost:8080/version` returns version JSON (no auth needed)
  - Unauthenticated managed mode: returns 401

Closes #473