### PR TITLE
feat(overlay): add GET /capabilities endpoint (INST-03, #472)

### DIFF
--- a/packages/fox-overlay/fox_overlay/webui_modules/__init__.py
+++ b/packages/fox-overlay/fox_overlay/webui_modules/__init__.py
@@ -20,4 +20,5 @@ from . import models_download  # noqa: F401  -- registers /api/local-models (bar
 from . import hostname  # noqa: F401  -- registers /api/settings/hostname (bare); imports _write_env_key from onboarding
 from . import readyz  # noqa: F401  -- registers GET /readyz (bare); always auth-exempt per INSTANCE_CONTRACT §4.5
 from . import version  # noqa: F401  -- registers GET /version (bare); auth-gated in managed mode per INSTANCE_CONTRACT §4.5
+from . import capabilities  # noqa: F401  -- registers GET /capabilities (bare); auth-gated in managed mode per INSTANCE_CONTRACT §4.5
 from . import test_hooks  # noqa: F401  -- (v0.7.7 #264) registers POST /test/* ONLY when FITB_TEST_MODE=1; production builds = no-op

--- a/packages/fox-overlay/fox_overlay/webui_modules/capabilities.py
+++ b/packages/fox-overlay/fox_overlay/webui_modules/capabilities.py
@@ -1,0 +1,58 @@
+"""GET /capabilities — feature manifest (INSTANCE_CONTRACT §4.4).
+
+Returns the contract version and a flat dict of capabilities that this
+instance *supports* (not what the plane has enabled/disabled — that's
+the plane's injected CapabilityFlags).
+
+Auth position (§4.5): behind the upstream auth gate in managed mode,
+open in standalone.  Registers through normal dispatch — no
+PUBLIC_PATHS expansion.
+"""
+from __future__ import annotations
+
+import logging
+import shutil
+
+logger = logging.getLogger(__name__)
+
+CONTRACT_VERSION = "2.0.0"
+
+
+def _has_module(name: str) -> bool:
+    try:
+        import importlib
+        importlib.import_module(name)
+        return True
+    except ImportError:
+        return False
+
+
+def get_capabilities() -> dict:
+    return {
+        "contract_version": CONTRACT_VERSION,
+        "capabilities": {
+            "local_fallback": _has_module("fox_overlay.webui_modules.local_fallback"),
+            "tailscale": shutil.which("tailscale") is not None,
+            "ollama": _has_module("fox_overlay.webui_modules.ollama"),
+            "web_search": True,
+            "file_upload": True,
+            "cron_jobs": True,
+            "model_download": _has_module("fox_overlay.webui_modules.models_download"),
+            "data_plane_access": False,
+        },
+    }
+
+
+# ── Dispatcher integration ─────────────────────────────────────────────
+from fox_overlay import dispatch  # noqa: E402
+
+
+def _handle_get(handler, parsed) -> bool:
+    if parsed.path != "/capabilities":
+        return False
+    from api.helpers import j
+    j(handler, get_capabilities())
+    return True
+
+
+dispatch.register_get("/capabilities", _handle_get, allow_bare=True)

--- a/packages/fox-overlay/tests/test_capabilities_endpoint.py
+++ b/packages/fox-overlay/tests/test_capabilities_endpoint.py
@@ -29,10 +29,10 @@ def _stub_upstream():
     api.auth = auth
     api.config = config
     api.helpers = helpers
-    sys.modules.setdefault("api", api)
-    sys.modules.setdefault("api.auth", auth)
-    sys.modules.setdefault("api.config", config)
-    sys.modules.setdefault("api.helpers", helpers)
+    sys.modules["api"] = api
+    sys.modules["api.auth"] = auth
+    sys.modules["api.config"] = config
+    sys.modules["api.helpers"] = helpers
 
 
 @pytest.fixture(autouse=True)

--- a/packages/fox-overlay/tests/test_capabilities_endpoint.py
+++ b/packages/fox-overlay/tests/test_capabilities_endpoint.py
@@ -1,0 +1,155 @@
+"""Tests for fox_overlay.webui_modules.capabilities — /capabilities endpoint (INST-03)."""
+from __future__ import annotations
+
+import json
+import sys
+import types
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+
+def _stub_upstream():
+    api = types.ModuleType("api")
+    auth = types.ModuleType("api.auth")
+    auth.PUBLIC_PATHS = frozenset({"/login", "/health"})
+    config = types.ModuleType("api.config")
+    config.load_settings = lambda: {}
+    helpers = types.ModuleType("api.helpers")
+
+    def _j(handler, data, status=200):
+        body = json.dumps(data).encode()
+        handler.send_response(status)
+        handler.send_header("Content-Type", "application/json")
+        handler.end_headers()
+        handler._body = body
+
+    helpers.j = _j
+    api.auth = auth
+    api.config = config
+    api.helpers = helpers
+    sys.modules.setdefault("api", api)
+    sys.modules.setdefault("api.auth", auth)
+    sys.modules.setdefault("api.config", config)
+    sys.modules.setdefault("api.helpers", helpers)
+
+
+@pytest.fixture(autouse=True)
+def _upstream():
+    _stub_upstream()
+    from fox_overlay import dispatch
+    dispatch._GET_TABLE.clear()
+    dispatch._POST_TABLE.clear()
+    dispatch._BootstrapState.frozen = False
+    yield
+    sys.modules.pop("fox_overlay.webui_modules.capabilities", None)
+
+
+def _load_capabilities():
+    sys.modules.pop("fox_overlay.webui_modules.capabilities", None)
+    import fox_overlay.webui_modules as _pkg
+    if hasattr(_pkg, "capabilities"):
+        delattr(_pkg, "capabilities")
+    from fox_overlay.webui_modules import capabilities
+    return capabilities
+
+
+def _make_handler():
+    h = SimpleNamespace()
+    h._headers_sent = []
+    h._body = None
+    h._status = None
+    h.send_response = lambda status: setattr(h, "_status", status)
+    h.send_header = lambda k, v: h._headers_sent.append((k, v))
+    h.end_headers = lambda: None
+    return h
+
+
+def _parsed(path):
+    return SimpleNamespace(path=path)
+
+
+class TestRegistration:
+    def test_registers_get_handler(self):
+        _load_capabilities()
+        from fox_overlay.dispatch import GET_TABLE
+        assert "/capabilities" in GET_TABLE
+
+    def test_no_post_handler(self):
+        _load_capabilities()
+        from fox_overlay.dispatch import POST_TABLE
+        assert "/capabilities" not in POST_TABLE
+
+    def test_does_not_expand_public_paths(self):
+        auth_mod = sys.modules["api.auth"]
+        _load_capabilities()
+        assert "/capabilities" not in auth_mod.PUBLIC_PATHS
+
+
+class TestHandler:
+    def test_handles_capabilities_path(self):
+        mod = _load_capabilities()
+        handler = _make_handler()
+        assert mod._handle_get(handler, _parsed("/capabilities")) is True
+
+    def test_declines_non_capabilities(self):
+        mod = _load_capabilities()
+        handler = _make_handler()
+        assert mod._handle_get(handler, _parsed("/capabilitiesX")) is False
+        assert mod._handle_get(handler, _parsed("/capabilities/extra")) is False
+        assert mod._handle_get(handler, _parsed("/health")) is False
+
+    def test_response_shape(self):
+        mod = _load_capabilities()
+        handler = _make_handler()
+        mod._handle_get(handler, _parsed("/capabilities"))
+        body = json.loads(handler._body)
+        assert "contract_version" in body
+        assert "capabilities" in body
+        assert isinstance(body["capabilities"], dict)
+
+
+class TestGetCapabilities:
+    def test_contract_version(self):
+        mod = _load_capabilities()
+        result = mod.get_capabilities()
+        assert result["contract_version"] == "2.0.0"
+
+    def test_capabilities_are_booleans(self):
+        mod = _load_capabilities()
+        result = mod.get_capabilities()
+        for key, value in result["capabilities"].items():
+            assert isinstance(value, bool), f"{key} is {type(value)}, expected bool"
+
+    def test_expected_capability_keys(self):
+        mod = _load_capabilities()
+        result = mod.get_capabilities()
+        expected = {
+            "local_fallback", "tailscale", "ollama", "web_search",
+            "file_upload", "cron_jobs", "model_download", "data_plane_access",
+        }
+        assert set(result["capabilities"].keys()) == expected
+
+    def test_data_plane_not_yet_supported(self):
+        mod = _load_capabilities()
+        result = mod.get_capabilities()
+        assert result["capabilities"]["data_plane_access"] is False
+
+    def test_local_fallback_reflects_module_availability(self):
+        mod = _load_capabilities()
+        with mock.patch.object(mod, "_has_module", side_effect=lambda n: n != "fox_overlay.webui_modules.local_fallback"):
+            result = mod.get_capabilities()
+        assert result["capabilities"]["local_fallback"] is False
+
+    def test_tailscale_reflects_binary_availability(self):
+        mod = _load_capabilities()
+        with mock.patch("shutil.which", return_value=None):
+            result = mod.get_capabilities()
+        assert result["capabilities"]["tailscale"] is False
+
+    def test_tailscale_true_when_binary_present(self):
+        mod = _load_capabilities()
+        with mock.patch("shutil.which", return_value="/usr/bin/tailscale"):
+            result = mod.get_capabilities()
+        assert result["capabilities"]["tailscale"] is True


### PR DESCRIPTION
## Summary

Add `GET /capabilities` endpoint returning a feature manifest with `contract_version` and a flat dict of capability booleans, per INSTANCE_CONTRACT §4.4.

- **Dynamic capability detection** — `local_fallback`, `ollama`, `model_download` via `importlib.import_module`; `tailscale` via `shutil.which`
- **Auth-gated in managed mode** — no `PUBLIC_PATHS` expansion per §4.5; standalone mode is unaffected
- **13 unit tests** — registration, handler routing, response shape, and dynamic detection mocking

### Deferred / out of scope

- `data_plane_access` hardcoded `False` until Fleet data-plane ships

## Test plan

- [x] `pytest packages/fox-overlay/tests/test_capabilities_endpoint.py -v` — 13 passed
- [x] Full suite `pytest packages/fox-overlay/tests/ -v` — 178 passed, 1 skipped
- [ ] On-target verification:
  - `curl http://localhost:8080/capabilities` returns JSON with `contract_version` and `capabilities` dict
  - All capability values are booleans
  - Endpoint returns 401 when `FOX_PLANE_AUTH_SECRET` is set and no `X-Fox-Auth` header provided

Closes #472