### PR TITLE
fix: exempt contract endpoints from onboarding redirect

### DIFF
--- a/packages/fox-overlay/fox_overlay/webui_modules/onboarding.py
+++ b/packages/fox-overlay/fox_overlay/webui_modules/onboarding.py
@@ -55,6 +55,12 @@ _SETUP_PREFIXES = (
     # against a fresh container without first completing onboarding.
     # Same shape as the /test/ whitelist above.
     "/api/models",
+    # Contract endpoints: Fleet conformance suite probes these before
+    # onboarding completes. Auth is handled by check_auth (X-Fox-Auth
+    # or session cookie), not by onboarding state.
+    "/readyz",
+    "/version",
+    "/capabilities",
 )
 
 

--- a/packages/fox-overlay/fox_overlay/webui_patches/auth.py
+++ b/packages/fox-overlay/fox_overlay/webui_patches/auth.py
@@ -10,8 +10,8 @@ this header on every request to a managed instance.
 One substitution inserts a block BEFORE ``cookie_val = parse_cookie(handler)``
 (after public-path checks, before session-cookie checks). The block:
 
-1. Reads ``FOX_PLANE_AUTH_SECRET`` from the environment (cached at
-   patch time — the secret doesn't change at runtime).
+1. Reads ``FOX_PLANE_AUTH_SECRET`` from the environment on each
+   request (supports secret rotation without restart).
 2. If the env var is unset or empty, skips (standalone mode — no-op).
 3. Reads ``X-Fox-Auth`` from the request headers.
 4. Compares with ``hmac.compare_digest`` (constant-time).


### PR DESCRIPTION
## Summary

Ensures Fleet conformance suite can reach contract endpoints on a Fox instance that hasn't completed onboarding yet.

- **FOX-01** — Add `/readyz`, `/version`, `/capabilities` to `_SETUP_PREFIXES` in onboarding.py so they aren't redirected to `/setup`. Auth is still enforced by `check_auth` (X-Fox-Auth or session cookie) — this only removes the onboarding-state gate.
- **FOX-02** — Fix auth.py docstring: `FOX_PLANE_AUTH_SECRET` is read per-request via `os.environ.get()`, not cached at patch time as the docstring claimed.

### Deferred / out of scope

- INSTANCE_CONTRACT.md documentation updates (Wave 5, FOX-03)
- Conformance CI automation (Wave 4, FLEET-06)

## Test plan

- [x] Diff reviewed: both changes are additive strings to a tuple and a docstring correction
- [ ] On-target verification:
  - Start Fox container without onboarding completed
  - Verify `/readyz`, `/version`, `/capabilities` return 200 (standalone) or 302/401 without auth (managed)
  - Verify onboarding wizard flow unchanged
  - Wave 3 cross-repo gate: conformance suite against new image