### PR TITLE
chore: defer apt publish to v0.7.49, redirect to .deb download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,7 @@ jobs:
   publish-apt:
     name: Publish to apt.foxinthebox.ai
     needs: [build-deb, deb-smoke-test]
+    continue-on-error: true  # #539 — secrets not yet configured; remove when populated
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
+## [Unreleased]
+
+### Changed
+- `.deb` install instructions: replaced non-functional `apt.foxinthebox.ai` commands with direct `.deb` download from GitHub Releases (#539)
+
+### Fixed
+- Release workflow: `publish-apt` job no longer marks the overall release as failed when apt repo secrets are not yet configured (#539)
+
+---
+
 ## [0.7.47] — 2026-06-17
 
 ### Fixed

--- a/packages/deb/README.md
+++ b/packages/deb/README.md
@@ -1,24 +1,16 @@
-# Fox in the Box — Apt Repository
+# Fox in the Box — Deb Packages
 
-`apt.foxinthebox.ai` hosts the Fox in the Box `.deb` packages for Ubuntu 22.04/24.04 and Zorin OS 16/17.
+`.deb` packages for Ubuntu 22.04/24.04 and Zorin OS 16/17.
 
 ## User install
 
+Download the `.deb` for your architecture from the [latest release](https://github.com/fox-in-the-box-ai/fox-in-the-box/releases/latest):
+
 ```bash
-# 1. Add GPG key
-curl -fsSL https://apt.foxinthebox.ai/gpg.asc \
-  | sudo gpg --dearmor -o /usr/share/keyrings/foxinthebox.gpg
-
-# 2. Add apt source
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/foxinthebox.gpg] \
-  https://apt.foxinthebox.ai stable main" \
-  | sudo tee /etc/apt/sources.list.d/foxinthebox.list
-
-# 3. Install
-sudo apt update && sudo apt install foxinthebox
+sudo apt install ./foxinthebox_<version>_<arch>.deb
 ```
 
-Or one-liner: `curl -fsSL https://foxinthebox.ai/install-deb.sh | bash`
+> **apt repo (coming in v0.7.49).** `apt.foxinthebox.ai` will provide `apt install foxinthebox` once GPG signing and R2 hosting are configured. Tracked in #539. Until then, download the `.deb` from GitHub Releases.
 
 ### From a local .deb file
 

--- a/packages/deb/README.md
+++ b/packages/deb/README.md
@@ -10,7 +10,7 @@ Download the `.deb` for your architecture from the [latest release](https://gith
 sudo apt install ./foxinthebox_<version>_<arch>.deb
 ```
 
-> **apt repo (coming in v0.7.49).** `apt.foxinthebox.ai` will provide `apt install foxinthebox` once GPG signing and R2 hosting are configured. Tracked in #539. Until then, download the `.deb` from GitHub Releases.
+> **apt repo (not yet available).** `apt.foxinthebox.ai` will provide `apt install foxinthebox` once GPG signing and R2 hosting are configured. Tracked in #539. Until then, download the `.deb` from GitHub Releases.
 
 ### From a local .deb file
 


### PR DESCRIPTION
## Summary

- **continue-on-error on publish-apt job** — the 5 secrets (#539) required for `apt.foxinthebox.ai` are not yet configured. This job has failed on every release since v0.7.45, polluting the release workflow status. `continue-on-error: true` preserves the job structure (no code change needed when secrets are added) while stopping false-red narratives.
- **Redirect deb README to GitHub Releases** — users hitting `apt.foxinthebox.ai` currently get 404. Updated `packages/deb/README.md` to point to `.deb` download from Releases, with a note that apt repo is coming in v0.7.49.

### Deferred / out of scope

- GPG key generation + R2 bucket setup — that's the #539 work itself, estimated 30 min one-time setup
- Homebrew tap token (#144 on fox-fleet) — separate issue, separate repo

## Test plan

- [x] `release.yml` syntax valid (single-line addition)
- [x] `packages/deb/README.md` link points to correct releases page
- [ ] Next release workflow run: publish-apt job fails but overall workflow shows success

Refs #539