### PR TITLE
Align CODEOWNERS to @roadhero across all repos

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # Default — all PRs require review from a maintainer
-* @bsgdigital
+* @roadhero
 
 # CI/CD and security-sensitive files
-.github/ @bsgdigital
-SECURITY.md @bsgdigital
-packages/integration/Dockerfile @bsgdigital
-packages/fox-overlay/ @bsgdigital
+.github/ @roadhero
+SECURITY.md @roadhero
+packages/integration/Dockerfile @roadhero
+packages/fox-overlay/ @roadhero


### PR DESCRIPTION
## Summary

- **Replace `@bsgdigital` with `@roadhero`** in all CODEOWNERS entries — aligns fox-in-the-box with fox-fleet and fox-fleet-enterprise, which already use `@roadhero`.

### Deferred / out of scope

- fox-contracts CODEOWNERS will be added in a separate PR to that repo.

## Test plan

- [x] All CODEOWNERS entries now reference `@roadhero`
- [ ] CI green on this PR