### PR TITLE
fix: overlay_version returns real product version

### DIFF
--- a/packages/fox-overlay/fox_overlay/webui_modules/version.py
+++ b/packages/fox-overlay/fox_overlay/webui_modules/version.py
@@ -33,13 +33,15 @@ def _get_runtime_version() -> str:
 
 def _get_overlay_version() -> str:
     try:
-        from importlib.metadata import version as pkg_version
-        return pkg_version("fox-overlay")
+        with open(_VERSION_FILE) as f:
+            v = f.read().strip()
+            if v:
+                return v
     except Exception:
         pass
     try:
-        with open(_VERSION_FILE) as f:
-            return f.read().strip()
+        from importlib.metadata import version as pkg_version
+        return pkg_version("fox-overlay")
     except Exception:
         return "unknown"
 


### PR DESCRIPTION
## Summary

`/version` endpoint returned `overlay_version: "0.0.1"` because `_get_overlay_version()` tried `importlib.metadata` first, which reads pyproject.toml's placeholder value. Swapped resolution order to prefer `/app/version.txt` (the real product version in container), falling back to importlib.metadata for dev environments.

- **Resolution order swap** — `/app/version.txt` first, `importlib.metadata` second

### Deferred / out of scope

- pyproject.toml version sync — not needed now that the version file takes priority
- runtime_version fix (LOW-02) — separate PR

## Test plan

- [x] `pytest packages/fox-overlay/` — 238 passed, 1 skipped
- [ ] On-target: build container, verify `GET /version` returns real overlay_version

Closes LOW-01 from REVERIFICATION_2026-06-10.