### PR TITLE
fix: Cluster A bug fixes (#549, #550, #557, #559, #564)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,9 +105,74 @@ jobs:
           R2_SECRET_KEY:   ${{ secrets.R2_SECRET_KEY }}
         run: bash packages/deb/publish-apt.sh
 
+  # ── Container :stable + :vX.Y.Z promotion ──────────────────────────────────
+  # Decoupled from the GitHub Release job (#550) so that a failing Electron
+  # build does not block :stable advancement. Operators using :stable get
+  # critical container fixes immediately; the GitHub Release (with desktop
+  # artifacts) follows once all platform builds succeed.
+  promote-container:
+    name: Promote container image
+    needs: [wait-for-container]
+    runs-on: ubuntu-latest
+
+    permissions:
+      packages: write
+
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version tag
+        id: tag
+        run: echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      # Pin the released image to the exact bytes wait-for-container pushed,
+      # while preserving the multi-arch manifest list (#82). The previous
+      # implementation used `docker pull && docker tag && docker push` —
+      # that pattern collapses a manifest list to a single-platform image
+      # because `docker pull` on the (amd64) runner only fetches the amd64
+      # child manifest, then the `tag` and `push` rewrite the new tag with
+      # just amd64. Switching to `docker buildx imagetools create` keeps
+      # the operation registry-side: it constructs the new tag pointing at
+      # the same manifest list, so `:vX.Y.Z` and `:stable` are multi-arch.
+      # The digest pinning rationale from #41 still holds — using
+      # `name@<index-digest>` as the source means a concurrent push to
+      # main can't mutate :latest between build and release.
+      - name: Re-tag Docker image as versioned and :stable
+        env:
+          DIGEST: ${{ needs.wait-for-container.outputs.digest }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$DIGEST" ]]; then
+            echo "::error::wait-for-container did not produce a digest output."
+            exit 1
+          fi
+          IMG="ghcr.io/fox-in-the-box-ai/cloud"
+          VERSION="${{ steps.tag.outputs.version }}"
+          docker buildx imagetools create -t "$IMG:$VERSION" "$IMG@$DIGEST"
+          docker buildx imagetools create -t "$IMG:stable"   "$IMG@$DIGEST"
+          # Verify the released tags are multi-arch — fail loudly if either
+          # has somehow become single-platform (ships a broken release
+          # before users find out).
+          for TAG in "$VERSION" "stable"; do
+            PLATFORMS=$(docker buildx imagetools inspect "$IMG:$TAG" \
+              --format '{{range .Manifest.Manifests}}{{.Platform.OS}}/{{.Platform.Architecture}}{{"\n"}}{{end}}')
+            echo "$IMG:$TAG platforms:"; echo "$PLATFORMS"
+            grep -qx 'linux/amd64' <<<"$PLATFORMS" || { echo "::error::$IMG:$TAG missing linux/amd64"; exit 1; }
+            grep -qx 'linux/arm64' <<<"$PLATFORMS" || { echo "::error::$IMG:$TAG missing linux/arm64"; exit 1; }
+          done
+          echo "✅ Both $IMG:$VERSION and $IMG:stable are multi-arch (linux/amd64, linux/arm64)"
+
   release:
     name: Create GitHub Release
-    needs: [wait-for-container, wait-for-electron, deb-smoke-test]
+    needs: [wait-for-electron, deb-smoke-test, promote-container]
     runs-on: ubuntu-latest
 
     permissions:
@@ -164,56 +229,9 @@ jobs:
           fi
           echo "✅ SMOKE_LOG.md entry for ${TAG} present + body is non-empty (has checked boxes or explicit bypass)"
 
-      - name: Log in to GHCR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Extract version tag
         id: tag
         run: echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-
-      # Pin the released image to the exact bytes wait-for-container pushed,
-      # while preserving the multi-arch manifest list (#82). The previous
-      # implementation used `docker pull && docker tag && docker push` —
-      # that pattern collapses a manifest list to a single-platform image
-      # because `docker pull` on the (amd64) runner only fetches the amd64
-      # child manifest, then the `tag` and `push` rewrite the new tag with
-      # just amd64. Switching to `docker buildx imagetools create` keeps
-      # the operation registry-side: it constructs the new tag pointing at
-      # the same manifest list, so `:vX.Y.Z` and `:stable` are multi-arch.
-      # The digest pinning rationale from #41 still holds — using
-      # `name@<index-digest>` as the source means a concurrent push to
-      # main can't mutate :latest between build and release.
-      - name: Re-tag Docker image as versioned and :stable
-        env:
-          DIGEST: ${{ needs.wait-for-container.outputs.digest }}
-        run: |
-          set -euo pipefail
-          if [[ -z "$DIGEST" ]]; then
-            echo "::error::wait-for-container did not produce a digest output."
-            exit 1
-          fi
-          IMG="ghcr.io/fox-in-the-box-ai/cloud"
-          VERSION="${{ steps.tag.outputs.version }}"
-          docker buildx imagetools create -t "$IMG:$VERSION" "$IMG@$DIGEST"
-          docker buildx imagetools create -t "$IMG:stable"   "$IMG@$DIGEST"
-          # Verify the released tags are multi-arch — fail loudly if either
-          # has somehow become single-platform (ships a broken release
-          # before users find out).
-          for TAG in "$VERSION" "stable"; do
-            PLATFORMS=$(docker buildx imagetools inspect "$IMG:$TAG" \
-              --format '{{range .Manifest.Manifests}}{{.Platform.OS}}/{{.Platform.Architecture}}{{"\n"}}{{end}}')
-            echo "$IMG:$TAG platforms:"; echo "$PLATFORMS"
-            grep -qx 'linux/amd64' <<<"$PLATFORMS" || { echo "::error::$IMG:$TAG missing linux/amd64"; exit 1; }
-            grep -qx 'linux/arm64' <<<"$PLATFORMS" || { echo "::error::$IMG:$TAG missing linux/arm64"; exit 1; }
-          done
-          echo "✅ Both $IMG:$VERSION and $IMG:stable are multi-arch (linux/amd64, linux/arm64)"
 
       - name: Download Windows artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,7 +177,6 @@ jobs:
 
     permissions:
       contents: write
-      packages: write
 
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- Keep-alive stream corruption on auth rejection: rejected POST requests no longer leave unread body bytes in the socket buffer, preventing HTTP request smuggling on the next keep-alive request (#559)
+- Container `:stable` tag promotion decoupled from Electron build success — a failed desktop build no longer blocks container availability (#550)
+- Fleet-provisioned containers: `/data` directory ownership corrected so the application user can create files directly under the mount point (#549)
+- Cron failure diagnostics patch retargeted to `_run_job_impl` after upstream refactored `run_job` into a thin wrapper (#557)
+- Upstream's `onboarding.js` script tag removed via static patch to prevent interference with Fox's own onboarding wizard (#564)
+
+### Changed
+- Release workflow: `promote-container` extracted into its own job with multi-arch verification, independent of Electron and `.deb` pipelines (#550)
+- Release workflow: `release` job permissions narrowed — removed unused `packages: write` (container ops moved to `promote-container`)
+
+---
+
 ## [0.7.50] — 2026-06-19
 
 ### Added

--- a/packages/fox-overlay/fox_overlay/agent_plugins/fox_overlay_plugin/monkey_patches/cron_diagnostics.py
+++ b/packages/fox-overlay/fox_overlay/agent_plugins/fox_overlay_plugin/monkey_patches/cron_diagnostics.py
@@ -6,7 +6,7 @@ migration (Phase 3). Five substitutions across three modules:
 
 * ``cron.jobs.create_job`` — add ``failure_history`` to the job dict.
 * ``cron.jobs.mark_job_run`` — maintain rolling last-5 failure entries.
-* ``cron.scheduler.run_job`` — enrich the FAILED output with agent
+* ``cron.scheduler._run_job_impl`` — enrich the FAILED output with agent
   diagnostics + traceback + session-log pointer.
 * ``cron.scheduler.tick`` — replace the one-line failure delivery
   message with a structured multi-line failure notification.
@@ -74,10 +74,12 @@ def apply() -> None:
         sentinel="_fox_patched_mark_job_run_failure_history",
     )
 
-    # 3) cron.scheduler.run_job — enrich FAILED output with diagnostics + traceback
+    # 3) cron.scheduler._run_job_impl — enrich FAILED output with diagnostics + traceback
+    # Upstream refactored run_job into a thin wrapper + _run_job_impl;
+    # the except-Exception error handler we patch lives in _run_job_impl.
     substitute_function(
         upstream_module=_u_scheduler,
-        function_name="run_job",
+        function_name="_run_job_impl",
         substitutions=[
             (
                 '    except Exception as e:\n'

--- a/packages/fox-overlay/fox_overlay/webui_patches/__init__.py
+++ b/packages/fox-overlay/fox_overlay/webui_patches/__init__.py
@@ -41,6 +41,8 @@ def apply_all() -> None:
     streaming.apply()
     from . import auth
     auth.apply()
+    from . import auth_body_drain
+    auth_body_drain.apply()
     from . import csrf
     csrf.apply()
-    _log.warning("[fox-overlay] webui_patches.apply_all() complete (%d patch modules)", 4)
+    _log.warning("[fox-overlay] webui_patches.apply_all() complete (%d patch modules)", 5)

--- a/packages/fox-overlay/fox_overlay/webui_patches/auth_body_drain.py
+++ b/packages/fox-overlay/fox_overlay/webui_patches/auth_body_drain.py
@@ -1,0 +1,48 @@
+"""Fox webui patch: auth_body_drain.py — close keep-alive on auth rejection (#559).
+
+Wraps ``check_auth`` in ``api/auth.py`` so that when authentication
+fails (``check_auth`` returns ``False``), ``handler.close_connection``
+is set to ``True``.  Without this, a rejected POST request leaves its
+unread body in the socket buffer; Python's ``BaseHTTPRequestHandler``
+then tries to parse those bytes as the next HTTP request on the
+keep-alive connection, corrupting the stream.
+
+Setting ``close_connection = True`` causes ``handle_one_request`` to
+exit its loop after the current response is flushed — the server
+closes the TCP connection cleanly and never tries to read a second
+request from the tainted buffer.
+
+Uses the wrap-and-splice pattern (post-call behavior change) rather
+than ``substitute_function`` (mid-function source edit) per the
+guidance in ``_substitute.py``.  This avoids coupling to
+``check_auth``'s internal anchors and composes cleanly with the
+AUTH-01 substitution in ``auth.py``.
+"""
+import logging
+
+_log = logging.getLogger("fox_overlay.webui_patches.auth_body_drain")
+
+_SENTINEL = "_fox_patched_check_auth_body_drain"
+
+
+def apply() -> None:
+    from api import auth as _u
+
+    if getattr(_u.check_auth, _SENTINEL, False):
+        return
+
+    _original = _u.check_auth
+
+    def check_auth(handler, parsed):
+        result = _original(handler, parsed)
+        if not result:
+            handler.close_connection = True
+        return result
+
+    for attr in dir(_original):
+        if attr.startswith("_fox_patched"):
+            setattr(check_auth, attr, getattr(_original, attr))
+    setattr(check_auth, _SENTINEL, True)
+    _u.check_auth = check_auth
+
+    _log.info("[fox-overlay] patched api.auth.check_auth (body-drain wrapper)")

--- a/packages/fox-overlay/fox_overlay/webui_patches/auth_body_drain.py
+++ b/packages/fox-overlay/fox_overlay/webui_patches/auth_body_drain.py
@@ -35,7 +35,7 @@ def apply() -> None:
 
     def check_auth(handler, parsed):
         result = _original(handler, parsed)
-        if not result:
+        if not result and hasattr(handler, "close_connection"):
             handler.close_connection = True
         return result
 

--- a/packages/fox-overlay/patches/webui/009-remove-onboarding-js-script-tag.patch
+++ b/packages/fox-overlay/patches/webui/009-remove-onboarding-js-script-tag.patch
@@ -1,0 +1,10 @@
+--- a/static/index.html
++++ b/static/index.html
+@@ -1559,7 +1559,6 @@
+ <script src="static/commands.js?v=__WEBUI_VERSION__" defer></script>
+ <script src="static/messages.js?v=__WEBUI_VERSION__" defer></script>
+ <script src="static/panels.js?v=__WEBUI_VERSION__" defer></script>
+-<script src="static/onboarding.js?v=__WEBUI_VERSION__" defer></script>
+ <script src="static/boot.js?v=__WEBUI_VERSION__" defer></script>
+ <script src="static/outline.js?v=__WEBUI_VERSION__" defer></script>
+

--- a/packages/fox-overlay/patches/webui/series
+++ b/packages/fox-overlay/patches/webui/series
@@ -16,3 +16,4 @@
 006-fox-empty-state-branding.patch
 007-ui-js-colon-split-fix.patch
 008-routes-py-colon-split-fix.patch
+009-remove-onboarding-js-script-tag.patch

--- a/packages/integration/entrypoint.sh
+++ b/packages/integration/entrypoint.sh
@@ -133,6 +133,7 @@ fi
 # ── 4. Fix permissions ─────────────────────────────────────────────────────────
 # Exclude /data/data/tailscale — tailscaled runs as root and manages its own state.
 echo "[entrypoint] Setting ownership on /data ..."
+chown foxinthebox:foxinthebox /data
 chown -R foxinthebox:foxinthebox \
     /data/apps \
     /data/config \


### PR DESCRIPTION
## Summary

Five bug fixes across container entrypoint, CI release workflow, and overlay patches — all Cluster A from the v0.7.51 backlog crunch.

- **#549 — entrypoint chown /data** — Fleet-provisioned containers had /data itself owned by root; subdirectory chowns were fine but the root dir wasn't. Added non-recursive chown of /data before the recursive chowns.
- **#550 — decouple :stable from Electron** — Extracted `promote-container` job so a failing Electron build doesn't block `:stable` advancement. Operators using `:stable` get critical container fixes immediately.
- **#564 — dead onboarding.js script tag** — `.fox-removals` deletes `static/onboarding.js` but upstream's `index.html` still references it. The 404 with `application/json` MIME type triggers strict MIME checking errors. Patch 009 removes the dead `<script>` tag.
- **#559 — POST body not consumed on 401/403** — `check_auth` sends error responses without reading the POST body, corrupting HTTP/1.1 keep-alive connections. Wraps `check_auth` to set `close_connection = True` on rejection.
- **#557 — cron_diagnostics anchor mismatch** — Upstream refactored `run_job` into a thin wrapper + `_run_job_impl`. The diagnostics patch targeted the wrong function, causing boot crash. Retargeted to `_run_job_impl`.

### Deferred / out of scope

- Upstream bump (v0.51.475 → v0.51.513+) — separate PR
- README polish (#419, #421, #422) — Cluster B

## Test plan

- [x] Patch 009 verified: `git -C forks/hermes-webui apply --check` passes
- [x] cron_diagnostics: all 5 substitutions verified against current upstream v2026.6.5 via Python import
- [x] auth_body_drain: wrapper pattern composes with existing AUTH-01 substitution
- [ ] On-target verification:
  - Fresh container boot — no monkey-patch crash (validates #557)
  - POST to /api/* without auth cookie on keep-alive — connection stays clean (validates #559)
  - Browser console on page load — no onboarding.js 404/MIME error (validates #564)
  - Release workflow dry-run — promote-container job visible in graph (validates #550)
  - Fleet-provisioned container — /data writable by foxinthebox (validates #549)

Closes #549
Closes #550
Closes #557
Closes #559
Closes #564