### PR TITLE
chore: label unsigned Electron artifacts and reduce retention

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ matrix.artifact-name }}
+          name: ${{ matrix.artifact-name }}${{ inputs.signing-environment == '' && '-unsigned' || '' }}
           path: ${{ matrix.artifact-path }}
           if-no-files-found: error
-          retention-days: 30
+          retention-days: ${{ inputs.signing-environment == '' && 3 || 30 }}


### PR DESCRIPTION
## Summary

Unsigned CI-only Electron artifacts are now visually distinct from signed release artifacts.

- **Artifact naming** — unsigned builds append `-unsigned` suffix (e.g. `fox-windows-unsigned`, `fox-macos-unsigned`) so they can't be confused with signed release artifacts
- **Retention reduction** — unsigned artifacts retain for 3 days (down from 30); they exist only for CI verification and don't need long-term storage

### Deferred / out of scope

- Signed artifact retention unchanged (30 days) — those are release assets and may be needed for rollback investigation

## Test plan

- [x] GitHub Actions expression syntax verified against existing patterns in the same file (lines 108, 116, 135, 151 use the same `inputs.signing-environment` guard)
- [x] Confirmed `null == ''` evaluates `true` in GitHub Actions expressions (push/workflow_dispatch triggers)
- [x] Release path unaffected: `release.yml` always passes `signing-environment: release`, so artifact names stay `fox-windows` / `fox-macos` with 30-day retention
- [ ] CI runs on this PR to confirm workflow syntax is valid

Closes #411