### PR TITLE
chore: release v0.7.49

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+---
+
+## [0.7.49] — 2026-06-17
+
 ### Changed
 - Upstream bump: hermes-webui v0.51.293 → v0.51.475 (180 upstream releases absorbed)
 - `.deb` install instructions: replaced non-functional `apt.foxinthebox.ai` commands with direct `.deb` download from GitHub Releases (#539)

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fox-in-the-box/electron",
   "productName": "fox-in-the-box",
-  "version": "0.7.47",
+  "version": "0.7.49",
   "description": "Fox in the box desktop app",
   "author": "Vulpy, Inc.",
   "main": "src/main.js",


### PR DESCRIPTION
## Summary

Version bump and CHANGELOG date stamp for v0.7.49 release.

- **Version bump** — `packages/electron/package.json` 0.7.47 → 0.7.49
- **CHANGELOG** — `[Unreleased]` section stamped as `[0.7.49] — 2026-06-17`, new empty `[Unreleased]` added

### What shipped in v0.7.49

- Upstream bump: hermes-webui v0.51.293 → v0.51.475 (180 upstream releases absorbed)
- Overlay patches 001/003/004/007 refreshed for upstream structural changes
- `.deb` install instructions fix (#539)
- Release workflow apt-publish fix (#539)

## Test plan

- [x] CHANGELOG format correct (new `[Unreleased]` section + dated `[0.7.49]` section)
- [x] Version in `package.json` matches tag target
- [x] CI green on this PR (version-only change, no code)