### PR TITLE
fix: runtime_version returns real value via direct import

### DIFF
--- a/packages/fox-overlay/fox_overlay/webui_modules/version.py
+++ b/packages/fox-overlay/fox_overlay/webui_modules/version.py
@@ -20,12 +20,9 @@ _VERSION_FILE = "/app/version.txt"
 
 def _get_runtime_version() -> str:
     try:
-        import sys
-        mod = sys.modules.get("api.updates")
-        if mod is not None:
-            v = getattr(mod, "WEBUI_VERSION", None)
-            if v:
-                return str(v)
+        from api.updates import WEBUI_VERSION
+        if WEBUI_VERSION:
+            return str(WEBUI_VERSION)
     except Exception:
         pass
     return "unknown"


### PR DESCRIPTION
## Summary

`/version` endpoint returned `runtime_version: "unknown"` because `_get_runtime_version()` used `sys.modules.get("api.updates")` — a lookup that fails when the module hasn't been imported into the current process yet at endpoint call time. Changed to a direct `from api.updates import WEBUI_VERSION` which triggers the import and returns the real Hermes WebUI version.

- **Direct import** — replaces `sys.modules.get()` with `from api.updates import WEBUI_VERSION`

### Deferred / out of scope

- overlay_version fix (LOW-01) — separate PR #517

## Test plan

- [x] `pytest packages/fox-overlay/` — 238 passed, 1 skipped
- [ ] On-target: build container, verify `GET /version` returns real runtime_version

Closes LOW-02 from REVERIFICATION_2026-06-10.