### PR TITLE
chore: add Python dependency lock file for container builds

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -370,13 +370,16 @@ jobs:
         if: matrix.platform.short == 'amd64'
         run: |
           set -euo pipefail
+          # Compare the committed lock file (baked into the image at build time)
+          # against the live pip freeze. Uses docker cp to avoid network fetch
+          # issues on fork PRs.
+          docker cp test-fox:/app/requirements.lock /tmp/lock-from-image.txt
+          grep -v '^#' /tmp/lock-from-image.txt | grep -v '^$' | sort > /tmp/lock.txt
           docker exec test-fox pip freeze --exclude-editable 2>/dev/null | sort > /tmp/freeze.txt
-          curl -fsSL "https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/packages/integration/requirements.lock" \
-            | grep -v '^#' | grep -v '^$' | sort > /tmp/lock.txt
           if ! diff -u /tmp/lock.txt /tmp/freeze.txt; then
             echo "::warning::pip freeze differs from requirements.lock — regenerate with: docker run --rm --entrypoint pip <image> freeze --exclude-editable | sort > packages/integration/requirements.lock"
           else
-            echo "✅ pip freeze matches requirements.lock"
+            echo "pip freeze matches requirements.lock"
           fi
 
       - name: Container logs (always — debug)

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -366,6 +366,19 @@ jobs:
           docker logs test-fox
           exit 1
 
+      - name: Verify pip lock consistency
+        if: matrix.platform.short == 'amd64'
+        run: |
+          set -euo pipefail
+          docker exec test-fox pip freeze --exclude-editable 2>/dev/null | sort > /tmp/freeze.txt
+          curl -fsSL "https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/packages/integration/requirements.lock" \
+            | grep -v '^#' | grep -v '^$' | sort > /tmp/lock.txt
+          if ! diff -u /tmp/lock.txt /tmp/freeze.txt; then
+            echo "::warning::pip freeze differs from requirements.lock — regenerate with: docker run --rm --entrypoint pip <image> freeze --exclude-editable | sort > packages/integration/requirements.lock"
+          else
+            echo "✅ pip freeze matches requirements.lock"
+          fi
+
       - name: Container logs (always — debug)
         if: always()
         run: docker logs test-fox 2>&1 || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 - `TRADEMARK.md` — trademark policy for project name and logo, with fork-renaming requirement (#410)
+- Python dependency lock file (`packages/integration/requirements.lock`) pins all transitive dependencies in container builds (#418)
 
 ### Changed
 - README roadmap section updated with current version targets and criteria-based v0.8.0 acceptance gate (#406)
+- Container builds use pip constraints to prevent silent dependency drift (#418)
 
 ---
 

--- a/packages/install-core/install-core.sh
+++ b/packages/install-core/install-core.sh
@@ -250,6 +250,7 @@ _install_soul() {
 # ── 8. pip install ────────────────────────────────────────────────────────────
 _pip_install() {
     local pip_cmd
+    local constraints_flag=""
 
     if [ "$FITB_CONTEXT" = "bare-metal" ]; then
         # Create an isolated venv so Fox doesn't pollute system Python
@@ -266,28 +267,34 @@ _pip_install() {
         pip_cmd="pip"
     fi
 
+    if [ -n "${FITB_PIP_CONSTRAINTS:-}" ] && [ -f "$FITB_PIP_CONSTRAINTS" ]; then
+        constraints_flag="-c $FITB_PIP_CONSTRAINTS"
+        _log "Using pip constraints: $FITB_PIP_CONSTRAINTS"
+    fi
+
     _log "Installing hermes-agent[anthropic,bedrock,google]..."
     "$pip_cmd" install -e "$FITB_APP_DIR/hermes-agent[anthropic,bedrock,google]" \
-        --quiet --no-cache-dir
+        $constraints_flag --quiet --no-cache-dir
 
     _log "Installing hermes-webui..."
     if [ -f "$FITB_APP_DIR/hermes-webui/requirements.txt" ]; then
         "$pip_cmd" install -r "$FITB_APP_DIR/hermes-webui/requirements.txt" \
-            --quiet --no-cache-dir
+            $constraints_flag --quiet --no-cache-dir
     elif [ -f "$FITB_APP_DIR/hermes-webui/setup.py" ] || \
          grep -q '^\[build-system\]' "$FITB_APP_DIR/hermes-webui/pyproject.toml" 2>/dev/null; then
-        "$pip_cmd" install -e "$FITB_APP_DIR/hermes-webui" --quiet --no-cache-dir
+        "$pip_cmd" install -e "$FITB_APP_DIR/hermes-webui" \
+            $constraints_flag --quiet --no-cache-dir
     else
         _die "hermes-webui has no requirements.txt, setup.py, or installable pyproject.toml"
     fi
 
     _log "Installing fox-overlay..."
-    "$pip_cmd" install -e "$FITB_OVERLAY_DIR" --quiet --no-cache-dir
+    "$pip_cmd" install -e "$FITB_OVERLAY_DIR" $constraints_flag --quiet --no-cache-dir
 
     # supervisor: needed in bare-metal (Docker installs it separately)
     if [ "$FITB_CONTEXT" = "bare-metal" ]; then
         _log "Installing supervisor..."
-        "$pip_cmd" install supervisor --quiet --no-cache-dir
+        "$pip_cmd" install supervisor $constraints_flag --quiet --no-cache-dir
     fi
 }
 

--- a/packages/install-core/install-core.sh
+++ b/packages/install-core/install-core.sh
@@ -20,6 +20,8 @@
 #   LLAMACPP_VERSION     Default: b9026
 #   FITB_OVERLAY_DIR     Path to fox-overlay package. Default: $FITB_APP_DIR/fox-overlay
 #                        Docker passes /tmp/fox-overlay (COPYd before install-core runs).
+#   FITB_PIP_CONSTRAINTS Path to pip constraints file (-c). Default: unset (no constraints).
+#                        Docker sets this to /app/requirements.lock.
 
 set -euo pipefail
 
@@ -250,7 +252,7 @@ _install_soul() {
 # ── 8. pip install ────────────────────────────────────────────────────────────
 _pip_install() {
     local pip_cmd
-    local constraints_flag=""
+    local constraints_flag=()
 
     if [ "$FITB_CONTEXT" = "bare-metal" ]; then
         # Create an isolated venv so Fox doesn't pollute system Python
@@ -268,33 +270,33 @@ _pip_install() {
     fi
 
     if [ -n "${FITB_PIP_CONSTRAINTS:-}" ] && [ -f "$FITB_PIP_CONSTRAINTS" ]; then
-        constraints_flag="-c $FITB_PIP_CONSTRAINTS"
+        constraints_flag=(-c "$FITB_PIP_CONSTRAINTS")
         _log "Using pip constraints: $FITB_PIP_CONSTRAINTS"
     fi
 
     _log "Installing hermes-agent[anthropic,bedrock,google]..."
     "$pip_cmd" install -e "$FITB_APP_DIR/hermes-agent[anthropic,bedrock,google]" \
-        $constraints_flag --quiet --no-cache-dir
+        "${constraints_flag[@]}" --quiet --no-cache-dir
 
     _log "Installing hermes-webui..."
     if [ -f "$FITB_APP_DIR/hermes-webui/requirements.txt" ]; then
         "$pip_cmd" install -r "$FITB_APP_DIR/hermes-webui/requirements.txt" \
-            $constraints_flag --quiet --no-cache-dir
+            "${constraints_flag[@]}" --quiet --no-cache-dir
     elif [ -f "$FITB_APP_DIR/hermes-webui/setup.py" ] || \
          grep -q '^\[build-system\]' "$FITB_APP_DIR/hermes-webui/pyproject.toml" 2>/dev/null; then
         "$pip_cmd" install -e "$FITB_APP_DIR/hermes-webui" \
-            $constraints_flag --quiet --no-cache-dir
+            "${constraints_flag[@]}" --quiet --no-cache-dir
     else
         _die "hermes-webui has no requirements.txt, setup.py, or installable pyproject.toml"
     fi
 
     _log "Installing fox-overlay..."
-    "$pip_cmd" install -e "$FITB_OVERLAY_DIR" $constraints_flag --quiet --no-cache-dir
+    "$pip_cmd" install -e "$FITB_OVERLAY_DIR" "${constraints_flag[@]}" --quiet --no-cache-dir
 
     # supervisor: needed in bare-metal (Docker installs it separately)
     if [ "$FITB_CONTEXT" = "bare-metal" ]; then
         _log "Installing supervisor..."
-        "$pip_cmd" install supervisor $constraints_flag --quiet --no-cache-dir
+        "$pip_cmd" install supervisor "${constraints_flag[@]}" --quiet --no-cache-dir
     fi
 }
 

--- a/packages/integration/Dockerfile
+++ b/packages/integration/Dockerfile
@@ -133,6 +133,12 @@ COPY forks/hermes-webui /app/hermes-webui
 # (slow) forks+pip layer cache.
 COPY packages/fox-overlay /app/fox-overlay
 
+# ── pip constraints (supply-chain pin) ───────────────────────────────────────
+# Pins every transitive Python dependency to the version resolved in the last
+# verified build. Prevents silent dep drift across builds. Regenerate after
+# upstream bumps: see packages/integration/requirements.lock header.
+COPY packages/integration/requirements.lock /app/requirements.lock
+
 # ── install-core.sh — patches, pip, supervisord.conf ─────────────────────────
 # Single source of truth for all install logic (shared with .deb postinst).
 # Runs in Docker context: repos already COPYd, binaries handled in separate
@@ -148,6 +154,7 @@ RUN set -eux; \
     FITB_OVERLAY_DIR=/app/fox-overlay \
     FITB_DISABLE_WEBUI_OVERLAY=${FITB_DISABLE_WEBUI_OVERLAY} \
     FITB_DISABLE_AGENT_OVERLAY=${FITB_DISABLE_AGENT_OVERLAY} \
+    FITB_PIP_CONSTRAINTS=/app/requirements.lock \
     bash /tmp/install-core.sh; \
     rm /tmp/install-core.sh; \
     chown -R foxinthebox:foxinthebox /app/hermes-agent /app/hermes-webui /app/fox-overlay

--- a/packages/integration/requirements.lock
+++ b/packages/integration/requirements.lock
@@ -1,0 +1,93 @@
+# Frozen Python dependencies for the Fox container image.
+# Generated from ghcr.io/fox-in-the-box-ai/cloud:v0.7.51 on 2026-06-20.
+#
+# This file pins every transitive dependency resolved during container build.
+# It is used as a pip constraints file (-c) to prevent silent dependency drift
+# across builds.
+#
+# To regenerate after an upstream bump or dependency change:
+#   docker run --rm --entrypoint pip <new-image> freeze --exclude-editable | sort > packages/integration/requirements.lock
+#
+# Editable packages (hermes-agent, hermes-webui, fox-overlay) are excluded —
+# they are installed from local source, not PyPI.
+Jinja2==3.1.6
+Markdown==3.10.2
+MarkupSafe==3.0.3
+PyJWT==2.13.0
+PyYAML==6.0.3
+Pygments==2.20.0
+annotated-doc==0.0.4
+annotated-types==0.7.0
+anthropic==0.87.0
+anyio==4.14.0
+boto3==1.42.89
+botocore==1.42.97
+certifi==2026.5.20
+cffi==2.0.0
+charset-normalizer==3.4.7
+click==8.4.1
+croniter==6.0.0
+cryptography==49.0.0
+distro==1.9.0
+docstring_parser==0.18.0
+fastapi==0.138.0
+fire==0.7.1
+google-api-core==2.31.0
+google-api-python-client==2.194.0
+google-auth-httplib2==0.3.1
+google-auth-oauthlib==1.3.1
+google-auth==2.55.0
+googleapis-common-protos==1.75.0
+h11==0.16.0
+httpcore==1.0.9
+httplib2==0.31.2
+httptools==0.8.0
+httpx==0.28.1
+idna==3.18
+jiter==0.15.0
+jmespath==1.1.0
+markdown-it-py==4.2.0
+mdurl==0.1.2
+oauthlib==3.3.1
+openai==2.24.0
+packaging==26.0
+pathspec==1.1.1
+pillow==12.2.0
+prompt_toolkit==3.0.52
+proto-plus==1.28.0
+protobuf==7.35.1
+psutil==7.2.2
+ptyprocess==0.7.0
+pyasn1==0.6.3
+pyasn1_modules==0.4.2
+pycparser==3.0
+pydantic==2.13.4
+pydantic_core==2.46.4
+pyparsing==3.3.2
+python-dateutil==2.9.0.post0
+python-dotenv==1.2.2
+python-multipart==0.0.32
+pytz==2026.2
+requests-oauthlib==2.0.0
+requests==2.33.0
+rich==14.3.3
+ruamel.yaml.clib==0.2.15
+ruamel.yaml==0.18.17
+s3transfer==0.16.1
+six==1.17.0
+sniffio==1.3.1
+socksio==1.0.0
+starlette==1.3.1
+supervisor==4.3.0
+tenacity==9.1.4
+termcolor==3.3.0
+tqdm==4.68.3
+typing-inspection==0.4.2
+typing_extensions==4.15.0
+uritemplate==4.2.0
+urllib3==2.7.0
+uvicorn==0.49.0
+uvloop==0.22.1
+watchfiles==1.2.0
+wcwidth==0.8.1
+websockets==15.0.1


### PR DESCRIPTION
## Summary

Supply-chain hardening: pin all transitive Python dependencies in the container image to prevent silent drift across builds.

- **requirements.lock** — 80 packages pinned from the v0.7.51 production image pip freeze output
- **install-core.sh** — new `FITB_PIP_CONSTRAINTS` env var; when set, all pip install calls use `-c` (constraints mode). Backwards-compatible — bare-metal installs are unaffected
- **Dockerfile** — COPYs lock file and sets the constraints env var during build
- **build-container.yml** — post-build pip freeze consistency check (warning-only, amd64 smoke job)

### Deferred / out of scope

- Hash-pinned constraints (`--require-hashes`) — follow-up improvement; version pinning is the first step
- Lock file for bare-metal `.deb` installs (different resolution surface)

## Test plan

- [x] Constraints file generated from verified v0.7.51 production image
- [x] Shell array pattern for `constraints_flag` (no word-splitting bugs)
- [x] `FITB_PIP_CONSTRAINTS` documented in install-core.sh header
- [x] CI consistency check uses `docker cp` (no fork PR curl issues)
- [x] CHANGELOG [Unreleased] entries added
- [ ] CI: container build succeeds with constraints applied
- [ ] CI: pip freeze consistency check passes (warning-only)

Closes #418