### PR TITLE
docs: add trademark policy and update roadmap version targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+- `TRADEMARK.md` — trademark policy for project name and logo, with fork-renaming requirement (#410)
+
+### Changed
+- README roadmap section updated with current version targets and criteria-based v0.8.0 acceptance gate (#406)
+
 ---
 
 ## [0.7.51] — 2026-06-20

--- a/README.md
+++ b/README.md
@@ -300,26 +300,32 @@ The app itself is free and open source. You only pay for AI usage at your provid
 
 ## Roadmap
 
-What we're working on next. No promises on dates — this is a small team — but this is the direction. v0.7.x is the stabilization cycle: v0.8.0 only ships once the verification rebuild is complete and the project is genuinely solid.
+What we're working on next. No promises on dates — this is a small team — but this is the direction.
 
-**Just shipped (v0.7.33–v0.7.44)**
-- **7-step progress window** — real-time install progress with diagnostics pane, post-reboot Docker resume, smooth animations (v0.7.33–v0.7.40)
-- **Fox branding in WebUI** — custom bot name, avatar, and empty-state branding via build-time patches (v0.7.23)
-- **Ollama local model routing** — correct provider routing, colon-split fixes across frontend and backend, picker dedup (v0.7.42–v0.7.44)
-- **Windows installer overhaul** — install-mode selection, HyperV/WSL2 detection, uninstaller data cleanup, Docker Desktop uninstall integration (v0.7.22–v0.7.27)
+**Recently shipped (v0.7.45–v0.7.51)**
+- **Upstream separation** — Fox overlays cleanly separated from upstream Hermes codebase; upstream updates no longer require merge conflicts (v0.6.0 / v0.7.0)
+- **Supply-chain hardening** — container `:stable` tag promotion decoupled from Electron builds, Fleet container ownership fixes, release workflow reliability (v0.7.49–v0.7.51)
+- **Comparison docs** — feature matrix vs Open WebUI, AnythingLLM, Jan, LibreChat (v0.7.51)
+- **Upstream bump** — hermes-webui v0.51.528, hermes-agent v2026.6.19 (v0.7.51)
 
-**v0.7.x stabilization in flight**
-- **#336 — Wizard local-fallback error on Windows** — needs Win11 Docker logs for diagnosis
-- **On-device smoke backlog** — 14 POST-RELEASE items unchecked since v0.7.17
-- **Upstream anchor drift (#439)** — blocks the next upstream bump
+**v0.7.x stabilization (in flight)**
+- Supply-chain hardening — Python dependency lock, Electron major bump, Windows artifact labeling
+- Custom provider UI — add OpenAI-compatible providers (llama.cpp, vLLM, LM Studio) from the settings panel
+- Diagnostic report — one-click "Send diagnostic report" in the launcher for support
 
-**Eventually (v0.8.0 and beyond)**
-- UI overhaul — a clean, professional design system replacing the current developer-tool look
+**v0.8.0 — ships when these criteria are met:**
+- Playwright E2E covers all critical user paths (provider setup, chat, model switching, failover)
+- Zero open P0 bugs
+- Container image passes clean Trivy scan
+- On-device smoke checklist fully green for two consecutive releases
+
+**Beyond v0.8.0**
 - Network isolation mode for enterprise — air-gapped Docker deployment
 - Routines — teach Fox multi-step workflows via conversation, runs on a schedule
-- Content-safety classifier (Llama Guard 3 1B), guardrail plugins, business-rule validators — opt-in safety layer for users who want it
+- Knowledge RAG — batch-ingest document collections for semantic retrieval
+- Content-safety classifier and guardrail plugins — opt-in safety layer
 
-**Have an idea?** [Open a discussion](https://github.com/fox-in-the-box-ai/fox-in-the-box/discussions) or [file a feature request](https://github.com/fox-in-the-box-ai/fox-in-the-box/issues/new).
+Track progress on the [issue board](https://github.com/fox-in-the-box-ai/fox-in-the-box/issues) or [open a discussion](https://github.com/fox-in-the-box-ai/fox-in-the-box/discussions).
 
 ---
 
@@ -345,4 +351,4 @@ Fox in the Box stands on the shoulders of:
 
 ## License
 
-MIT — see [LICENSE](LICENSE).
+MIT — see [LICENSE](LICENSE). The name "Fox in the Box" and the fox logo are trademarks of Vulpy Inc. — see [TRADEMARK.md](TRADEMARK.md).

--- a/README.md
+++ b/README.md
@@ -302,8 +302,8 @@ The app itself is free and open source. You only pay for AI usage at your provid
 
 What we're working on next. No promises on dates — this is a small team — but this is the direction.
 
-**Recently shipped (v0.7.45–v0.7.51)**
-- **Upstream separation** — Fox overlays cleanly separated from upstream Hermes codebase; upstream updates no longer require merge conflicts (v0.6.0 / v0.7.0)
+**Recently shipped**
+- **Upstream separation** — Fox overlays cleanly separated from upstream Hermes codebase; upstream updates no longer require merge conflicts
 - **Supply-chain hardening** — container `:stable` tag promotion decoupled from Electron builds, Fleet container ownership fixes, release workflow reliability (v0.7.49–v0.7.51)
 - **Comparison docs** — feature matrix vs Open WebUI, AnythingLLM, Jan, LibreChat (v0.7.51)
 - **Upstream bump** — hermes-webui v0.51.528, hermes-agent v2026.6.19 (v0.7.51)
@@ -351,4 +351,4 @@ Fox in the Box stands on the shoulders of:
 
 ## License
 
-MIT — see [LICENSE](LICENSE). The name "Fox in the Box" and the fox logo are trademarks of Vulpy Inc. — see [TRADEMARK.md](TRADEMARK.md).
+MIT — see [LICENSE](LICENSE). The name "Fox in the Box" and the fox logo are trademarks of Vulpy Inc. (operating as Fox in the Box) — see [TRADEMARK.md](TRADEMARK.md).

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,7 +1,7 @@
 # Trademark Policy
 
-The name **Fox in the Box**, the fox avatar, and the associated logos are
-trademarks of Vulpy Inc. (operating as Fox in the Box).
+The name **Fox in the Box**, the fox logo, and the associated branding are
+unregistered trademarks of Vulpy Inc. (operating as Fox in the Box).
 
 ## What the MIT license covers
 
@@ -13,11 +13,11 @@ the trademarks.
 
 | Use case | Allowed? | Condition |
 |----------|----------|-----------|
-| Running unmodified Fox in the Box for yourself or your organization | Yes | No conditions |
+| Running Fox in the Box as distributed | Yes | No conditions |
 | Describing compatibility ("works with Fox in the Box") | Yes | Do not imply endorsement |
 | Writing about Fox in the Box (blog posts, documentation, reviews) | Yes | Use the name accurately |
 | Distributing a modified fork under the Fox in the Box name | No | Rename your fork |
-| Using the fox avatar in your own product branding | No | Create your own branding |
+| Using the fox logo in your own product branding | No | Create your own branding |
 
 ## Forks and derivative works
 
@@ -28,6 +28,7 @@ attribution.
 
 ## Questions
 
-If your use case is not covered above, open an
+If your use case is not covered above, email
+[legal@foxinthebox.ai](mailto:legal@foxinthebox.ai) or open an
 [issue](https://github.com/fox-in-the-box-ai/fox-in-the-box/issues/new)
-or contact the maintainers.
+for non-sensitive questions.

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,0 +1,33 @@
+# Trademark Policy
+
+The name **Fox in the Box**, the fox avatar, and the associated logos are
+trademarks of Vulpy Inc. (operating as Fox in the Box).
+
+## What the MIT license covers
+
+The [MIT license](LICENSE) grants broad permissions to use, copy, modify,
+and distribute the **source code**. It does not grant permission to use
+the trademarks.
+
+## Using the name and logo
+
+| Use case | Allowed? | Condition |
+|----------|----------|-----------|
+| Running unmodified Fox in the Box for yourself or your organization | Yes | No conditions |
+| Describing compatibility ("works with Fox in the Box") | Yes | Do not imply endorsement |
+| Writing about Fox in the Box (blog posts, documentation, reviews) | Yes | Use the name accurately |
+| Distributing a modified fork under the Fox in the Box name | No | Rename your fork |
+| Using the fox avatar in your own product branding | No | Create your own branding |
+
+## Forks and derivative works
+
+If you fork this project and distribute it, you must use a different
+product name and different branding. You may state that your project is
+"based on Fox in the Box" or "derived from Fox in the Box" for
+attribution.
+
+## Questions
+
+If your use case is not covered above, open an
+[issue](https://github.com/fox-in-the-box-ai/fox-in-the-box/issues/new)
+or contact the maintainers.


### PR DESCRIPTION
## Summary

Add trademark policy and update the README roadmap to reflect current project state.

- **TRADEMARK.md** — new file establishing Vulpy Inc. trademark rights over the "Fox in the Box" name and logo, with fork-renaming requirement, usage table, and contact info
- **README roadmap** — replaced stale v0.7.33–v0.7.44 references with current shipped work, added criteria-based v0.8.0 acceptance gate (Playwright E2E, zero P0, clean Trivy, two consecutive green smokes), cleaned up "Eventually" section

### Deferred / out of scope

- Formal USPTO trademark registration (legal milestone, separate track)
- Full quarterly roadmap (premature for current team size)

## Test plan

- [x] No code changes — docs only
- [x] TRADEMARK.md entity name matches LICENSE entity name
- [x] Terminology consistent across TRADEMARK.md and README.md
- [x] No Rule 9 / Rule 10 leaks (no investor names, no strategic context)
- [x] CHANGELOG [Unreleased] entries added

Closes #406
Closes #410