### PR TITLE
feat(overlay): custom provider CRUD in Settings → Providers (#144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 - Approval card shows a plain-English explanation of flagged commands — helps users understand what a command does before approving (#150)
 - Diagnostic report button in the error window and via Ctrl+Shift+D — collects system, Docker, and log data in one click for support (#293)
+- Custom provider management in Settings → Providers — add, edit, test, and delete OpenAI-compatible endpoints (llama.cpp, LM Studio, vLLM, etc.) directly from the UI (#144)
 
 ### Fixed
 - macOS notarization config updated for electron-builder 26 (team ID read from environment variable instead of inline config) (#574)

--- a/packages/fox-overlay/MANIFEST.toml
+++ b/packages/fox-overlay/MANIFEST.toml
@@ -21,6 +21,7 @@
 "fallback-polish.js" = "fox-only"
 "hostname-prompt.js" = "fox-only"
 "approval-explain.js" = "fox-only"
+"custom-providers.js" = "fox-only"
 # Phase 7 — Fox onboarding wizard static files (moved from fork's static/setup.* after Phase 7a removed them):
 "setup.html" = "fox-only"
 "setup.css" = "fox-only"
@@ -63,6 +64,7 @@
 "fox_overlay.webui_modules.hostname" = "fox-only-additive"  # claims /api/settings/hostname (bare + /dismiss-prompt) (was forks/hermes-webui/api/hostname.py)
 "fox_overlay.webui_modules.onboarding" = "fox-only-additive"  # Phase 7: claims /setup (bare) + /api/setup/; exports _write_env_key for hostname (was forks/hermes-webui/api/onboarding.py)
 "fox_overlay.webui_modules.approval_explain" = "fox-only-additive"  # claims POST /api/approval-explain/ — aux LLM command explanation (#150)
+"fox_overlay.webui_modules.custom_providers" = "fox-only-additive"  # claims /api/settings/custom-providers (bare + /test + /delete) — CRUD for OpenAI-compat providers (#144)
 
 # Phase 6 — webui mid-file monkey-patches. Fork files are restored to
 # virgin upstream content; these modules re-apply Fox behavior at runtime

--- a/packages/fox-overlay/fox_overlay/webui_modules/__init__.py
+++ b/packages/fox-overlay/fox_overlay/webui_modules/__init__.py
@@ -22,4 +22,5 @@ from . import readyz  # noqa: F401  -- registers GET /readyz (bare); always auth
 from . import version  # noqa: F401  -- registers GET /version (bare); auth-gated in managed mode per INSTANCE_CONTRACT §4.5
 from . import capabilities  # noqa: F401  -- registers GET /capabilities (bare); auth-gated in managed mode per INSTANCE_CONTRACT §4.5
 from . import approval_explain  # noqa: F401  -- registers POST /api/approval-explain/ at import
+from . import custom_providers  # noqa: F401  -- registers /api/settings/custom-providers (bare + sub-paths); CRUD for OpenAI-compat providers (#144)
 from . import test_hooks  # noqa: F401  -- (v0.7.7 #264) registers POST /test/* ONLY when FITB_TEST_MODE=1; production builds = no-op

--- a/packages/fox-overlay/fox_overlay/webui_modules/custom_providers.py
+++ b/packages/fox-overlay/fox_overlay/webui_modules/custom_providers.py
@@ -10,6 +10,8 @@ Routes:
     POST /api/settings/custom-providers/test  → probe base_url/models
     POST /api/settings/custom-providers/delete → remove by name
 """
+from __future__ import annotations
+
 import json
 import logging
 import re
@@ -51,7 +53,7 @@ def _validate_base_url(url: str) -> tuple[bool, str]:
     return True, url
 
 
-def _validate_models(models: Any) -> tuple[bool, list[str]]:
+def _validate_models(models: Any) -> tuple[bool, list[str] | str]:
     if not isinstance(models, list):
         return False, "Models must be a list."
     cleaned = []
@@ -76,7 +78,8 @@ def _read_custom_providers() -> list[dict]:
     return [e for e in entries if isinstance(e, dict) and e.get("name")]
 
 
-def _write_custom_providers(entries: list[dict]) -> None:
+def _modify_custom_providers(mutator) -> None:
+    """Read-modify-write custom_providers atomically under _cfg_lock."""
     from api.config import (
         _cfg_lock,
         _get_config_path,
@@ -87,6 +90,11 @@ def _write_custom_providers(entries: list[dict]) -> None:
         cfg = _load_yaml_config_file(_get_config_path())
         if not isinstance(cfg, dict):
             cfg = {}
+        entries = cfg.get("custom_providers", [])
+        if not isinstance(entries, list):
+            entries = []
+        entries = [e for e in entries if isinstance(e, dict) and e.get("name")]
+        entries = mutator(entries)
         cfg["custom_providers"] = entries
         _save_yaml_config_file(_get_config_path(), cfg)
 
@@ -125,8 +133,10 @@ def upsert_provider(body: dict) -> dict[str, Any]:
     raw_key = body.get("api_key")
     if isinstance(raw_key, str):
         api_key = raw_key.strip()
+    if api_key == "****":
+        api_key = ""
 
-    new_entry = {
+    new_entry: dict[str, Any] = {
         "name": name,
         "base_url": base_url,
         "models": models,
@@ -134,21 +144,20 @@ def upsert_provider(body: dict) -> dict[str, Any]:
     if api_key:
         new_entry["api_key"] = api_key
 
-    entries = _read_custom_providers()
     name_lower = name.lower()
-    replaced = False
-    for i, entry in enumerate(entries):
-        if str(entry.get("name", "")).strip().lower() == name_lower:
-            if api_key == "****":
-                new_entry["api_key"] = entry.get("api_key", "")
-            entries[i] = new_entry
-            replaced = True
-            break
-    if not replaced:
+
+    def _mutate(entries: list[dict]) -> list[dict]:
+        for i, entry in enumerate(entries):
+            if str(entry.get("name", "")).strip().lower() == name_lower:
+                if not api_key and entry.get("api_key"):
+                    new_entry["api_key"] = entry["api_key"]
+                entries[i] = new_entry
+                return entries
         entries.append(new_entry)
+        return entries
 
     try:
-        _write_custom_providers(entries)
+        _modify_custom_providers(_mutate)
     except Exception as exc:
         logger.exception("Failed to save custom providers: %s", exc)
         return {"ok": False, "error": f"Failed to save: {exc}"}
@@ -162,19 +171,21 @@ def delete_provider(body: dict) -> dict[str, Any]:
     if not isinstance(raw_name, str) or not raw_name.strip():
         return {"ok": False, "error": "Name is required."}
     target = raw_name.strip().lower()
+    found = [False]
 
-    entries = _read_custom_providers()
-    before_len = len(entries)
-    entries = [e for e in entries if str(e.get("name", "")).strip().lower() != target]
-
-    if len(entries) == before_len:
-        return {"ok": False, "error": f"Provider '{raw_name.strip()}' not found."}
+    def _mutate(entries: list[dict]) -> list[dict]:
+        result = [e for e in entries if str(e.get("name", "")).strip().lower() != target]
+        found[0] = len(result) < len(entries)
+        return result
 
     try:
-        _write_custom_providers(entries)
+        _modify_custom_providers(_mutate)
     except Exception as exc:
         logger.exception("Failed to delete custom provider: %s", exc)
         return {"ok": False, "error": f"Failed to save: {exc}"}
+
+    if not found[0]:
+        return {"ok": False, "error": f"Provider '{raw_name.strip()}' not found."}
 
     logger.info("Custom provider deleted: %s", raw_name.strip())
     return {"ok": True}
@@ -199,8 +210,8 @@ def test_provider(body: dict) -> dict[str, Any]:
         req.add_header("Authorization", f"Bearer {api_key}")
 
     try:
-        with urllib.request.urlopen(req, timeout=5) as resp:
-            data = json.loads(resp.read().decode("utf-8", errors="replace"))
+        with urllib.request.urlopen(req, timeout=5) as resp:  # nosec B310 -- user-supplied URL, validated to http(s) scheme
+            data = json.loads(resp.read(1_048_576).decode("utf-8", errors="replace"))
             models_found = 0
             if isinstance(data, dict) and isinstance(data.get("data"), list):
                 models_found = len(data["data"])

--- a/packages/fox-overlay/fox_overlay/webui_modules/custom_providers.py
+++ b/packages/fox-overlay/fox_overlay/webui_modules/custom_providers.py
@@ -1,0 +1,274 @@
+"""Fox additive webui module: custom OpenAI-compatible provider management (#144).
+
+Exposes CRUD + connectivity-test endpoints for custom providers stored
+in config.yaml's ``custom_providers`` list.  Follows the hostname.py
+dispatcher pattern (allow_bare=True, own boundary check).
+
+Routes:
+    GET  /api/settings/custom-providers       → list (API keys masked)
+    POST /api/settings/custom-providers       → add or update
+    POST /api/settings/custom-providers/test  → probe base_url/models
+    POST /api/settings/custom-providers/delete → remove by name
+"""
+import json
+import logging
+import re
+import urllib.error
+import urllib.request
+from typing import Any
+
+logger = logging.getLogger("fox_overlay.webui_modules.custom_providers")
+
+_URL_RE = re.compile(r"^https?://[^\s]+$", re.IGNORECASE)
+_NAME_MAX_LEN = 64
+
+
+def _mask_key(key: str | None) -> str:
+    if not key or not str(key).strip():
+        return ""
+    return "****"
+
+
+def _validate_name(name: str) -> tuple[bool, str]:
+    if not isinstance(name, str):
+        return False, "Name must be a string."
+    name = name.strip()
+    if not name:
+        return False, "Name is required."
+    if len(name) > _NAME_MAX_LEN:
+        return False, f"Name must be {_NAME_MAX_LEN} characters or fewer."
+    return True, name
+
+
+def _validate_base_url(url: str) -> tuple[bool, str]:
+    if not isinstance(url, str):
+        return False, "Base URL must be a string."
+    url = url.strip().rstrip("/")
+    if not url:
+        return False, "Base URL is required."
+    if not _URL_RE.match(url):
+        return False, "Base URL must start with http:// or https://."
+    return True, url
+
+
+def _validate_models(models: Any) -> tuple[bool, list[str]]:
+    if not isinstance(models, list):
+        return False, "Models must be a list."
+    cleaned = []
+    for m in models:
+        if isinstance(m, str):
+            s = m.strip()
+            if s:
+                cleaned.append(s)
+    if not cleaned:
+        return False, "At least one model is required."
+    return True, cleaned
+
+
+def _read_custom_providers() -> list[dict]:
+    from api.config import get_config
+    cfg = get_config()
+    if not isinstance(cfg, dict):
+        return []
+    entries = cfg.get("custom_providers", [])
+    if not isinstance(entries, list):
+        return []
+    return [e for e in entries if isinstance(e, dict) and e.get("name")]
+
+
+def _write_custom_providers(entries: list[dict]) -> None:
+    from api.config import (
+        _cfg_lock,
+        _get_config_path,
+        _load_yaml_config_file,
+        _save_yaml_config_file,
+    )
+    with _cfg_lock:
+        cfg = _load_yaml_config_file(_get_config_path())
+        if not isinstance(cfg, dict):
+            cfg = {}
+        cfg["custom_providers"] = entries
+        _save_yaml_config_file(_get_config_path(), cfg)
+
+    from api.config import invalidate_models_cache, reload_config
+    reload_config()
+    invalidate_models_cache()
+
+
+def get_providers_list() -> dict[str, Any]:
+    entries = _read_custom_providers()
+    result = []
+    for entry in entries:
+        result.append({
+            "name": entry.get("name", ""),
+            "base_url": entry.get("base_url", ""),
+            "api_key": _mask_key(entry.get("api_key")),
+            "models": entry.get("models", []),
+        })
+    return {"ok": True, "providers": result}
+
+
+def upsert_provider(body: dict) -> dict[str, Any]:
+    ok, name = _validate_name(body.get("name", ""))
+    if not ok:
+        return {"ok": False, "error": name}
+
+    ok, base_url = _validate_base_url(body.get("base_url", ""))
+    if not ok:
+        return {"ok": False, "error": base_url}
+
+    ok, models = _validate_models(body.get("models", []))
+    if not ok:
+        return {"ok": False, "error": models}
+
+    api_key = ""
+    raw_key = body.get("api_key")
+    if isinstance(raw_key, str):
+        api_key = raw_key.strip()
+
+    new_entry = {
+        "name": name,
+        "base_url": base_url,
+        "models": models,
+    }
+    if api_key:
+        new_entry["api_key"] = api_key
+
+    entries = _read_custom_providers()
+    name_lower = name.lower()
+    replaced = False
+    for i, entry in enumerate(entries):
+        if str(entry.get("name", "")).strip().lower() == name_lower:
+            if api_key == "****":
+                new_entry["api_key"] = entry.get("api_key", "")
+            entries[i] = new_entry
+            replaced = True
+            break
+    if not replaced:
+        entries.append(new_entry)
+
+    try:
+        _write_custom_providers(entries)
+    except Exception as exc:
+        logger.exception("Failed to save custom providers: %s", exc)
+        return {"ok": False, "error": f"Failed to save: {exc}"}
+
+    logger.info("Custom provider upserted: %s → %s", name, base_url)
+    return {"ok": True}
+
+
+def delete_provider(body: dict) -> dict[str, Any]:
+    raw_name = body.get("name", "")
+    if not isinstance(raw_name, str) or not raw_name.strip():
+        return {"ok": False, "error": "Name is required."}
+    target = raw_name.strip().lower()
+
+    entries = _read_custom_providers()
+    before_len = len(entries)
+    entries = [e for e in entries if str(e.get("name", "")).strip().lower() != target]
+
+    if len(entries) == before_len:
+        return {"ok": False, "error": f"Provider '{raw_name.strip()}' not found."}
+
+    try:
+        _write_custom_providers(entries)
+    except Exception as exc:
+        logger.exception("Failed to delete custom provider: %s", exc)
+        return {"ok": False, "error": f"Failed to save: {exc}"}
+
+    logger.info("Custom provider deleted: %s", raw_name.strip())
+    return {"ok": True}
+
+
+def test_provider(body: dict) -> dict[str, Any]:
+    ok, base_url = _validate_base_url(body.get("base_url", ""))
+    if not ok:
+        return {"ok": False, "error": base_url}
+
+    api_key = ""
+    raw_key = body.get("api_key")
+    if isinstance(raw_key, str):
+        api_key = raw_key.strip()
+    if api_key == "****":
+        api_key = ""
+
+    models_url = base_url.rstrip("/") + "/models"
+    req = urllib.request.Request(models_url, method="GET")
+    req.add_header("Accept", "application/json")
+    if api_key:
+        req.add_header("Authorization", f"Bearer {api_key}")
+
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            data = json.loads(resp.read().decode("utf-8", errors="replace"))
+            models_found = 0
+            if isinstance(data, dict) and isinstance(data.get("data"), list):
+                models_found = len(data["data"])
+            return {"ok": True, "models_found": models_found}
+    except urllib.error.HTTPError as exc:
+        if exc.code == 401 or exc.code == 403:
+            return {"ok": False, "error": "Authentication required or denied."}
+        return {"ok": False, "error": f"HTTP {exc.code}: {exc.reason}"}
+    except urllib.error.URLError as exc:
+        reason = str(getattr(exc, "reason", exc))
+        return {"ok": False, "error": f"Connection failed: {reason}"}
+    except Exception as exc:
+        return {"ok": False, "error": f"Connection failed: {exc}"}
+
+
+# ── Route handlers ──────────────────────────────────────────────────────────
+
+def handle_get(handler) -> dict[str, Any]:
+    return get_providers_list()
+
+
+def handle_post(handler, body: dict) -> dict[str, Any]:
+    return upsert_provider(body)
+
+
+def handle_delete(handler, body: dict) -> dict[str, Any]:
+    return delete_provider(body)
+
+
+def handle_test(handler, body: dict) -> dict[str, Any]:
+    return test_provider(body)
+
+
+# ── Fox dispatcher integration ──────────────────────────────────────────────
+from fox_overlay import dispatch  # noqa: E402
+
+
+def _handle_get(handler, parsed) -> bool:
+    from api.helpers import j
+    if parsed.path == "/api/settings/custom-providers":
+        j(handler, handle_get(handler))
+        return True
+    return False
+
+
+def _handle_post(handler, parsed) -> bool:
+    from api.helpers import j, read_body
+
+    if parsed.path == "/api/settings/custom-providers":
+        body = read_body(handler)
+        result = handle_post(handler, body)
+        j(handler, result, status=200 if result.get("ok") else 400)
+        return True
+
+    if parsed.path == "/api/settings/custom-providers/test":
+        body = read_body(handler)
+        result = handle_test(handler, body)
+        j(handler, result, status=200 if result.get("ok") else 400)
+        return True
+
+    if parsed.path == "/api/settings/custom-providers/delete":
+        body = read_body(handler)
+        result = handle_delete(handler, body)
+        j(handler, result, status=200 if result.get("ok") else 400)
+        return True
+
+    return False
+
+
+dispatch.register_get("/api/settings/custom-providers", _handle_get, allow_bare=True)
+dispatch.register_post("/api/settings/custom-providers", _handle_post, allow_bare=True)

--- a/packages/fox-overlay/tests/test_custom_providers.py
+++ b/packages/fox-overlay/tests/test_custom_providers.py
@@ -70,6 +70,9 @@ def _upstream():
     dispatch._BootstrapState.frozen = False
     yield
     sys.modules.pop("fox_overlay.webui_modules.custom_providers", None)
+    sys.modules.pop("api.config", None)
+    sys.modules.pop("api.helpers", None)
+    sys.modules.pop("api", None)
 
 
 def _load_module():

--- a/packages/fox-overlay/tests/test_custom_providers.py
+++ b/packages/fox-overlay/tests/test_custom_providers.py
@@ -219,6 +219,12 @@ class TestUpsertProvider:
         assert result["ok"] is False
         assert "http" in result["error"].lower()
 
+    def test_rejects_name_too_long(self):
+        mod = _load_module()
+        result = mod.upsert_provider({"name": "x" * 65, "base_url": "http://x/v1", "models": ["m"]})
+        assert result["ok"] is False
+        assert "64" in result["error"]
+
     def test_rejects_empty_models(self):
         mod = _load_module()
         result = mod.upsert_provider({"name": "Bad", "base_url": "http://x/v1", "models": []})

--- a/packages/fox-overlay/tests/test_custom_providers.py
+++ b/packages/fox-overlay/tests/test_custom_providers.py
@@ -1,0 +1,338 @@
+"""Tests for fox_overlay.webui_modules.custom_providers — /api/settings/custom-providers (#144)."""
+from __future__ import annotations
+
+import json
+import sys
+import types
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+
+def _stub_upstream():
+    api = types.ModuleType("api")
+    helpers = types.ModuleType("api.helpers")
+    config = types.ModuleType("api.config")
+
+    def _j(handler, data, status=200):
+        body = json.dumps(data).encode()
+        handler.send_response(status)
+        handler.send_header("Content-Type", "application/json")
+        handler.end_headers()
+        handler._body = body
+
+    def _read_body(handler):
+        return handler._request_body
+
+    helpers.j = _j
+    helpers.read_body = _read_body
+    api.helpers = helpers
+
+    import threading
+    config._cfg_lock = threading.Lock()
+    config._config_store = {"custom_providers": []}
+
+    def _get_config_path():
+        return "/fake/config.yaml"
+
+    def _load_yaml_config_file(path):
+        import copy
+        return copy.deepcopy(config._config_store)
+
+    def _save_yaml_config_file(path, cfg):
+        import copy
+        config._config_store = copy.deepcopy(cfg)
+
+    def get_config():
+        import copy
+        return copy.deepcopy(config._config_store)
+
+    config._get_config_path = _get_config_path
+    config._load_yaml_config_file = _load_yaml_config_file
+    config._save_yaml_config_file = _save_yaml_config_file
+    config.get_config = get_config
+    config.reload_config = lambda: None
+    config.invalidate_models_cache = lambda: None
+
+    api.config = config
+    sys.modules["api"] = api
+    sys.modules["api.helpers"] = helpers
+    sys.modules["api.config"] = config
+
+
+@pytest.fixture(autouse=True)
+def _upstream():
+    _stub_upstream()
+    from fox_overlay import dispatch
+    dispatch._GET_TABLE.clear()
+    dispatch._POST_TABLE.clear()
+    dispatch._BootstrapState.frozen = False
+    yield
+    sys.modules.pop("fox_overlay.webui_modules.custom_providers", None)
+
+
+def _load_module():
+    sys.modules.pop("fox_overlay.webui_modules.custom_providers", None)
+    import fox_overlay.webui_modules as _pkg
+    if hasattr(_pkg, "custom_providers"):
+        delattr(_pkg, "custom_providers")
+    from fox_overlay.webui_modules import custom_providers
+    return custom_providers
+
+
+def _make_handler(body=None):
+    h = SimpleNamespace()
+    h._headers_sent = []
+    h._body = None
+    h._status = None
+    h._request_body = body or {}
+    h.send_response = lambda status: setattr(h, "_status", status)
+    h.send_header = lambda k, v: h._headers_sent.append((k, v))
+    h.end_headers = lambda: None
+    return h
+
+
+def _parsed(path):
+    return SimpleNamespace(path=path)
+
+
+def _set_providers(entries):
+    sys.modules["api.config"]._config_store["custom_providers"] = entries
+
+
+class TestRegistration:
+    def test_registers_get_handler(self):
+        _load_module()
+        from fox_overlay.dispatch import GET_TABLE
+        assert "/api/settings/custom-providers" in GET_TABLE
+
+    def test_registers_post_handler(self):
+        _load_module()
+        from fox_overlay.dispatch import POST_TABLE
+        assert "/api/settings/custom-providers" in POST_TABLE
+
+
+class TestGetProviders:
+    def test_empty_list(self):
+        mod = _load_module()
+        result = mod.get_providers_list()
+        assert result["ok"] is True
+        assert result["providers"] == []
+
+    def test_returns_providers_with_masked_keys(self):
+        _set_providers([
+            {"name": "Local LLM", "base_url": "http://localhost:8080/v1", "api_key": "sk-secret-123", "models": ["llama3"]},
+            {"name": "No Key", "base_url": "http://example.com/v1", "models": ["gpt4"]},
+        ])
+        mod = _load_module()
+        result = mod.get_providers_list()
+        assert result["ok"] is True
+        assert len(result["providers"]) == 2
+        assert result["providers"][0]["api_key"] == "****"
+        assert result["providers"][0]["name"] == "Local LLM"
+        assert result["providers"][1]["api_key"] == ""
+
+    def test_get_handler_dispatches(self):
+        _set_providers([{"name": "Test", "base_url": "http://x/v1", "models": ["m1"]}])
+        mod = _load_module()
+        handler = _make_handler()
+        assert mod._handle_get(handler, _parsed("/api/settings/custom-providers")) is True
+        body = json.loads(handler._body)
+        assert body["ok"] is True
+        assert len(body["providers"]) == 1
+
+    def test_get_declines_wrong_path(self):
+        mod = _load_module()
+        handler = _make_handler()
+        assert mod._handle_get(handler, _parsed("/api/settings/custom-providersX")) is False
+
+
+class TestUpsertProvider:
+    def test_add_valid_provider(self):
+        mod = _load_module()
+        result = mod.upsert_provider({
+            "name": "My LLM",
+            "base_url": "http://192.168.1.10:8080/v1",
+            "models": ["llama3", "phi4"],
+        })
+        assert result["ok"] is True
+        stored = sys.modules["api.config"]._config_store["custom_providers"]
+        assert len(stored) == 1
+        assert stored[0]["name"] == "My LLM"
+        assert stored[0]["base_url"] == "http://192.168.1.10:8080/v1"
+        assert stored[0]["models"] == ["llama3", "phi4"]
+        assert "api_key" not in stored[0]
+
+    def test_add_with_api_key(self):
+        mod = _load_module()
+        result = mod.upsert_provider({
+            "name": "Keyed",
+            "base_url": "https://api.example.com/v1",
+            "api_key": "sk-test-key-123",
+            "models": ["model1"],
+        })
+        assert result["ok"] is True
+        stored = sys.modules["api.config"]._config_store["custom_providers"]
+        assert stored[0]["api_key"] == "sk-test-key-123"
+
+    def test_update_existing_provider(self):
+        _set_providers([
+            {"name": "My LLM", "base_url": "http://old/v1", "models": ["old-model"]},
+        ])
+        mod = _load_module()
+        result = mod.upsert_provider({
+            "name": "My LLM",
+            "base_url": "http://new/v1",
+            "models": ["new-model"],
+        })
+        assert result["ok"] is True
+        stored = sys.modules["api.config"]._config_store["custom_providers"]
+        assert len(stored) == 1
+        assert stored[0]["base_url"] == "http://new/v1"
+        assert stored[0]["models"] == ["new-model"]
+
+    def test_update_preserves_key_when_masked(self):
+        _set_providers([
+            {"name": "Keyed", "base_url": "http://x/v1", "api_key": "real-secret", "models": ["m1"]},
+        ])
+        mod = _load_module()
+        result = mod.upsert_provider({
+            "name": "Keyed",
+            "base_url": "http://x/v1",
+            "api_key": "****",
+            "models": ["m1", "m2"],
+        })
+        assert result["ok"] is True
+        stored = sys.modules["api.config"]._config_store["custom_providers"]
+        assert stored[0]["api_key"] == "real-secret"
+
+    def test_rejects_empty_name(self):
+        mod = _load_module()
+        result = mod.upsert_provider({"name": "", "base_url": "http://x/v1", "models": ["m"]})
+        assert result["ok"] is False
+        assert "required" in result["error"].lower()
+
+    def test_rejects_invalid_url_scheme(self):
+        mod = _load_module()
+        result = mod.upsert_provider({"name": "Bad", "base_url": "ftp://evil/v1", "models": ["m"]})
+        assert result["ok"] is False
+        assert "http" in result["error"].lower()
+
+    def test_rejects_empty_models(self):
+        mod = _load_module()
+        result = mod.upsert_provider({"name": "Bad", "base_url": "http://x/v1", "models": []})
+        assert result["ok"] is False
+        assert "model" in result["error"].lower()
+
+    def test_strips_trailing_slash_from_url(self):
+        mod = _load_module()
+        mod.upsert_provider({"name": "T", "base_url": "http://x:8080/v1/", "models": ["m"]})
+        stored = sys.modules["api.config"]._config_store["custom_providers"]
+        assert stored[0]["base_url"] == "http://x:8080/v1"
+
+    def test_case_insensitive_name_matching(self):
+        _set_providers([{"name": "My LLM", "base_url": "http://x/v1", "models": ["m"]}])
+        mod = _load_module()
+        mod.upsert_provider({"name": "my llm", "base_url": "http://y/v1", "models": ["n"]})
+        stored = sys.modules["api.config"]._config_store["custom_providers"]
+        assert len(stored) == 1
+        assert stored[0]["base_url"] == "http://y/v1"
+
+
+class TestDeleteProvider:
+    def test_delete_existing(self):
+        _set_providers([
+            {"name": "Keep", "base_url": "http://a/v1", "models": ["m"]},
+            {"name": "Remove", "base_url": "http://b/v1", "models": ["m"]},
+        ])
+        mod = _load_module()
+        result = mod.delete_provider({"name": "Remove"})
+        assert result["ok"] is True
+        stored = sys.modules["api.config"]._config_store["custom_providers"]
+        assert len(stored) == 1
+        assert stored[0]["name"] == "Keep"
+
+    def test_delete_nonexistent(self):
+        mod = _load_module()
+        result = mod.delete_provider({"name": "ghost"})
+        assert result["ok"] is False
+        assert "not found" in result["error"].lower()
+
+    def test_delete_handler_dispatches(self):
+        _set_providers([{"name": "X", "base_url": "http://x/v1", "models": ["m"]}])
+        mod = _load_module()
+        handler = _make_handler({"name": "X"})
+        assert mod._handle_post(handler, _parsed("/api/settings/custom-providers/delete")) is True
+        body = json.loads(handler._body)
+        assert body["ok"] is True
+
+
+class TestTestProvider:
+    def test_rejects_invalid_url(self):
+        mod = _load_module()
+        result = mod.test_provider({"base_url": "not-a-url"})
+        assert result["ok"] is False
+
+    def test_successful_probe(self):
+        mod = _load_module()
+        response_data = json.dumps({"data": [{"id": "m1"}, {"id": "m2"}]}).encode()
+        mock_resp = mock.MagicMock()
+        mock_resp.read.return_value = response_data
+        mock_resp.__enter__ = mock.Mock(return_value=mock_resp)
+        mock_resp.__exit__ = mock.Mock(return_value=False)
+        with mock.patch.object(mod.urllib.request, "urlopen", return_value=mock_resp):
+            result = mod.test_provider({"base_url": "http://localhost:8080/v1"})
+        assert result["ok"] is True
+        assert result["models_found"] == 2
+
+    def test_connection_refused(self):
+        mod = _load_module()
+        import urllib.error
+        with mock.patch.object(mod.urllib.request, "urlopen", side_effect=urllib.error.URLError("Connection refused")):
+            result = mod.test_provider({"base_url": "http://localhost:9999/v1"})
+        assert result["ok"] is False
+        assert "connection" in result["error"].lower()
+
+    def test_auth_error(self):
+        mod = _load_module()
+        import urllib.error
+        with mock.patch.object(mod.urllib.request, "urlopen", side_effect=urllib.error.HTTPError(
+            "http://x/models", 401, "Unauthorized", {}, None
+        )):
+            result = mod.test_provider({"base_url": "http://x/v1"})
+        assert result["ok"] is False
+        assert "auth" in result["error"].lower()
+
+    def test_handler_dispatches(self):
+        mod = _load_module()
+        response_data = json.dumps({"data": []}).encode()
+        mock_resp = mock.MagicMock()
+        mock_resp.read.return_value = response_data
+        mock_resp.__enter__ = mock.Mock(return_value=mock_resp)
+        mock_resp.__exit__ = mock.Mock(return_value=False)
+        handler = _make_handler({"base_url": "http://localhost:8080/v1"})
+        with mock.patch.object(mod.urllib.request, "urlopen", return_value=mock_resp):
+            assert mod._handle_post(handler, _parsed("/api/settings/custom-providers/test")) is True
+        body = json.loads(handler._body)
+        assert body["ok"] is True
+
+
+class TestDispatchBoundary:
+    def test_post_declines_wrong_path(self):
+        mod = _load_module()
+        handler = _make_handler()
+        assert mod._handle_post(handler, _parsed("/api/settings/custom-providersX")) is False
+
+    def test_post_handles_upsert(self):
+        mod = _load_module()
+        handler = _make_handler({"name": "X", "base_url": "http://x/v1", "models": ["m"]})
+        assert mod._handle_post(handler, _parsed("/api/settings/custom-providers")) is True
+        body = json.loads(handler._body)
+        assert body["ok"] is True
+
+    def test_post_returns_400_on_validation_error(self):
+        mod = _load_module()
+        handler = _make_handler({"name": "", "base_url": "http://x/v1", "models": ["m"]})
+        assert mod._handle_post(handler, _parsed("/api/settings/custom-providers")) is True
+        assert handler._status == 400

--- a/packages/fox-overlay/webui_static/custom-providers.js
+++ b/packages/fox-overlay/webui_static/custom-providers.js
@@ -1,0 +1,363 @@
+/* Fox in the Box — custom OpenAI-compatible provider management (#144, v0.7.53).
+ *
+ * Injects an "Add Custom Provider" button and edit/delete controls into
+ * Settings → Providers.  Talks to /api/settings/custom-providers/*.
+ */
+
+(function () {
+  'use strict';
+
+  var API_BASE = '/api/settings/custom-providers';
+  var _initialized = false;
+  var _formVisible = false;
+  var _editingName = null;
+
+  // ── Helpers ────────────────────────────────────────────────────────────
+
+  function esc(s) {
+    var d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  function $(id) { return document.getElementById(id); }
+
+  function _api(path, body) {
+    var opts = { credentials: 'same-origin', headers: { 'Content-Type': 'application/json' } };
+    if (body !== undefined) {
+      opts.method = 'POST';
+      opts.body = JSON.stringify(body);
+    }
+    return fetch(API_BASE + (path || ''), opts).then(function (r) { return r.json(); });
+  }
+
+  // ── Container & injection point ────────────────────────────────────────
+
+  function _getProvidersList() { return $('providersList'); }
+
+  function _getOrCreateContainer() {
+    var existing = $('foxCustomProviders');
+    if (existing) return existing;
+    var list = _getProvidersList();
+    if (!list) return null;
+    var container = document.createElement('div');
+    container.id = 'foxCustomProviders';
+    container.style.cssText = 'margin-top:16px;';
+    list.parentNode.insertBefore(container, list.nextSibling);
+    return container;
+  }
+
+  // ── Render ─────────────────────────────────────────────────────────────
+
+  function _renderAll() {
+    var container = _getOrCreateContainer();
+    if (!container) return;
+
+    _api().then(function (data) {
+      if (!data || !data.ok) return;
+      var providers = data.providers || [];
+      var html = '';
+
+      // Section header with add button
+      html += '<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px">';
+      html += '<div style="font-size:13px;font-weight:600;color:var(--text)">Custom Providers</div>';
+      html += '<button type="button" id="foxCpAddBtn" style="' + _btnStyle('var(--accent)', 'white') + '">+ Add Provider</button>';
+      html += '</div>';
+
+      // Form area (hidden by default)
+      html += '<div id="foxCpFormArea"></div>';
+
+      // Provider cards
+      if (providers.length === 0 && !_formVisible) {
+        html += '<div style="text-align:center;padding:16px 0;color:var(--muted);font-size:13px">';
+        html += 'No custom providers configured. Add one to connect Fox to llama.cpp, LM Studio, vLLM, or any OpenAI-compatible endpoint.';
+        html += '</div>';
+      }
+
+      for (var i = 0; i < providers.length; i++) {
+        html += _renderProviderCard(providers[i]);
+      }
+
+      container.innerHTML = html;
+
+      // Wire add button
+      var addBtn = $('foxCpAddBtn');
+      if (addBtn) {
+        addBtn.onclick = function () {
+          _editingName = null;
+          _formVisible = true;
+          _showForm(null);
+        };
+      }
+
+      if (_formVisible) {
+        _showForm(_editingName ? _findProvider(providers, _editingName) : null);
+      }
+
+      // Wire edit/delete buttons
+      var cards = container.querySelectorAll('[data-fox-cp-name]');
+      for (var j = 0; j < cards.length; j++) {
+        (function (card) {
+          var name = card.getAttribute('data-fox-cp-name');
+          var editBtn = card.querySelector('.fox-cp-edit');
+          var deleteBtn = card.querySelector('.fox-cp-delete');
+          var headerBtn = card.querySelector('.fox-cp-header');
+
+          if (headerBtn) {
+            headerBtn.onclick = function () { card.classList.toggle('open'); };
+          }
+          if (editBtn) {
+            editBtn.onclick = function () {
+              _editingName = name;
+              _formVisible = true;
+              var p = _findProvider(data.providers, name);
+              _showForm(p);
+            };
+          }
+          if (deleteBtn) {
+            deleteBtn.onclick = function () {
+              if (!confirm('Delete custom provider "' + name + '"?')) return;
+              _api('/delete', { name: name }).then(function (r) {
+                if (r && r.ok) {
+                  _formVisible = false;
+                  _editingName = null;
+                  _renderAll();
+                  _refreshUpstreamProviders();
+                } else {
+                  alert((r && r.error) || 'Delete failed.');
+                }
+              });
+            };
+          }
+        })(cards[j]);
+      }
+    });
+  }
+
+  function _findProvider(list, name) {
+    for (var i = 0; i < list.length; i++) {
+      if (list[i].name === name) return list[i];
+    }
+    return null;
+  }
+
+  function _renderProviderCard(p) {
+    var modelCount = Array.isArray(p.models) ? p.models.length : 0;
+    var meta = modelCount + (modelCount === 1 ? ' model' : ' models');
+    if (p.api_key) meta += ' · Key configured';
+
+    var html = '<div class="provider-card" data-fox-cp-name="' + esc(p.name) + '">';
+    html += '<button type="button" class="provider-card-header fox-cp-header">';
+    html += '<div class="provider-card-info">';
+    html += '<div class="provider-card-name">' + esc(p.name) + '</div>';
+    html += '<div class="provider-card-meta">' + esc(meta) + '</div>';
+    html += '</div>';
+    html += '<svg class="provider-card-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" width="16" height="16"><path d="M6 9l6 6 6-6"/></svg>';
+    html += '</button>';
+
+    html += '<div class="provider-card-body">';
+    html += '<div style="font-size:12px;color:var(--muted);margin-bottom:8px">';
+    html += '<span style="font-weight:500">URL:</span> ' + esc(p.base_url);
+    html += '</div>';
+    if (modelCount > 0) {
+      html += '<div style="font-size:12px;color:var(--muted);margin-bottom:8px">';
+      html += '<span style="font-weight:500">Models:</span> ' + esc(p.models.join(', '));
+      html += '</div>';
+    }
+    html += '<div style="display:flex;gap:8px;margin-top:8px">';
+    html += '<button type="button" class="fox-cp-edit" style="' + _btnStyle('var(--accent)', 'white') + '">Edit</button>';
+    html += '<button type="button" class="fox-cp-delete" style="' + _btnStyle('var(--error,#e53e3e)', 'white') + '">Delete</button>';
+    html += '</div>';
+    html += '</div>';
+    html += '</div>';
+    return html;
+  }
+
+  // ── Form ───────────────────────────────────────────────────────────────
+
+  function _showForm(provider) {
+    var area = $('foxCpFormArea');
+    if (!area) return;
+
+    var isEdit = provider !== null && provider !== undefined;
+
+    var html = '<div style="background:var(--code-bg);border:1px solid var(--border2);border-radius:8px;padding:16px;margin-bottom:12px">';
+    html += '<div style="font-size:13px;font-weight:600;margin-bottom:12px">' + (isEdit ? 'Edit Provider' : 'Add Custom Provider') + '</div>';
+
+    html += _formField('foxCpName', 'Display Name', 'e.g. Home llama.cpp', isEdit ? provider.name : '', isEdit);
+    html += _formField('foxCpUrl', 'Base URL', 'e.g. http://192.168.1.50:8080/v1', isEdit ? provider.base_url : '', false);
+    html += _formField('foxCpKey', 'API Key (optional)', 'Leave empty if not required', '', false, true);
+    html += _formField('foxCpModels', 'Models (comma-separated)', 'e.g. llama-3.1-8b-instruct, phi4-mini', isEdit ? (provider.models || []).join(', ') : '', false);
+
+    // Test connection
+    html += '<div style="display:flex;align-items:center;gap:8px;margin-top:12px">';
+    html += '<button type="button" id="foxCpTestBtn" style="' + _btnStyle('var(--border2)', 'var(--text)') + '">Test Connection</button>';
+    html += '<span id="foxCpTestResult" style="font-size:12px"></span>';
+    html += '</div>';
+
+    // Save / Cancel
+    html += '<div style="display:flex;gap:8px;margin-top:12px">';
+    html += '<button type="button" id="foxCpSaveBtn" style="' + _btnStyle('var(--accent)', 'white') + '">Save</button>';
+    html += '<button type="button" id="foxCpCancelBtn" style="' + _btnStyle('var(--border2)', 'var(--text)') + '">Cancel</button>';
+    html += '</div>';
+    html += '</div>';
+
+    area.innerHTML = html;
+
+    // Wire buttons
+    $('foxCpTestBtn').onclick = _doTest;
+    $('foxCpSaveBtn').onclick = _doSave;
+    $('foxCpCancelBtn').onclick = function () {
+      _formVisible = false;
+      _editingName = null;
+      _renderAll();
+    };
+  }
+
+  function _formField(id, label, placeholder, value, disabled, isPassword) {
+    var type = isPassword ? 'password' : 'text';
+    var disabledAttr = disabled ? ' disabled' : '';
+    var autocomplete = isPassword ? ' autocomplete="off"' : '';
+    return '<div style="margin-bottom:8px">' +
+      '<label style="font-size:12px;color:var(--muted);display:block;margin-bottom:4px">' + esc(label) + '</label>' +
+      '<input type="' + type + '" id="' + id + '" placeholder="' + esc(placeholder) + '" value="' + esc(value || '') + '"' + disabledAttr + autocomplete +
+      ' style="width:100%;padding:8px;background:var(--bg);color:var(--text);border:1px solid var(--border2);border-radius:6px;font-size:13px;box-sizing:border-box">' +
+      '</div>';
+  }
+
+  function _getFormValues() {
+    return {
+      name: ($('foxCpName') || {}).value || '',
+      base_url: ($('foxCpUrl') || {}).value || '',
+      api_key: ($('foxCpKey') || {}).value || '',
+      models: (($('foxCpModels') || {}).value || '').split(',').map(function (s) { return s.trim(); }).filter(Boolean),
+    };
+  }
+
+  function _doTest() {
+    var vals = _getFormValues();
+    var result = $('foxCpTestResult');
+    var btn = $('foxCpTestBtn');
+    if (!result || !btn) return;
+    if (!vals.base_url) {
+      result.textContent = 'Enter a Base URL first.';
+      result.style.color = 'var(--error,#e53e3e)';
+      return;
+    }
+    btn.disabled = true;
+    btn.textContent = 'Testing...';
+    result.textContent = '';
+
+    _api('/test', { base_url: vals.base_url, api_key: vals.api_key || '' })
+      .then(function (r) {
+        btn.disabled = false;
+        btn.textContent = 'Test Connection';
+        if (r && r.ok) {
+          var msg = 'Reachable';
+          if (typeof r.models_found === 'number') {
+            msg += ', ' + r.models_found + ' model' + (r.models_found === 1 ? '' : 's') + ' discovered';
+          }
+          result.textContent = msg;
+          result.style.color = 'var(--success,#38a169)';
+        } else {
+          result.textContent = (r && r.error) || 'Connection failed.';
+          result.style.color = 'var(--error,#e53e3e)';
+        }
+      })
+      .catch(function () {
+        btn.disabled = false;
+        btn.textContent = 'Test Connection';
+        result.textContent = 'Request failed.';
+        result.style.color = 'var(--error,#e53e3e)';
+      });
+  }
+
+  function _doSave() {
+    var vals = _getFormValues();
+    var btn = $('foxCpSaveBtn');
+    if (!btn) return;
+    btn.disabled = true;
+    btn.textContent = 'Saving...';
+
+    _api('', vals)
+      .then(function (r) {
+        btn.disabled = false;
+        btn.textContent = 'Save';
+        if (r && r.ok) {
+          _formVisible = false;
+          _editingName = null;
+          _renderAll();
+          _refreshUpstreamProviders();
+        } else {
+          alert((r && r.error) || 'Save failed.');
+        }
+      })
+      .catch(function () {
+        btn.disabled = false;
+        btn.textContent = 'Save';
+        alert('Save failed — network error.');
+      });
+  }
+
+  // ── Refresh upstream provider list ─────────────────────────────────────
+
+  function _refreshUpstreamProviders() {
+    if (typeof window.loadProvidersPanel === 'function') {
+      window.loadProvidersPanel();
+    }
+  }
+
+  // ── Button style helper ────────────────────────────────────────────────
+
+  function _btnStyle(bg, color) {
+    return 'padding:6px 12px;border:none;border-radius:6px;font-size:12px;font-weight:600;cursor:pointer;background:' + bg + ';color:' + color;
+  }
+
+  // ── Injection: detect when Settings → Providers is visible ─────────────
+
+  function _tryInit() {
+    var pane = $('settingsPaneProviders');
+    if (!pane) return;
+
+    if (_initialized) return;
+    _initialized = true;
+
+    var observer = new MutationObserver(function () {
+      var container = $('foxCustomProviders');
+      var list = _getProvidersList();
+      if (list && list.offsetParent !== null && !container) {
+        _renderAll();
+      }
+    });
+
+    observer.observe(pane, { childList: true, subtree: true });
+    _renderAll();
+  }
+
+  // Poll until the settings pane exists, then inject
+  var _pollCount = 0;
+  var _pollTimer = setInterval(function () {
+    _pollCount++;
+    var pane = $('settingsPaneProviders');
+    if (pane) {
+      clearInterval(_pollTimer);
+      _tryInit();
+      return;
+    }
+    if (_pollCount > 300) clearInterval(_pollTimer);
+  }, 500);
+
+  // Also listen for settings panel switches
+  var _origSwitchSettingsSection = window.switchSettingsSection;
+  if (typeof _origSwitchSettingsSection === 'function') {
+    window.switchSettingsSection = function (section) {
+      _origSwitchSettingsSection.apply(this, arguments);
+      if (section === 'providers') {
+        setTimeout(function () {
+          _initialized = false;
+          _tryInit();
+        }, 100);
+      }
+    };
+  }
+})();

--- a/packages/integration/Dockerfile
+++ b/packages/integration/Dockerfile
@@ -160,7 +160,7 @@ RUN set -eux; \
     chown -R foxinthebox:foxinthebox /app/hermes-agent /app/hermes-webui /app/fox-overlay
 
 ENV HERMES_WEBUI_EXTENSION_DIR=/app/fox-overlay/webui_static \
-    HERMES_WEBUI_EXTENSION_SCRIPT_URLS=/extensions/onboarding-preview.js,/extensions/fox-overlay.js,/extensions/hostname-prompt.js,/extensions/fallback-polish.js,/extensions/stream-error-retry.js,/extensions/chat-model-preselect.js,/extensions/model-picker-filter.js,/extensions/approval-explain.js \
+    HERMES_WEBUI_EXTENSION_SCRIPT_URLS=/extensions/onboarding-preview.js,/extensions/fox-overlay.js,/extensions/hostname-prompt.js,/extensions/fallback-polish.js,/extensions/stream-error-retry.js,/extensions/chat-model-preselect.js,/extensions/model-picker-filter.js,/extensions/approval-explain.js,/extensions/custom-providers.js \
     HERMES_WEBUI_EXTENSION_STYLESHEET_URLS=/extensions/fox-in-the-box.css
 
 # ── entrypoint (full version — replaces Task 03 stub) ─────────────────────────


### PR DESCRIPTION
## Summary

Adds a complete custom provider management UI to Settings → Providers, letting users add, edit, test connectivity, and delete OpenAI-compatible endpoints (llama.cpp, LM Studio, vLLM, etc.) directly from the browser without editing config.yaml.

- **Backend module** (`fox_overlay.webui_modules.custom_providers`) — CRUD + connectivity-test endpoints, atomic config.yaml writes under `_cfg_lock`, API key masking in GET responses
- **Frontend overlay** (`custom-providers.js`) — injects into upstream's `#settingsPaneProviders`, provider cards with expand/collapse, form with test-connection button, XSS-safe HTML escaping
- **27 unit tests** covering validation, upsert/delete, masked-key preservation, dispatcher boundaries, and connection probe mocking

### Deferred / out of scope

- Reonboarding flow changes (not in scope per standing rule)
- Multi-provider wizard expansion (that's #13's territory)
- SSRF controls for `test_provider` (acceptable in single-user self-hosted model; needs revisiting if Fox Cloud becomes multi-tenant)

## Test plan

- [x] Local quality gate green: 27/27 pytest tests passing
- [x] Adversarial 4-perspective review (SECURITY / CORRECTNESS / TEST DISCIPLINE / CODE QUALITY) — 0 blocking, 4 should-fix items all resolved
- [ ] CI checks green (Build & Push, Windows smoke, full, guard)
- [ ] On-target verification:
  - Add a custom provider pointing to a local llama.cpp instance
  - Test Connection button shows reachable + model count
  - Edit provider URL and models, verify update persists
  - Delete provider, verify removal from Settings and model picker
  - Verify API key masking: set a key, re-open edit form, key field is empty (not leaked)
  - Verify upstream provider list refreshes after save/delete

Closes #144