### PR TITLE
fix(electron): boolean notarize config for electron-builder 26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+- macOS notarization config updated for electron-builder 26 (team ID read from environment variable instead of inline config) (#574)
+
 ---
 
 ## [0.7.52] — 2026-06-20

--- a/packages/electron/electron-builder.yml
+++ b/packages/electron/electron-builder.yml
@@ -62,8 +62,7 @@ mac:
   gatekeeperAssess: false
   entitlements: build/entitlements.mac.plist
   entitlementsInherit: build/entitlements.mac.plist
-  notarize:
-    teamId: Z6J8AVT9QK
+  notarize: true
 
 linux:
   category: Utility


### PR DESCRIPTION
## Summary

electron-builder 26 changed `mac.notarize` from an object (`{ teamId: "..." }`) to a boolean. The team ID is now read from the `APPLE_TEAM_ID` environment variable, which is already set in the `build-electron.yml` workflow.

- **`electron-builder.yml`** — `notarize: { teamId: Z6J8AVT9QK }` → `notarize: true`

### Deferred / out of scope

- Re-running the v0.7.52 release workflow to produce desktop installers (can be done after merge if needed)

## Test plan

- [x] Local quality gate: config-only change, no code paths affected
- [ ] On-target verification:
  - Merge, tag a patch release, verify `build-electron` macOS job succeeds with notarization

Closes #574