### PR TITLE
fix: widen onboarding _SETUP_PREFIXES /static/favicon to /static/

### DIFF
--- a/packages/fox-overlay/fox_overlay/webui_modules/onboarding.py
+++ b/packages/fox-overlay/fox_overlay/webui_modules/onboarding.py
@@ -39,7 +39,7 @@ _SETUP_PREFIXES = (
     # so the wizard's CSS + JS load cleanly without being bounced.
     "/extensions/",
     "/health",
-    "/static/favicon",
+    "/static/",
     # v0.7.17: /test/* routes are gated by FITB_TEST_MODE=1 in fox-overlay's
     # bootstrap, so in production builds they don't exist and whitelisting
     # them is a no-op. In CI / playwright runs FITB_TEST_MODE=1 is set and


### PR DESCRIPTION
## Summary

Follow-up to #555 — the login page loads `/static/login.js` externally (routes.py line 5266), not inline. Without this fix, the onboarding redirect catches `/static/login.js` and the login form renders with zero JavaScript — password submit silently fails.

- **Widen `/static/favicon` to `/static/`** — aligns with `check_auth`'s existing `/static/` bypass (auth.py line 570); static files carry no auth sensitivity

### Deferred / out of scope

- Same as #555

## Test plan

- [x] Local quality gate: single-line diff in `_SETUP_PREFIXES`
- [x] Adversarial review identified this gap (security reviewer BLOCK finding)
- [ ] On-target verification: login page loads login.js, form submits work