### PR TITLE
fix: break onboarding redirect loop by exempting auth paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Upstream overlay strategy doc (`docs/architecture/upstream-overlay.md`) — decision flow for when to push Fox overlay patches upstream, detection during patch refresh, quarterly sweep process (#307)
 - `upstream-candidate` label for tracking overlay patches that should also ship as upstream Hermes PRs
 
+### Fixed
+- Onboarding redirect loop: `/login` and `/api/auth/` paths now exempt from onboarding redirect, breaking the chicken-and-egg between patch 003's redirect-to-setup and check_auth's redirect-to-login
+
 ---
 
 ## [0.7.49] — 2026-06-17

--- a/packages/fox-overlay/fox_overlay/webui_modules/onboarding.py
+++ b/packages/fox-overlay/fox_overlay/webui_modules/onboarding.py
@@ -61,6 +61,11 @@ _SETUP_PREFIXES = (
     "/readyz",
     "/version",
     "/capabilities",
+    # Auth flow: check_auth redirects /setup → login?next=/setup, so
+    # /login and /api/auth/ must be exempt to break the chicken-and-egg
+    # (patch 003 places the onboarding redirect before check_auth).
+    "/login",
+    "/api/auth/",
 )
 
 


### PR DESCRIPTION
## Summary

Fixes the redirect loop between `/setup` and `login?next=/setup` on fresh Fox instances with auth enabled (managed mode via Fleet, or standalone with `HERMES_WEBUI_PASSWORD` set).

- **Add `/login` to `_SETUP_PREFIXES`** — so the login page renders instead of being bounced to `/setup`
- **Add `/api/auth/` to `_SETUP_PREFIXES`** — so the login POST and auth status check complete during onboarding

### Root cause

Patch 003 (`003-server-py-onboarding-redirect.patch`) places the onboarding redirect **before** `check_auth` in `do_GET`. When onboarding is incomplete, every request not in `_SETUP_PREFIXES` gets 302'd to `/setup`. But `/setup` is not in `PUBLIC_PATHS`, so `check_auth` redirects unauthenticated users to `login?next=/setup`. Since `/login` was not in `_SETUP_PREFIXES`, the onboarding redirect caught it and sent it back to `/setup` — infinite loop.

### Deferred / out of scope

- X-Fox-Auth secret alignment between Fleet and Fox (deployment configuration, not a code bug — PlaneAuthToken and InstancePassword are intentionally different values)
- Unit tests for `should_redirect_to_setup` exemptions (tracked as should-fix; the redirect loop is production-blocking)

## Test plan

- [x] Local quality gate: git diff is clean, only `onboarding.py` and `CHANGELOG.md` touched
- [x] Multi-agent panel: 3 architects approve, 4-perspective adversarial review passes (security, correctness, test discipline, code quality), QA passes
- [ ] On-target verification:
  - Fresh Fox container with `HERMES_WEBUI_PASSWORD` set → can reach login page → can log in → redirected to `/setup` → wizard renders
  - Fleet-managed instance with valid X-Fox-Auth → `/setup` serves directly (no login page needed)
  - After onboarding completes → `/login` exemption becomes a no-op (`should_redirect_to_setup` returns False for all paths)