### PR TITLE
feat(electron): diagnostic report button and Ctrl+Shift+D shortcut (#293)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 - Approval card shows a plain-English explanation of flagged commands — helps users understand what a command does before approving (#150)
+- Diagnostic report button in the error window and via Ctrl+Shift+D — collects system, Docker, and log data in one click for support (#293)
 
 ### Fixed
 - macOS notarization config updated for electron-builder 26 (team ID read from environment variable instead of inline config) (#574)

--- a/packages/electron/assets/diagnostic.html
+++ b/packages/electron/assets/diagnostic.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy"
+      content="default-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self';">
+<style>
+@font-face {
+  font-family: "Sora";
+  src: url("fonts/Sora.woff2") format("woff2-variations");
+  font-weight: 100 900;
+  font-display: swap;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: "Sora", "Segoe UI", system-ui, sans-serif;
+  background: #0D0D1A;
+  color: #FFF8DC;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  padding: 28px 32px;
+  overflow: hidden;
+}
+
+.header {
+  flex-shrink: 0;
+  margin-bottom: 16px;
+}
+
+.brand-name {
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: rgba(255,248,220,0.5);
+  margin-bottom: 4px;
+}
+
+.accent-bar {
+  height: 2px;
+  background: linear-gradient(90deg, #26A69A 0%, rgba(38,166,154,0.2) 100%);
+  border-radius: 1px;
+  margin: 10px 0 14px;
+}
+
+.heading {
+  font-size: 16px;
+  font-weight: 600;
+  color: #26A69A;
+  letter-spacing: -0.01em;
+  margin-bottom: 6px;
+}
+
+.subtitle {
+  font-size: 12px;
+  color: rgba(255,248,220,0.45);
+  line-height: 1.5;
+}
+
+.loading {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  color: rgba(255,248,220,0.4);
+}
+
+.loading-dot {
+  display: inline-block;
+  animation: pulse 1.4s ease-in-out infinite;
+}
+@keyframes pulse {
+  0%, 80%, 100% { opacity: 0.3; }
+  40% { opacity: 1; }
+}
+
+.report-body {
+  flex: 1;
+  overflow-y: auto;
+  font-family: ui-monospace, "Cascadia Code", Consolas, monospace;
+  font-size: 11px;
+  color: rgba(255,248,220,0.65);
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+  padding: 12px;
+  background: rgba(255,255,255,0.03);
+  border: 1px solid rgba(255,255,255,0.06);
+  border-radius: 8px;
+  display: none;
+}
+
+.report-body::-webkit-scrollbar { width: 4px; }
+.report-body::-webkit-scrollbar-track { background: transparent; }
+.report-body::-webkit-scrollbar-thumb { background: rgba(38,166,154,0.3); border-radius: 2px; }
+
+.error-text {
+  flex: 1;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  color: #EF5350;
+}
+
+.actions {
+  flex-shrink: 0;
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 14px;
+}
+
+.btn {
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 8px 16px;
+  border-radius: 6px;
+  border: none;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+.btn:hover { opacity: 0.85; }
+.btn:disabled { opacity: 0.4; cursor: default; }
+
+.btn-copy {
+  background: rgba(38,166,154,0.15);
+  color: #26A69A;
+  border: 1px solid rgba(38,166,154,0.35);
+}
+.btn-close {
+  background: rgba(255,255,255,0.08);
+  color: rgba(255,248,220,0.7);
+  border: 1px solid rgba(255,255,255,0.1);
+}
+</style>
+</head>
+<body>
+<div class="header">
+  <div class="brand-name">Fox in the Box</div>
+  <div class="accent-bar"></div>
+  <div class="heading">Diagnostic Report</div>
+  <div class="subtitle">Review the report below, then copy to clipboard to share with support.</div>
+</div>
+
+<div class="loading" id="loading">
+  Gathering diagnostics<span class="loading-dot">...</span>
+</div>
+
+<pre class="report-body" id="report-body"></pre>
+
+<div class="error-text" id="error-text"></div>
+
+<div class="actions">
+  <button class="btn btn-copy" id="btn-copy" disabled>Copy to clipboard</button>
+  <button class="btn btn-close" id="btn-close">Close</button>
+</div>
+
+<script src="diagnostic.js"></script>
+</body>
+</html>

--- a/packages/electron/assets/diagnostic.js
+++ b/packages/electron/assets/diagnostic.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _reportText = '';
+let _reportText = '';
 
 if (window.fitbDiagnostic) {
   window.fitbDiagnostic.gather().then(function (markdown) {
@@ -11,7 +11,7 @@ if (window.fitbDiagnostic) {
       return;
     }
     _reportText = markdown;
-    var body = document.getElementById('report-body');
+    const body = document.getElementById('report-body');
     body.textContent = markdown;
     body.style.display = 'block';
     document.getElementById('btn-copy').disabled = false;
@@ -25,7 +25,7 @@ if (window.fitbDiagnostic) {
 document.getElementById('btn-copy').addEventListener('click', function () {
   if (_reportText && window.fitbDiagnostic) {
     window.fitbDiagnostic.copy(_reportText);
-    var btn = document.getElementById('btn-copy');
+    const btn = document.getElementById('btn-copy');
     btn.textContent = 'Copied!';
     setTimeout(function () { btn.textContent = 'Copy to clipboard'; }, 2000);
   }

--- a/packages/electron/assets/diagnostic.js
+++ b/packages/electron/assets/diagnostic.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var _reportText = '';
+
+if (window.fitbDiagnostic) {
+  window.fitbDiagnostic.gather().then(function (markdown) {
+    document.getElementById('loading').style.display = 'none';
+    if (!markdown) {
+      document.getElementById('error-text').style.display = 'flex';
+      document.getElementById('error-text').textContent = 'Failed to generate diagnostic report.';
+      return;
+    }
+    _reportText = markdown;
+    var body = document.getElementById('report-body');
+    body.textContent = markdown;
+    body.style.display = 'block';
+    document.getElementById('btn-copy').disabled = false;
+  }).catch(function (err) {
+    document.getElementById('loading').style.display = 'none';
+    document.getElementById('error-text').style.display = 'flex';
+    document.getElementById('error-text').textContent = 'Error: ' + (err.message || err);
+  });
+}
+
+document.getElementById('btn-copy').addEventListener('click', function () {
+  if (_reportText && window.fitbDiagnostic) {
+    window.fitbDiagnostic.copy(_reportText);
+    var btn = document.getElementById('btn-copy');
+    btn.textContent = 'Copied!';
+    setTimeout(function () { btn.textContent = 'Copy to clipboard'; }, 2000);
+  }
+});
+
+document.getElementById('btn-close').addEventListener('click', function () {
+  if (window.fitbDiagnostic) window.fitbDiagnostic.close();
+});

--- a/packages/electron/assets/error.html
+++ b/packages/electron/assets/error.html
@@ -149,6 +149,12 @@ details[open] .diag-arrow { transform: rotate(90deg); }
   color: #FFD700;
   border: 1px solid rgba(255,215,0,0.3);
 }
+.btn-diag {
+  background: rgba(38,166,154,0.12);
+  color: #26A69A;
+  border: 1px solid rgba(38,166,154,0.3);
+  margin-right: auto;
+}
 .btn-close {
   background: rgba(255,255,255,0.08);
   color: rgba(255,248,220,0.7);
@@ -176,6 +182,7 @@ details[open] .diag-arrow { transform: rotate(90deg); }
   </details>
 
   <div class="actions">
+    <button class="btn btn-diag" id="btn-diag">Diagnostic report</button>
     <button class="btn btn-copy" id="btn-copy">Copy diagnostics</button>
     <button class="btn btn-close" id="btn-close">Close</button>
   </div>

--- a/packages/electron/assets/error.js
+++ b/packages/electron/assets/error.js
@@ -19,6 +19,10 @@ if (window.fitbError) {
   });
 }
 
+document.getElementById('btn-diag').addEventListener('click', () => {
+  if (window.fitbError) window.fitbError.openDiagnosticReport();
+});
+
 document.getElementById('btn-copy').addEventListener('click', () => {
   if (window.fitbError) window.fitbError.copyDiagnostics();
 });

--- a/packages/electron/src/diagnostic-report.js
+++ b/packages/electron/src/diagnostic-report.js
@@ -9,7 +9,7 @@ const SCRUB_PATTERNS = [
   { re: /sk-[A-Za-z0-9_-]{20,}/g, sub: 'sk-[REDACTED]' },
   { re: /key-[A-Za-z0-9_-]{20,}/g, sub: 'key-[REDACTED]' },
   { re: /Bearer\s+[A-Za-z0-9._-]{20,}/gi, sub: 'Bearer [REDACTED]' },
-  { re: /(OPENROUTER_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|API_KEY|SECRET|TOKEN|PASSWORD)\s*=\s*\S+/gi, sub: '$1=[REDACTED]' },
+  { re: /(OPENROUTER_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|API_KEY|SECRET|TOKEN|PASSWORD)\s*=\s*(?:"[^"]*"|'[^']*'|\S+)/gi, sub: '$1=[REDACTED]' },
 ];
 
 function scrubText(text) {
@@ -27,11 +27,21 @@ function scrubText(text) {
   return result;
 }
 
+const MAX_LOG_BYTES = 2 * 1024 * 1024;
+
 function readLogTail(logPath, lines) {
   try {
-    const content = fs.readFileSync(logPath, 'utf8');
-    const allLines = content.split('\n');
-    return allLines.slice(-lines).join('\n');
+    const stat = fs.statSync(logPath);
+    const start = Math.max(0, stat.size - MAX_LOG_BYTES);
+    const fd = fs.openSync(logPath, 'r');
+    try {
+      const buf = Buffer.alloc(Math.min(stat.size, MAX_LOG_BYTES));
+      fs.readSync(fd, buf, 0, buf.length, start);
+      const allLines = buf.toString('utf8').split('\n');
+      return allLines.slice(-lines).join('\n');
+    } finally {
+      fs.closeSync(fd);
+    }
   } catch (err) {
     return `[Could not read log: ${err.message}]`;
   }
@@ -53,8 +63,7 @@ function runSafe(command, args, timeoutMs) {
   });
 }
 
-async function gatherDiagnosticReport({ dockerManager, logPath, foxVersion, platform }) {
-  platform = platform || process.platform;
+async function gatherDiagnosticReport({ dockerManager, logPath, foxVersion, platform = process.platform }) {
   const report = {
     timestamp: new Date().toISOString(),
     installation_id: randomUUID(),
@@ -118,7 +127,7 @@ async function gatherDiagnosticReport({ dockerManager, logPath, foxVersion, plat
       filtered = raw.split('\n').filter(l => /docker/i.test(l)).join('\n')
         || '[No docker entries in launchctl]';
     }
-    report.darwin = { docker_daemon: filtered };
+    report.darwin = { docker_daemon: scrubText(filtered) };
   }
 
   return report;
@@ -206,5 +215,7 @@ module.exports = {
   formatAsMarkdown,
   scrubText,
   readLogTail,
+  runSafe,
   SCRUB_PATTERNS,
+  MAX_LOG_BYTES,
 };

--- a/packages/electron/src/diagnostic-report.js
+++ b/packages/electron/src/diagnostic-report.js
@@ -1,0 +1,210 @@
+'use strict';
+
+const os = require('os');
+const fs = require('fs');
+const { execFile } = require('child_process');
+const { randomUUID } = require('crypto');
+
+const SCRUB_PATTERNS = [
+  { re: /sk-[A-Za-z0-9_-]{20,}/g, sub: 'sk-[REDACTED]' },
+  { re: /key-[A-Za-z0-9_-]{20,}/g, sub: 'key-[REDACTED]' },
+  { re: /Bearer\s+[A-Za-z0-9._-]{20,}/gi, sub: 'Bearer [REDACTED]' },
+  { re: /(OPENROUTER_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|API_KEY|SECRET|TOKEN|PASSWORD)\s*=\s*\S+/gi, sub: '$1=[REDACTED]' },
+];
+
+function scrubText(text) {
+  if (!text) return '';
+  let result = text;
+  const home = os.homedir();
+  if (home) {
+    const escaped = home.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const placeholder = process.platform === 'win32' ? '%USERPROFILE%' : '$HOME';
+    result = result.replace(new RegExp(escaped, 'g'), placeholder);
+  }
+  for (const { re, sub } of SCRUB_PATTERNS) {
+    result = result.replace(re, sub);
+  }
+  return result;
+}
+
+function readLogTail(logPath, lines) {
+  try {
+    const content = fs.readFileSync(logPath, 'utf8');
+    const allLines = content.split('\n');
+    return allLines.slice(-lines).join('\n');
+  } catch (err) {
+    return `[Could not read log: ${err.message}]`;
+  }
+}
+
+function runSafe(command, args, timeoutMs) {
+  return new Promise((resolve) => {
+    try {
+      execFile(command, args, { timeout: timeoutMs }, (err, stdout, stderr) => {
+        if (err) {
+          resolve(`[Error: ${err.message}]`);
+          return;
+        }
+        resolve((stdout || '') + (stderr ? `\n[stderr] ${stderr}` : ''));
+      });
+    } catch (err) {
+      resolve(`[Failed to run: ${err.message}]`);
+    }
+  });
+}
+
+async function gatherDiagnosticReport({ dockerManager, logPath, foxVersion, platform }) {
+  platform = platform || process.platform;
+  const report = {
+    timestamp: new Date().toISOString(),
+    installation_id: randomUUID(),
+    fox_version: foxVersion || 'unknown',
+    os: {
+      platform,
+      arch: process.arch,
+      version: os.release(),
+      free_ram_gb: Math.round(os.freemem() / (1024 ** 3) * 10) / 10,
+      total_ram_gb: Math.round(os.totalmem() / (1024 ** 3) * 10) / 10,
+    },
+    docker: {},
+    log_tail: '',
+  };
+
+  if (dockerManager) {
+    try {
+      const diag = await dockerManager.getDiagnostics();
+      report.docker.daemon_reachable = diag.daemonReachable;
+      report.docker.active_socket = diag.activeSocket;
+      if (diag.dockerVersion) {
+        const v = diag.dockerVersion;
+        report.docker.version = {
+          Version: v.Version,
+          ApiVersion: v.ApiVersion,
+          Os: v.Os,
+          Arch: v.Arch,
+          KernelVersion: v.KernelVersion,
+        };
+      }
+      if (diag.container) {
+        report.docker.container = {
+          id: diag.container.id ? diag.container.id.substring(0, 12) : null,
+          name: diag.container.name,
+          state: diag.container.state,
+          status: diag.container.status,
+        };
+      }
+      if (diag.error) report.docker.error = diag.error;
+      const sysInfo = await dockerManager.getDockerSystemInfo();
+      if (sysInfo) report.docker.system_info = sysInfo;
+    } catch (err) {
+      report.docker.error = err.message;
+    }
+  }
+
+  if (logPath) {
+    report.log_tail = scrubText(readLogTail(logPath, 500));
+  }
+
+  if (platform === 'win32') {
+    const [wslStatus, wslList] = await Promise.all([
+      runSafe('wsl', ['--status'], 5000),
+      runSafe('wsl', ['--list', '--verbose'], 5000),
+    ]);
+    report.windows = { wsl_status: wslStatus, wsl_list: wslList };
+  } else if (platform === 'darwin') {
+    const raw = await runSafe('launchctl', ['list'], 5000);
+    let filtered = raw;
+    if (!raw.startsWith('[')) {
+      filtered = raw.split('\n').filter(l => /docker/i.test(l)).join('\n')
+        || '[No docker entries in launchctl]';
+    }
+    report.darwin = { docker_daemon: filtered };
+  }
+
+  return report;
+}
+
+function formatAsMarkdown(report) {
+  const lines = [];
+  lines.push('# Fox in the Box — Diagnostic Report');
+  lines.push('');
+  lines.push(`**Generated:** ${report.timestamp}`);
+  lines.push(`**Installation ID:** ${report.installation_id}`);
+  lines.push(`**Fox version:** ${report.fox_version}`);
+  lines.push('');
+
+  lines.push('## System');
+  lines.push(`- Platform: ${report.os.platform} (${report.os.arch})`);
+  lines.push(`- OS version: ${report.os.version}`);
+  lines.push(`- RAM: ${report.os.free_ram_gb} GB free / ${report.os.total_ram_gb} GB total`);
+  lines.push('');
+
+  lines.push('## Docker');
+  if (report.docker.error) {
+    lines.push(`- Error: ${report.docker.error}`);
+  }
+  lines.push(`- Daemon reachable: ${report.docker.daemon_reachable || false}`);
+  if (report.docker.active_socket) {
+    lines.push(`- Socket: ${report.docker.active_socket}`);
+  }
+  if (report.docker.version) {
+    const v = report.docker.version;
+    lines.push(`- Docker version: ${v.Version || 'unknown'} (API ${v.ApiVersion || '?'})`);
+    lines.push(`- Docker OS/Arch: ${v.Os || '?'}/${v.Arch || '?'}`);
+  }
+  if (report.docker.system_info) {
+    const si = report.docker.system_info;
+    if (si.OperatingSystem) lines.push(`- OS type: ${si.OSType || '?'} — ${si.OperatingSystem}`);
+    if (si.NCPU) lines.push(`- CPUs: ${si.NCPU}`);
+    if (si.MemTotal) lines.push(`- Docker memory: ${Math.round(si.MemTotal / (1024 ** 3) * 10) / 10} GB`);
+  }
+  if (report.docker.container) {
+    const c = report.docker.container;
+    lines.push(`- Container: ${c.name || '?'} — ${c.state || '?'} (${c.status || '?'})`);
+    lines.push(`- Container ID: ${c.id || '?'}`);
+  } else {
+    lines.push('- Container: not found');
+  }
+  lines.push('');
+
+  if (report.windows) {
+    lines.push('## Windows / WSL');
+    lines.push('');
+    lines.push('**WSL --status:**');
+    lines.push('```');
+    lines.push(report.windows.wsl_status || '[not available]');
+    lines.push('```');
+    lines.push('');
+    lines.push('**WSL --list --verbose:**');
+    lines.push('```');
+    lines.push(report.windows.wsl_list || '[not available]');
+    lines.push('```');
+    lines.push('');
+  }
+
+  if (report.darwin) {
+    lines.push('## macOS / Docker Daemon');
+    lines.push('```');
+    lines.push(report.darwin.docker_daemon || '[not available]');
+    lines.push('```');
+    lines.push('');
+  }
+
+  if (report.log_tail) {
+    lines.push('## Electron log (last 500 lines)');
+    lines.push('');
+    lines.push('```');
+    lines.push(report.log_tail);
+    lines.push('```');
+  }
+
+  return lines.join('\n');
+}
+
+module.exports = {
+  gatherDiagnosticReport,
+  formatAsMarkdown,
+  scrubText,
+  readLogTail,
+  SCRUB_PATTERNS,
+};

--- a/packages/electron/src/diagnostic-report.js
+++ b/packages/electron/src/diagnostic-report.js
@@ -9,7 +9,7 @@ const SCRUB_PATTERNS = [
   { re: /sk-[A-Za-z0-9_-]{20,}/g, sub: 'sk-[REDACTED]' },
   { re: /key-[A-Za-z0-9_-]{20,}/g, sub: 'key-[REDACTED]' },
   { re: /Bearer\s+[A-Za-z0-9._-]{20,}/gi, sub: 'Bearer [REDACTED]' },
-  { re: /(OPENROUTER_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|API_KEY|SECRET|TOKEN|PASSWORD)\s*=\s*(?:"[^"]*"|'[^']*'|\S+)/gi, sub: '$1=[REDACTED]' },
+  { re: /(OPENROUTER_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|API_KEY|SECRET|TOKEN|PASSWORD|\w+_KEY)\s*=\s*(?:"[^"]*"|'[^']*'|\S+)/gi, sub: '$1=[REDACTED]' },
 ];
 
 function scrubText(text) {
@@ -27,20 +27,22 @@ function scrubText(text) {
   return result;
 }
 
+const fsPromises = fs.promises;
+
 const MAX_LOG_BYTES = 2 * 1024 * 1024;
 
-function readLogTail(logPath, lines) {
+async function readLogTail(logPath, lines) {
   try {
-    const stat = fs.statSync(logPath);
+    const stat = await fsPromises.stat(logPath);
     const start = Math.max(0, stat.size - MAX_LOG_BYTES);
-    const fd = fs.openSync(logPath, 'r');
+    const fh = await fsPromises.open(logPath, 'r');
     try {
-      const buf = Buffer.alloc(Math.min(stat.size, MAX_LOG_BYTES));
-      fs.readSync(fd, buf, 0, buf.length, start);
+      const buf = Buffer.allocUnsafe(Math.min(stat.size, MAX_LOG_BYTES));
+      await fh.read(buf, 0, buf.length, start);
       const allLines = buf.toString('utf8').split('\n');
       return allLines.slice(-lines).join('\n');
     } finally {
-      fs.closeSync(fd);
+      await fh.close();
     }
   } catch (err) {
     return `[Could not read log: ${err.message}]`;
@@ -111,7 +113,7 @@ async function gatherDiagnosticReport({ dockerManager, logPath, foxVersion, plat
   }
 
   if (logPath) {
-    report.log_tail = scrubText(readLogTail(logPath, 500));
+    report.log_tail = scrubText(await readLogTail(logPath, 500));
   }
 
   if (platform === 'win32') {
@@ -119,7 +121,7 @@ async function gatherDiagnosticReport({ dockerManager, logPath, foxVersion, plat
       runSafe('wsl', ['--status'], 5000),
       runSafe('wsl', ['--list', '--verbose'], 5000),
     ]);
-    report.windows = { wsl_status: wslStatus, wsl_list: wslList };
+    report.windows = { wsl_status: scrubText(wslStatus), wsl_list: scrubText(wslList) };
   } else if (platform === 'darwin') {
     const raw = await runSafe('launchctl', ['list'], 5000);
     let filtered = raw;

--- a/packages/electron/src/docker-manager.js
+++ b/packages/electron/src/docker-manager.js
@@ -649,6 +649,27 @@ async function getDiagnostics() {
   return diagnostics;
 }
 
+const _SYSTEM_INFO_ALLOWLIST = [
+  'ServerVersion', 'OSType', 'OperatingSystem', 'KernelVersion',
+  'Architecture', 'NCPU', 'MemTotal', 'DockerRootDir',
+];
+
+async function getDockerSystemInfo() {
+  if (!docker) return null;
+  try {
+    const reachable = await isDaemonRunning();
+    if (!reachable) return null;
+    const info = await docker.info();
+    const result = {};
+    for (const key of _SYSTEM_INFO_ALLOWLIST) {
+      if (key in info) result[key] = info[key];
+    }
+    return result;
+  } catch (err) {
+    return { error: err.message };
+  }
+}
+
 function monitorContainerSetupLogs(showProgress, {
   pollIntervalMs = 1_000,
   tailLines = 400,
@@ -722,4 +743,5 @@ module.exports = {
   restartContainer,
   removeContainerAndImage,
   getDiagnostics,
+  getDockerSystemInfo,
 };

--- a/packages/electron/src/docker-manager.js
+++ b/packages/electron/src/docker-manager.js
@@ -651,7 +651,7 @@ async function getDiagnostics() {
 
 const _SYSTEM_INFO_ALLOWLIST = [
   'ServerVersion', 'OSType', 'OperatingSystem', 'KernelVersion',
-  'Architecture', 'NCPU', 'MemTotal', 'DockerRootDir',
+  'Architecture', 'NCPU', 'MemTotal',
 ];
 
 async function getDockerSystemInfo() {

--- a/packages/electron/src/main.js
+++ b/packages/electron/src/main.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { app, BrowserWindow, dialog, shell, clipboard, ipcMain } = require('electron');
+const { app, BrowserWindow, dialog, shell, clipboard, ipcMain, globalShortcut } = require('electron');
 const { spawn, exec } = require('child_process');
 const path = require('path');
 const fs = require('fs');
@@ -19,6 +19,7 @@ const {
 const { runStartup, ensureContainerHealthy, StartupPhaseError } = require('./startup-orchestrator');
 const { registerWindowsRunOnceResume } = require('./windows-run-once');
 const { APP_HOME_URL } = require('./app-urls');
+const diagnosticReport = require('./diagnostic-report');
 const APP_ICON = process.platform === 'win32'
   ? path.join(__dirname, '..', 'assets', 'icon.ico')
   : path.join(__dirname, '..', 'assets', 'icon.png');
@@ -306,6 +307,7 @@ function showError(details) {
     });
   });
   ipcMain.once('error:close', () => win.close());
+  ipcMain.once('error:open-diagnostic', () => openDiagnosticWindow());
 
   win.loadFile(path.join(__dirname, '..', 'assets', 'error.html'));
   win.setMenu(null);
@@ -313,6 +315,71 @@ function showError(details) {
   win.on('closed', () => {
     _errorData = null;
     if (_fatalStartup) app.exit(1);
+  });
+}
+
+// ─── Diagnostic report (#293) ────────────────────────────────────────────────
+
+let _diagnosticWin = null;
+
+function openDiagnosticWindow() {
+  if (_diagnosticWin && !_diagnosticWin.isDestroyed()) {
+    _diagnosticWin.focus();
+    return;
+  }
+
+  _diagnosticWin = new BrowserWindow({
+    width: 640,
+    height: 520,
+    resizable: true,
+    minimizable: false,
+    maximizable: false,
+    closable: true,
+    alwaysOnTop: true,
+    frame: true,
+    title: 'Fox in the Box — Diagnostic Report',
+    icon: APP_ICON,
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      preload: path.join(__dirname, 'preload-diagnostic.js'),
+    },
+  });
+
+  ipcMain.handleOnce('diagnostic:gather', async () => {
+    try {
+      const report = await diagnosticReport.gatherDiagnosticReport({
+        dockerManager: docker,
+        logPath: path.join(app.getPath('logs'), 'main.log'),
+        foxVersion: app.getVersion(),
+      });
+      return diagnosticReport.formatAsMarkdown(report);
+    } catch (err) {
+      log.error('Diagnostic report gather failed:', err);
+      return null;
+    }
+  });
+
+  ipcMain.once('diagnostic:copy', (_event, text) => {
+    clipboard.writeText(text);
+    if (_diagnosticWin && !_diagnosticWin.isDestroyed()) {
+      dialog.showMessageBox(_diagnosticWin, {
+        type: 'info',
+        message: 'Diagnostic report copied to clipboard.',
+        buttons: ['OK'],
+      });
+    }
+  });
+
+  ipcMain.once('diagnostic:close', () => {
+    if (_diagnosticWin && !_diagnosticWin.isDestroyed()) _diagnosticWin.close();
+  });
+
+  _diagnosticWin.loadFile(path.join(__dirname, '..', 'assets', 'diagnostic.html'));
+  _diagnosticWin.setMenu(null);
+
+  _diagnosticWin.on('closed', () => {
+    _diagnosticWin = null;
   });
 }
 
@@ -618,6 +685,10 @@ async function main() {
   if (resumeAfterReboot) {
     log.info('[startup] Post-reboot resume (--resume-setup)');
   }
+
+  globalShortcut.register('CommandOrControl+Shift+D', () => {
+    openDiagnosticWindow();
+  });
 
   _setupInProgress = true;
   let _tailnetUrl = null;

--- a/packages/electron/src/main.js
+++ b/packages/electron/src/main.js
@@ -330,6 +330,10 @@ function openDiagnosticWindow() {
     return;
   }
 
+  ipcMain.removeHandler('diagnostic:gather');
+  ipcMain.removeAllListeners('diagnostic:copy');
+  ipcMain.removeAllListeners('diagnostic:close');
+
   _diagnosticWin = new BrowserWindow({
     width: 640,
     height: 520,
@@ -348,7 +352,7 @@ function openDiagnosticWindow() {
     },
   });
 
-  ipcMain.handleOnce('diagnostic:gather', async () => {
+  ipcMain.handle('diagnostic:gather', async () => {
     try {
       const report = await diagnosticReport.gatherDiagnosticReport({
         dockerManager: docker,
@@ -691,9 +695,10 @@ async function main() {
     log.info('[startup] Post-reboot resume (--resume-setup)');
   }
 
-  globalShortcut.register('CommandOrControl+Shift+D', () => {
+  const shortcutOk = globalShortcut.register('CommandOrControl+Shift+D', () => {
     openDiagnosticWindow();
   });
+  if (!shortcutOk) log.warn('Failed to register diagnostic shortcut Ctrl+Shift+D');
 
   _setupInProgress = true;
   let _tailnetUrl = null;

--- a/packages/electron/src/main.js
+++ b/packages/electron/src/main.js
@@ -84,6 +84,7 @@ function migrateLegacyUserData() {
 migrateLegacyUserData();
 
 app.whenReady().then(main).catch(handleStartupError);
+app.on('will-quit', () => { globalShortcut.unregisterAll(); });
 app.setAppUserModelId('io.foxinthebox.desktop');
 // v0.7.19: `app.setName('Fox in the box')` removed — `productName: fox-in-the-box`
 // in package.json now drives the userData path, which is what we want
@@ -313,6 +314,7 @@ function showError(details) {
   win.setMenu(null);
 
   win.on('closed', () => {
+    ipcMain.removeAllListeners('error:open-diagnostic');
     _errorData = null;
     if (_fatalStartup) app.exit(1);
   });
@@ -379,6 +381,9 @@ function openDiagnosticWindow() {
   _diagnosticWin.setMenu(null);
 
   _diagnosticWin.on('closed', () => {
+    ipcMain.removeHandler('diagnostic:gather');
+    ipcMain.removeAllListeners('diagnostic:copy');
+    ipcMain.removeAllListeners('diagnostic:close');
     _diagnosticWin = null;
   });
 }

--- a/packages/electron/src/preload-diagnostic.js
+++ b/packages/electron/src/preload-diagnostic.js
@@ -1,0 +1,8 @@
+'use strict';
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('fitbDiagnostic', {
+  gather: () => ipcRenderer.invoke('diagnostic:gather'),
+  copy: (text) => ipcRenderer.send('diagnostic:copy', text),
+  close: () => ipcRenderer.send('diagnostic:close'),
+});

--- a/packages/electron/src/preload-error.js
+++ b/packages/electron/src/preload-error.js
@@ -5,4 +5,5 @@ contextBridge.exposeInMainWorld('fitbError', {
   getData: () => ipcRenderer.invoke('error:get-data'),
   copyDiagnostics: () => ipcRenderer.send('error:copy'),
   close: () => ipcRenderer.send('error:close'),
+  openDiagnosticReport: () => ipcRenderer.send('error:open-diagnostic'),
 });

--- a/tests/electron/diagnostic-report.test.js
+++ b/tests/electron/diagnostic-report.test.js
@@ -89,16 +89,16 @@ describe('readLogTail', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test('returns last N lines', () => {
-    const result = readLogTail(logFile, 5);
+  test('returns last N lines', async () => {
+    const result = await readLogTail(logFile, 5);
     const lines = result.split('\n');
     expect(lines).toContain('line 20');
     expect(lines).toContain('line 16');
     expect(lines).not.toContain('line 1');
   });
 
-  test('returns error message for missing file', () => {
-    const result = readLogTail('/nonexistent/path/log.txt', 10);
+  test('returns error message for missing file', async () => {
+    const result = await readLogTail('/nonexistent/path/log.txt', 10);
     expect(result).toMatch(/\[Could not read log:/);
   });
 });

--- a/tests/electron/diagnostic-report.test.js
+++ b/tests/electron/diagnostic-report.test.js
@@ -1,0 +1,273 @@
+'use strict';
+
+jest.mock('electron-log', () => ({ info: jest.fn(), warn: jest.fn(), debug: jest.fn(), error: jest.fn() }));
+
+const os = require('os');
+const fs = require('fs');
+const path = require('path');
+const { scrubText, readLogTail, formatAsMarkdown, gatherDiagnosticReport } = require('../../packages/electron/src/diagnostic-report');
+
+// ─── scrubText ──────────────────────────────────────────────────────────────
+
+describe('scrubText', () => {
+  test('redacts OpenRouter-style API keys', () => {
+    const input = 'Using key sk-or-v1-abc123def456ghi789jkl012mno345pqr678stu901vwx234yz';
+    expect(scrubText(input)).toBe('Using key sk-[REDACTED]');
+  });
+
+  test('redacts sk- prefixed keys', () => {
+    const input = 'OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrst';
+    expect(scrubText(input)).toBe('OPENAI_API_KEY=[REDACTED]');
+  });
+
+  test('redacts Bearer tokens', () => {
+    const input = 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature';
+    expect(scrubText(input)).toBe('Authorization: Bearer [REDACTED]');
+  });
+
+  test('redacts env var assignments for known secret names', () => {
+    const input = 'OPENROUTER_API_KEY=sk-or-v1-longvalue123456789012345';
+    expect(scrubText(input)).toBe('OPENROUTER_API_KEY=[REDACTED]');
+  });
+
+  test('redacts PASSWORD env var', () => {
+    expect(scrubText('DB_PASSWORD=hunter2')).toBe('DB_PASSWORD=[REDACTED]');
+  });
+
+  test('replaces home directory paths (unix)', () => {
+    const home = os.homedir();
+    const input = `Loading config from ${home}/Documents/config.json`;
+    const result = scrubText(input);
+    expect(result).not.toContain(home);
+    if (process.platform !== 'win32') {
+      expect(result).toContain('$HOME/Documents/config.json');
+    }
+  });
+
+  test('handles multiple keys in one block', () => {
+    const input = [
+      'API_KEY=mysecretvalue123',
+      'key-abcdefghijklmnopqrstuvwxyz',
+      'Bearer tok_1234567890abcdefghijklmno',
+    ].join('\n');
+    const result = scrubText(input);
+    expect(result).not.toContain('mysecretvalue123');
+    expect(result).toContain('key-[REDACTED]');
+    expect(result).toContain('Bearer [REDACTED]');
+  });
+
+  test('returns empty string for falsy input', () => {
+    expect(scrubText(null)).toBe('');
+    expect(scrubText(undefined)).toBe('');
+    expect(scrubText('')).toBe('');
+  });
+
+  test('leaves safe text unchanged', () => {
+    const input = 'Fox in the box v0.7.52 starting up';
+    expect(scrubText(input)).toBe(input);
+  });
+});
+
+// ─── readLogTail ────────────────────────────────────────────────────────────
+
+describe('readLogTail', () => {
+  const tmpDir = path.join(os.tmpdir(), 'fitb-diag-test-' + Date.now());
+  const logFile = path.join(tmpDir, 'test.log');
+
+  beforeAll(() => {
+    fs.mkdirSync(tmpDir, { recursive: true });
+    const lines = Array.from({ length: 20 }, (_, i) => `line ${i + 1}`);
+    fs.writeFileSync(logFile, lines.join('\n'));
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('returns last N lines', () => {
+    const result = readLogTail(logFile, 5);
+    const lines = result.split('\n');
+    expect(lines).toContain('line 20');
+    expect(lines).toContain('line 16');
+    expect(lines).not.toContain('line 1');
+  });
+
+  test('returns error message for missing file', () => {
+    const result = readLogTail('/nonexistent/path/log.txt', 10);
+    expect(result).toMatch(/\[Could not read log:/);
+  });
+});
+
+// ─── formatAsMarkdown ───────────────────────────────────────────────────────
+
+describe('formatAsMarkdown', () => {
+  const baseReport = {
+    timestamp: '2026-06-20T12:00:00.000Z',
+    installation_id: 'test-uuid-1234',
+    fox_version: 'v0.7.53',
+    os: {
+      platform: 'darwin',
+      arch: 'arm64',
+      version: '25.5.0',
+      free_ram_gb: 8.2,
+      total_ram_gb: 16.0,
+    },
+    docker: {
+      daemon_reachable: true,
+      active_socket: 'default',
+      version: { Version: '27.5.1', ApiVersion: '1.47', Os: 'linux', Arch: 'amd64' },
+      container: { id: 'abc123def456', name: '/fox-in-the-box', state: 'running', status: 'Up 2 hours' },
+    },
+    log_tail: 'Fox in the box starting up\nContainer healthy',
+  };
+
+  test('includes header and version', () => {
+    const md = formatAsMarkdown(baseReport);
+    expect(md).toContain('# Fox in the Box — Diagnostic Report');
+    expect(md).toContain('v0.7.53');
+    expect(md).toContain('test-uuid-1234');
+  });
+
+  test('includes system info', () => {
+    const md = formatAsMarkdown(baseReport);
+    expect(md).toContain('darwin (arm64)');
+    expect(md).toContain('8.2 GB free');
+  });
+
+  test('includes docker info', () => {
+    const md = formatAsMarkdown(baseReport);
+    expect(md).toContain('Daemon reachable: true');
+    expect(md).toContain('27.5.1');
+    expect(md).toContain('/fox-in-the-box');
+  });
+
+  test('includes log tail', () => {
+    const md = formatAsMarkdown(baseReport);
+    expect(md).toContain('Fox in the box starting up');
+    expect(md).toContain('Container healthy');
+  });
+
+  test('includes windows section when present', () => {
+    const report = { ...baseReport, windows: { wsl_status: 'Default: Ubuntu', wsl_list: '  NAME    STATE' } };
+    const md = formatAsMarkdown(report);
+    expect(md).toContain('Windows / WSL');
+    expect(md).toContain('Default: Ubuntu');
+  });
+
+  test('includes darwin section when present', () => {
+    const report = { ...baseReport, darwin: { docker_daemon: 'com.docker.vmnetd' } };
+    const md = formatAsMarkdown(report);
+    expect(md).toContain('macOS / Docker Daemon');
+    expect(md).toContain('com.docker.vmnetd');
+  });
+
+  test('handles missing container gracefully', () => {
+    const report = { ...baseReport, docker: { daemon_reachable: false } };
+    const md = formatAsMarkdown(report);
+    expect(md).toContain('Container: not found');
+  });
+
+  test('handles docker system_info when present', () => {
+    const report = {
+      ...baseReport,
+      docker: {
+        ...baseReport.docker,
+        system_info: { OSType: 'linux', OperatingSystem: 'Docker Desktop', NCPU: 8, MemTotal: 17179869184 },
+      },
+    };
+    const md = formatAsMarkdown(report);
+    expect(md).toContain('linux');
+    expect(md).toContain('Docker Desktop');
+    expect(md).toContain('CPUs: 8');
+  });
+});
+
+// ─── gatherDiagnosticReport ─────────────────────────────────────────────────
+
+describe('gatherDiagnosticReport', () => {
+  test('returns report with OS info even without docker', async () => {
+    const report = await gatherDiagnosticReport({});
+    expect(report.os.platform).toBeTruthy();
+    expect(report.os.arch).toBeTruthy();
+    expect(report.installation_id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(report.timestamp).toBeTruthy();
+  });
+
+  test('calls dockerManager.getDiagnostics when provided', async () => {
+    const mockDocker = {
+      getDiagnostics: jest.fn().mockResolvedValue({
+        daemonReachable: true,
+        activeSocket: '/var/run/docker.sock',
+        dockerVersion: { Version: '27.0.0', ApiVersion: '1.46', Os: 'linux', Arch: 'amd64' },
+        container: { id: 'abcdef123456', name: '/fox-in-the-box', state: 'running', status: 'Up' },
+      }),
+      getDockerSystemInfo: jest.fn().mockResolvedValue({
+        OSType: 'linux',
+        OperatingSystem: 'Ubuntu 24.04',
+        NCPU: 4,
+      }),
+    };
+
+    const report = await gatherDiagnosticReport({ dockerManager: mockDocker });
+    expect(mockDocker.getDiagnostics).toHaveBeenCalled();
+    expect(mockDocker.getDockerSystemInfo).toHaveBeenCalled();
+    expect(report.docker.daemon_reachable).toBe(true);
+    expect(report.docker.version.Version).toBe('27.0.0');
+    expect(report.docker.container.id).toBe('abcdef123456');
+    expect(report.docker.system_info.NCPU).toBe(4);
+  });
+
+  test('handles dockerManager errors gracefully', async () => {
+    const mockDocker = {
+      getDiagnostics: jest.fn().mockRejectedValue(new Error('Docker not available')),
+      getDockerSystemInfo: jest.fn().mockResolvedValue(null),
+    };
+
+    const report = await gatherDiagnosticReport({ dockerManager: mockDocker });
+    expect(report.docker.error).toBe('Docker not available');
+  });
+
+  test('does not include container logs (SEC-1)', async () => {
+    const mockDocker = {
+      getDiagnostics: jest.fn().mockResolvedValue({
+        daemonReachable: true,
+        containerLogs: 'secret conversation content here',
+        container: { id: 'abc', name: '/fox', state: 'running', status: 'Up' },
+      }),
+      getDockerSystemInfo: jest.fn().mockResolvedValue(null),
+    };
+
+    const report = await gatherDiagnosticReport({ dockerManager: mockDocker });
+    const fullText = JSON.stringify(report);
+    expect(fullText).not.toContain('secret conversation content');
+  });
+
+  test('scrubs log content', async () => {
+    const tmpDir = path.join(os.tmpdir(), 'fitb-diag-gather-' + Date.now());
+    const logFile = path.join(tmpDir, 'main.log');
+    fs.mkdirSync(tmpDir, { recursive: true });
+    fs.writeFileSync(logFile, 'Using API_KEY=sk-or-v1-reallylongsecretkeythatshouldberedacted\nNormal log line');
+
+    try {
+      const report = await gatherDiagnosticReport({ logPath: logFile });
+      expect(report.log_tail).not.toContain('reallylongsecretkeythatshouldberedacted');
+      expect(report.log_tail).toContain('API_KEY=[REDACTED]');
+      expect(report.log_tail).toContain('Normal log line');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test('truncates container ID to 12 chars', async () => {
+    const mockDocker = {
+      getDiagnostics: jest.fn().mockResolvedValue({
+        daemonReachable: true,
+        container: { id: 'abcdef1234567890abcdef1234567890', name: '/fox', state: 'running', status: 'Up' },
+      }),
+      getDockerSystemInfo: jest.fn().mockResolvedValue(null),
+    };
+
+    const report = await gatherDiagnosticReport({ dockerManager: mockDocker });
+    expect(report.docker.container.id).toBe('abcdef123456');
+  });
+});

--- a/tests/electron/diagnostic-report.test.js
+++ b/tests/electron/diagnostic-report.test.js
@@ -5,7 +5,7 @@ jest.mock('electron-log', () => ({ info: jest.fn(), warn: jest.fn(), debug: jest
 const os = require('os');
 const fs = require('fs');
 const path = require('path');
-const { scrubText, readLogTail, formatAsMarkdown, gatherDiagnosticReport } = require('../../packages/electron/src/diagnostic-report');
+const { scrubText, readLogTail, runSafe, formatAsMarkdown, gatherDiagnosticReport, MAX_LOG_BYTES } = require('../../packages/electron/src/diagnostic-report');
 
 // ─── scrubText ──────────────────────────────────────────────────────────────
 
@@ -62,6 +62,11 @@ describe('scrubText', () => {
     expect(scrubText('')).toBe('');
   });
 
+  test('redacts quoted values in env var assignments', () => {
+    expect(scrubText('API_KEY="my secret value"')).toBe('API_KEY=[REDACTED]');
+    expect(scrubText("TOKEN='single-quoted-secret'")).toBe('TOKEN=[REDACTED]');
+  });
+
   test('leaves safe text unchanged', () => {
     const input = 'Fox in the box v0.7.52 starting up';
     expect(scrubText(input)).toBe(input);
@@ -95,6 +100,25 @@ describe('readLogTail', () => {
   test('returns error message for missing file', () => {
     const result = readLogTail('/nonexistent/path/log.txt', 10);
     expect(result).toMatch(/\[Could not read log:/);
+  });
+});
+
+// ─── runSafe ────────────────────────────────────────────────────────────────
+
+describe('runSafe', () => {
+  test('returns stdout of a successful command', async () => {
+    const result = await runSafe('echo', ['hello'], 5000);
+    expect(result.trim()).toBe('hello');
+  });
+
+  test('returns error message for a missing command', async () => {
+    const result = await runSafe('nonexistent_cmd_12345', [], 5000);
+    expect(result).toMatch(/\[Error:|Failed to run:/);
+  });
+
+  test('returns error message on timeout', async () => {
+    const result = await runSafe('sleep', ['30'], 100);
+    expect(result).toMatch(/\[Error:/);
   });
 });
 
@@ -269,5 +293,31 @@ describe('gatherDiagnosticReport', () => {
 
     const report = await gatherDiagnosticReport({ dockerManager: mockDocker });
     expect(report.docker.container.id).toBe('abcdef123456');
+  });
+
+  test('gathers darwin-specific info when platform is darwin', async () => {
+    const report = await gatherDiagnosticReport({ platform: 'darwin' });
+    expect(report.os.platform).toBe('darwin');
+    if (process.platform === 'darwin') {
+      expect(report.darwin).toBeDefined();
+      expect(report.darwin.docker_daemon).toBeDefined();
+    }
+    expect(report.windows).toBeUndefined();
+  });
+
+  test('gathers windows-specific info when platform is win32', async () => {
+    const report = await gatherDiagnosticReport({ platform: 'win32' });
+    expect(report.os.platform).toBe('win32');
+    expect(report.windows).toBeDefined();
+    expect(report.windows.wsl_status).toBeDefined();
+    expect(report.windows.wsl_list).toBeDefined();
+    expect(report.darwin).toBeUndefined();
+  });
+
+  test('skips platform sections for linux', async () => {
+    const report = await gatherDiagnosticReport({ platform: 'linux' });
+    expect(report.os.platform).toBe('linux');
+    expect(report.windows).toBeUndefined();
+    expect(report.darwin).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Adds a diagnostic report feature that collects system, Docker, and Electron log data in one click for support troubleshooting.

- **Diagnostic report module** (`diagnostic-report.js`) — gathers OS info, Docker daemon/container/system state (via Dockerode with field allowlists), and the last 500 lines of the Electron log, with privacy scrubbing (API keys, Bearer tokens, env var secrets, home directory paths)
- **Two entry points** — "Diagnostic report" button in the error window, and `Ctrl+Shift+D` / `Cmd+Shift+D` global shortcut
- **Preview-and-copy UI** — Fox-branded window matching existing error.html style; user reviews the report before copying to clipboard
- **SEC-1 compliant** — Dockerode APIs only (no shell commands for Docker), field allowlists on system info, no container logs, execFile not exec, random UUID not hostname hash, all output scrubbed for secrets

### Key implementation details

- IPC handler lifecycle: `handleOnce` + cleanup in window `closed` event prevents handler leak on repeated open/close
- `readLogTail` reads only the last 2 MB of the log file to avoid blocking the main process
- Scrub patterns handle quoted env var values (`API_KEY="secret"`)
- `globalShortcut` unregistered in `will-quit` event
- Platform-specific sections: WSL status on Windows, launchctl Docker entries on macOS (scrubbed)

### Deferred / out of scope

- Async file reading for log tail (current sync read is capped at 2 MB — acceptable for Electron main process)
- Network diagnostics (DNS, proxy detection) — separate ticket if needed

## Test plan

- [x] Local quality gate: `pnpm lint`, `pnpm test` (32 diagnostic-report tests pass, full suite green minus pre-existing docker-manager mock issues)
- [x] Adversarial 4-perspective code review (SECURITY / CORRECTNESS / TEST DISCIPLINE / CODE QUALITY)
- [ ] On-target verification:
  - Open error window → click "Diagnostic report" → verify preview loads with system/Docker/log data
  - Press Ctrl+Shift+D → verify diagnostic window opens
  - Copy button → paste into text editor → verify no API keys or home paths leaked
  - Open/close diagnostic window repeatedly → verify no IPC handler errors in console
  - Test on macOS and Windows

Closes #293