### PR TITLE
fix: runtime_version returns real value via build-time injection

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -86,6 +86,8 @@ jobs:
             SHORT_SHA="$(echo "${{ github.sha }}" | cut -c1-7)"
             echo "fitb_version=dev-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
           fi
+          RUNTIME_VERSION=$(grep '^hermes_webui_tag' packages/fox-overlay/versions.toml | sed 's/.*= *"\(.*\)"/\1/')
+          echo "runtime_version=${RUNTIME_VERSION:-unknown}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push by digest
         id: build
@@ -105,6 +107,7 @@ jobs:
           cache-to:   type=gha,scope=cloud-${{ matrix.platform.short }},mode=max
           build-args: |
             FITB_VERSION=${{ steps.meta.outputs.fitb_version }}
+            FITB_RUNTIME_VERSION=${{ steps.meta.outputs.runtime_version }}
 
       - name: Export per-platform digest as artifact
         run: |

--- a/packages/fox-overlay/fox_overlay/webui_modules/version.py
+++ b/packages/fox-overlay/fox_overlay/webui_modules/version.py
@@ -16,9 +16,17 @@ logger = logging.getLogger(__name__)
 
 CONTRACT_VERSION = "2.0.0"
 _VERSION_FILE = "/app/version.txt"
+_RUNTIME_VERSION_FILE = "/app/runtime_version.txt"
 
 
 def _get_runtime_version() -> str:
+    try:
+        with open(_RUNTIME_VERSION_FILE) as f:
+            v = f.read().strip()
+            if v and v != "unknown":
+                return v
+    except Exception:
+        pass
     try:
         from api.updates import WEBUI_VERSION
         if WEBUI_VERSION:

--- a/packages/integration/Dockerfile
+++ b/packages/integration/Dockerfile
@@ -27,6 +27,7 @@ ARG LLAMACPP_VERSION=b9026
 # FITB_VERSION: written to /app/version.txt for migrations and display.
 # hermes-agent / hermes-webui are copied from forks/ at build time (requires submodules).
 ARG FITB_VERSION=v0.1.0
+ARG FITB_RUNTIME_VERSION=unknown
 # FITB_DEV=1: runtime uses bind-mounted repos under /root/.hermes/ (see dev-init.sh).
 ARG FITB_DEV=0
 
@@ -116,6 +117,7 @@ COPY packages/integration/default-configs/ /app/defaults/
 COPY packages/integration/app-root/version.txt /app/version.txt
 # Overwrite version.txt with the build-arg value (migrations / display).
 RUN echo "${FITB_VERSION}" > /app/version.txt
+RUN echo "${FITB_RUNTIME_VERSION}" > /app/runtime_version.txt
 
 # ── migration scripts ─────────────────────────────────────────────────────────
 COPY packages/integration/scripts/ /app/scripts/


### PR DESCRIPTION
## Summary

- **Build-time injection** — reads `hermes_webui_tag` from `versions.toml` during CI, writes to `/app/runtime_version.txt` via `FITB_RUNTIME_VERSION` build arg
- **Request-time resolution** — `_get_runtime_version()` reads `/app/runtime_version.txt` first, falls back to `api.updates.WEBUI_VERSION` (dev mode), then `"unknown"`

Same architecture as the existing `FITB_VERSION` → `/app/version.txt` pattern that fixed `overlay_version` (PR #517).

### Before

```json
{"runtime_version": "unknown"}
```

### After (container built from tagged release)

```json
{"runtime_version": "v0.51.293"}
```

### Deferred / out of scope

- The `api.updates.WEBUI_VERSION` import path still fails at handler time; this is the expected fallback, not the primary source

## Test plan

- [x] `grep` extracts `hermes_webui_tag` correctly from `versions.toml`
- [ ] CI builds image with `FITB_RUNTIME_VERSION` arg
- [ ] Container `/version` endpoint returns real runtime version
- [ ] Dev mode (no `/app/runtime_version.txt`) falls back gracefully