### PR TITLE
chore: add PR template with standing discipline checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Summary
+
+## Ticket
+
+## Checklist
+
+- [ ] Local quality gate green (`pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build`)
+- [ ] Ticket ID cited above
+- [ ] No new warnings introduced
+- [ ] CI status: all required checks green (Build & Push amd64/arm64, Merge manifest, Smoke amd64/arm64, smoke, validate)
+- [ ] CHANGELOG entry added for any user-visible change
+- [ ] No internal/private content added to this public repo (audits, panels, working notes → fox-private-docs)
+
+## Deferred / out of scope
+


### PR DESCRIPTION
## Summary

Add `.github/PULL_REQUEST_TEMPLATE.md` to enforce standing discipline on every PR:
- CI green gate (all 7 required checks)
- CHANGELOG entry for user-visible changes
- Private content check (no audits/panels/working notes in public repo)

## Ticket

TASK-S-03

## Test plan

- [x] Template renders correctly on new PR creation
- [x] Checklist items match the standing discipline rules