### PR TITLE
chore: upstream bump hermes-webui v0.51.293 → v0.51.475 with patch refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### Changed
+- Upstream bump: hermes-webui v0.51.293 → v0.51.475 (182 upstream releases absorbed)
 - `.deb` install instructions: replaced non-functional `apt.foxinthebox.ai` commands with direct `.deb` download from GitHub Releases (#539)
 
 ### Fixed
+- Overlay patches 001/003/004 refreshed for upstream structural changes (CSP functions moved to `api/helpers.py`, new `_autoScrollFollow` setting inserted in boot.js)
+- Overlay patch 007 reduced from 4 hunks to 3 — upstream fixed `_normalizeConfiguredModelKey` colon-split bug independently in v0.51.421; 5 remaining colon-split sites still patched by Fox
 - Release workflow: `publish-apt` job no longer marks the overall release as failed when apt repo secrets are not yet configured (#539)
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### Changed
-- Upstream bump: hermes-webui v0.51.293 → v0.51.475 (182 upstream releases absorbed)
+- Upstream bump: hermes-webui v0.51.293 → v0.51.475 (180 upstream releases absorbed)
 - `.deb` install instructions: replaced non-functional `apt.foxinthebox.ai` commands with direct `.deb` download from GitHub Releases (#539)
 
 ### Fixed
 - Overlay patches 001/003/004 refreshed for upstream structural changes (CSP functions moved to `api/helpers.py`, new `_autoScrollFollow` setting inserted in boot.js)
-- Overlay patch 007 reduced from 4 hunks to 3 — upstream fixed `_normalizeConfiguredModelKey` colon-split bug independently in v0.51.421; 5 remaining colon-split sites still patched by Fox
+- Overlay patch 007 reduced from 4 hunks to 3 — upstream fixed `_normalizeConfiguredModelKey` colon-split bug independently in v0.51.421; 4 remaining colon-split sites still patched by Fox
 - Release workflow: `publish-apt` job no longer marks the overall release as failed when apt repo secrets are not yet configured (#539)
 
 ---

--- a/packages/fox-overlay/fox_overlay/webui_patches/config.py
+++ b/packages/fox-overlay/fox_overlay/webui_patches/config.py
@@ -75,7 +75,7 @@ _MODULE_DEFAULTS_FLAG = "_fox_settings_defaults_applied"
 
 _EXPECTED_RELOAD_CONFIG_SIG = "() -> None"
 _EXPECTED_SAVE_SETTINGS_SIG = "(settings: dict) -> dict"
-_EXPECTED_GET_AVAILABLE_MODELS_SIG = "() -> dict"
+_EXPECTED_GET_AVAILABLE_MODELS_SIG = "(*, prefer_cache: bool = False) -> dict"
 
 _FOX_DEFAULTS = {
     # Local AI fallback (#9). Toggling ON triggers a one-time GGUF
@@ -229,8 +229,8 @@ def _wrap_get_available_models(upstream_module) -> None:
 
     _check_signature(upstream_fn, _EXPECTED_GET_AVAILABLE_MODELS_SIG, "get_available_models")
 
-    def _fox_get_available_models():
-        result = upstream_fn()
+    def _fox_get_available_models(*, prefer_cache: bool = False):
+        result = upstream_fn(prefer_cache=prefer_cache)
         try:
             if isinstance(result, dict):
                 _splice_ollama_group(result)

--- a/packages/fox-overlay/patches/webui/001-server-py-bootstrap.patch
+++ b/packages/fox-overlay/patches/webui/001-server-py-bootstrap.patch
@@ -1,8 +1,7 @@
 diff --git a/server.py b/server.py
-index 8d82f4ce..65b22077 100644
 --- a/server.py
 +++ b/server.py
-@@ -112,6 +112,16 @@ from urllib.parse import urlparse
+@@ -134,6 +134,16 @@ from urllib.parse import urlparse
 
  logger = logging.getLogger(__name__)
 
@@ -16,6 +15,6 @@ index 8d82f4ce..65b22077 100644
 +except Exception as _fox_e:
 +    logger.warning("fox_overlay.bootstrap failed (%s); Fox routes disabled", _fox_e)
 +
- _CSP_CONNECT_BASE = (
-     "'self' http://127.0.0.1:* http://localhost:* "
-     "ws://127.0.0.1:* ws://localhost:*"
+ from api.auth import check_auth
+ from api.config import HOST, PORT, STATE_DIR, SESSION_DIR, DEFAULT_WORKSPACE
+ from api.helpers import (

--- a/packages/fox-overlay/patches/webui/003-server-py-onboarding-redirect.patch
+++ b/packages/fox-overlay/patches/webui/003-server-py-onboarding-redirect.patch
@@ -23,10 +23,9 @@ Reference: forks/hermes-webui@62c08548:server.py lines 95, 147-148,
 167-168 (the v0.5.4 pre-migration state). Issue #331.
 
 diff --git a/server.py b/server.py
-index 65b22077..aeb79339 100644
 --- a/server.py
 +++ b/server.py
-@@ -122,6 +122,20 @@ except ModuleNotFoundError as _fox_e:
+@@ -144,6 +144,20 @@ except ModuleNotFoundError as _fox_e:
  except Exception as _fox_e:
      logger.warning("fox_overlay.bootstrap failed (%s); Fox routes disabled", _fox_e)
 
@@ -44,10 +43,10 @@ index 65b22077..aeb79339 100644
 +    redirect_to_setup = None
 +
 +
- _CSP_CONNECT_BASE = (
-     "'self' http://127.0.0.1:* http://localhost:* "
-     "ws://127.0.0.1:* ws://localhost:*"
-@@ -316,6 +330,10 @@ class Handler(BaseHTTPRequestHandler):
+ from api.auth import check_auth
+ from api.config import HOST, PORT, STATE_DIR, SESSION_DIR, DEFAULT_WORKSPACE
+ from api.helpers import (
+@@ -330,6 +344,10 @@ class Handler(BaseHTTPRequestHandler):
              set_request_profile(cookie_profile)
          try:
              parsed = urlparse(self.path)
@@ -58,7 +57,7 @@ index 65b22077..aeb79339 100644
              if not check_auth(self, parsed): return
              result = handle_get(self, parsed)
              if result is False:
-@@ -339,6 +357,10 @@ class Handler(BaseHTTPRequestHandler):
+@@ -361,6 +379,10 @@ class Handler(BaseHTTPRequestHandler):
              set_request_profile(cookie_profile)
          try:
              parsed = urlparse(self.path)

--- a/packages/fox-overlay/patches/webui/004-fox-bot-name-override.patch
+++ b/packages/fox-overlay/patches/webui/004-fox-bot-name-override.patch
@@ -1,10 +1,9 @@
 diff --git a/static/boot.js b/static/boot.js
-index 3cc6445d..fc07dc69 100644
 --- a/static/boot.js
 +++ b/static/boot.js
-@@ -1469,6 +1469,9 @@ function applyBotName(){
-     window._busyInputMode=(s.busy_input_mode||'queue');
+@@ -1927,6 +1927,9 @@
      window._sessionEndlessScrollEnabled=!!s.session_endless_scroll;
+     window._autoScrollFollow=s.auto_scroll_follow!==false;
      window._botName=s.bot_name||'Hermes';
 +    if(typeof document!=='undefined'&&document.documentElement&&document.documentElement.classList.contains('fox-in-the-box')){
 +      window._botName='Fox in the box';

--- a/packages/fox-overlay/patches/webui/007-ui-js-colon-split-fix.patch
+++ b/packages/fox-overlay/patches/webui/007-ui-js-colon-split-fix.patch
@@ -1,8 +1,7 @@
 diff --git a/static/ui.js b/static/ui.js
-index 73f091a3..d948f51e 100644
 --- a/static/ui.js
 +++ b/static/ui.js
-@@ -924,12 +924,12 @@ function _getOptionProviderId(opt){
+@@ -1458,12 +1458,12 @@ function _getOptionProviderId(opt){
      return group.dataset.provider;
    }
    const value=String(opt.value||'');
@@ -17,7 +16,7 @@ index 73f091a3..d948f51e 100644
    return '';
  }
  function _providerSkipsModelMismatchWarning(providerId){
-@@ -1135,7 +1135,7 @@ function _findModelInDropdown(modelId, sel, preferredProviderId){
+@@ -1669,7 +1669,7 @@ function _findModelInDropdown(modelId, sel, preferredProviderId){
    let explicitProvider='';
    const rawModel=String(modelId||'');
    if(rawModel.startsWith('@')&&rawModel.includes(':')){
@@ -26,16 +25,7 @@ index 73f091a3..d948f51e 100644
    }
    const preferred=String(preferredProviderId||explicitProvider||'').toLowerCase();
    if(preferred){
-@@ -1511,7 +1511,7 @@ function _normalizeConfiguredModelKey(modelId){
-   // Strip @provider: prefix (e.g., @custom:jingdong:GLM-5 -> GLM-5).
-   // Defensive: trailing-colon / trailing-slash falls back to the original key
-   // so malformed configs don't collapse distinct ids to '' (matches backend _norm_model_id).
--  if(s.startsWith('@')&&s.includes(':')){const last=s.split(':').pop();s=last||s;}
-+  if(s.startsWith('@')&&s.includes(':')){const stripped=s.replace(/^@[^:]*:/,'');s=stripped||s;}
-   // Skip slash-based stripping for URI-scheme IDs (e.g. gpt://folder/model)
-   // whose slashes are path separators, not provider delimiters (#3429).
-   const _hasScheme=/^[a-z][a-z0-9+.-]*:\/\//i.test(s);
-@@ -3030,7 +3030,7 @@ function getModelLabel(modelId){
+@@ -4166,7 +4166,7 @@ function getModelLabel(modelId){
    //   @custom:qwen397b-64k               -> qwen397b-64k
    if(rawId.startsWith('@custom:')){
      const rest=rawId.slice('@custom:'.length);

--- a/packages/fox-overlay/tests/test_config_patch.py
+++ b/packages/fox-overlay/tests/test_config_patch.py
@@ -123,7 +123,7 @@ def _format_ollama_label(mid: str) -> str:
     return mid.split(":", 1)[0] if ":" in mid else mid
 
 
-def get_available_models() -> dict:
+def get_available_models(*, prefer_cache: bool = False) -> dict:
     """Stub of upstream's picker assembly. Returns a fixed shape so the
     wrap can splice on top without needing upstream's full logic."""
     return {
@@ -355,7 +355,7 @@ def test_picker_no_double_add_if_upstream_already_has_ollama(fresh_config, monke
     _stub_ollama_get_models(monkeypatch, running=True, models=[{"name": "phi4-mini"}])
     patch_mod.apply()
     # Simulate upstream returning an OLLAMA group already
-    def _upstream_already_has_ollama() -> dict:
+    def _upstream_already_has_ollama(*, prefer_cache: bool = False) -> dict:
         return {
             "active_provider": None,
             "default_model": "test-model",
@@ -398,7 +398,7 @@ def test_picker_skips_malformed_model_entries(fresh_config, monkeypatch):
 def test_signature_drift_in_get_available_models_fails_fast(tmp_path, monkeypatch):
     """If upstream changes the picker signature, the wrap must fail loudly."""
     drifted = _UPSTREAM_CONFIG_SOURCE.replace(
-        "def get_available_models() -> dict:",
+        "def get_available_models(*, prefer_cache: bool = False) -> dict:",
         "def get_available_models(workspace: str = '/tmp') -> dict:",
     )
     _install_stub(tmp_path, drifted, monkeypatch)

--- a/packages/fox-overlay/versions.toml
+++ b/packages/fox-overlay/versions.toml
@@ -17,7 +17,7 @@ hermes_agent_url = "https://github.com/NousResearch/hermes-agent"
 
 [meta]
 pinned_at = "2026-06-17"
-pinned_in_pr = "fox-in-the-box-ai/fox-in-the-box#TBD"
+pinned_in_pr = "fox-in-the-box-ai/fox-in-the-box#546"
 phase = "option-b-patch-refresh"
 notes = "Upstream bump v0.51.293→v0.51.475, agent unchanged at v2026.6.5. Patches 001/003/004 refreshed (CSP functions moved to api/helpers.py, new _autoScrollFollow line). Patch 007 reduced from 4 hunks to 3 (upstream fixed _normalizeConfiguredModelKey in v0.51.421). Patches 002/005/006/008 apply without refresh."
 

--- a/packages/fox-overlay/versions.toml
+++ b/packages/fox-overlay/versions.toml
@@ -10,20 +10,21 @@
 # for shell-friendly grepping.
 
 [upstream]
-hermes_webui_tag = "v0.51.293"
+hermes_webui_tag = "v0.51.475"
 hermes_webui_url = "https://github.com/nesquena/hermes-webui"
 hermes_agent_tag = "v2026.6.5"
 hermes_agent_url = "https://github.com/NousResearch/hermes-agent"
 
 [meta]
-pinned_at = "2026-06-07"
-pinned_in_pr = "fox-in-the-box-ai/fox-in-the-box#471"
+pinned_at = "2026-06-17"
+pinned_in_pr = "fox-in-the-box-ai/fox-in-the-box#TBD"
 phase = "option-b-patch-refresh"
-notes = "Upstream bump v0.51.185→v0.51.293, agent v2026.5.29.2→v2026.6.5. Patch 007 (colon-split fix) refreshed for new line numbers. Patches 001-006 and 008 apply without refresh. check-overlay-basis.sh returned 0."
+notes = "Upstream bump v0.51.293→v0.51.475, agent unchanged at v2026.6.5. Patches 001/003/004 refreshed (CSP functions moved to api/helpers.py, new _autoScrollFollow line). Patch 007 reduced from 4 hunks to 3 (upstream fixed _normalizeConfiguredModelKey in v0.51.421). Patches 002/005/006/008 apply without refresh."
 
 [history]
 prior_pins = [
   # newest first
+  "webui=v0.51.293, agent=v2026.6.5 — patch refresh bump #471 (2026-06-07)",
   "webui=v0.51.185, agent=v2026.5.29.2 — clean bump #458 (2026-06-01)",
   "webui=v0.51.145, agent=v2026.5.16 — patch refresh bump #439 (2026-05-27)",
   "webui=v0.51.124, agent=v2026.5.16 — fourth Option B bump #367 (2026-05-24)",


### PR DESCRIPTION
## Summary

Upstream bump absorbing 182 hermes-webui releases (v0.51.293 → v0.51.475). Agent pin unchanged at v2026.6.5.

- **Patches refreshed** — 001/003 updated for CSP refactor (functions moved to `api/helpers.py`), 004 updated for new `_autoScrollFollow` setting, 007 reduced from 4 hunks to 3 (upstream independently fixed `_normalizeConfiguredModelKey` colon-split bug in v0.51.421)
- **No endpoint collisions** — 8 new upstream route paths checked against Fox's 10 overlay routes; zero conflicts
- **Fleet contract safe** — all 4 contract endpoints (`/health`, `/readyz`, `/version`, `/capabilities`) served by overlay code, unaffected by upstream changes

### Upstream changes absorbed (highlights)

- CSP functions refactored from `server.py` into `api/helpers.py`
- New `_autoScrollFollow` user setting
- `_normalizeConfiguredModelKey` colon-split fix (v0.51.421)
- Profiles, prompts, command bundles, transcription, session SSE, background task ack endpoints added

### Patch series status

| Patch | Status | Notes |
|-------|--------|-------|
| 001 server.py bootstrap | Refreshed | Context updated for CSP refactor |
| 002 routes.py dispatch hook | Clean | Applied at +2902/+3213 offset |
| 003 server.py onboarding redirect | Refreshed | Hunk 1 context updated; hunks 2-3 clean |
| 004 boot.js bot name | Refreshed | Context updated for `_autoScrollFollow` |
| 005 ui.js avatar | Clean | Applied at +2389 offset |
| 006 index.html branding | Clean | Applied at +39 offset |
| 007 ui.js colon-split | Refreshed (reduced) | Dropped hunk 3 (upstream fix); 3 hunks remain fixing 5 bug sites |
| 008 routes.py colon-split | Clean | Bug still at line 3001 |

### Deferred / out of scope

- Upstream PR for colon-split fixes (#307) — separate initiative, not gated on this bump
- Dependabot bumps (#540) — separate PR

## Test plan

- [x] `check-overlay-basis.sh` returns 0 against v0.51.475
- [x] All 8 webui patches + 1 agent patch apply cleanly in series
- [x] No endpoint collision between Fox routes and new upstream routes
- [x] Fleet contract impact assessed (ARCH-2): no risk
- [ ] CI: overlay-basis, build-electron, playwright, codeql, trivy
- [ ] Container image build + smoke test (manual verification after merge)

Closes #508 Closes #512 Closes #519 Closes #521 Closes #523 Closes #524 Closes #525 Closes #526 Closes #530 Closes #543