### PR TITLE
fix(electron): remove deprecated publisherName from win config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+- Electron build failure on electron-builder 26 — removed deprecated `publisherName` from win config (publisher name now derived from signing certificate)
+
 ---
 
 ## [0.7.53] — 2026-06-20

--- a/packages/electron/electron-builder.yml
+++ b/packages/electron/electron-builder.yml
@@ -25,7 +25,6 @@ afterPack: ./build/afterPack.js
 
 win:
   icon: assets/icon.ico
-  publisherName: Vulpy, Inc.
   target:
     - target: nsis
       arch:


### PR DESCRIPTION
## Summary

Fixes Electron desktop build failure on both macOS and Windows runners that has blocked desktop artifact generation since v0.7.52.

- **Root cause:** electron-builder 26.15.3 removed `publisherName` from `WindowsConfiguration` schema. The property in `electron-builder.yml` caused schema validation to reject the entire `win` block.
- **Fix:** Remove `publisherName: Vulpy, Inc.` — in electron-builder 26+, publisher name is derived from the code-signing certificate at build time.

### Why this wasn't caught

The PR CI for the Electron 28→42 migration (#572) passed because the PR workflow runs `build-electron.yml` in a mode that doesn't trigger the config validation path that fails. The release workflow (tag-triggered) uses `--publish never` which does trigger full config loading + schema validation.

### Impact

- v0.7.52 release: container + .deb artifacts published, Electron .dmg/.exe skipped
- v0.7.53 release: same — container + .deb published, Electron skipped
- After this fix merges: re-tag or re-run release workflow to generate desktop installers

## Test plan

- [x] Schema validation: verified `publisherName` absent from `WindowsConfiguration` in electron-builder 26.15.3 schema
- [x] All other config properties validated against 26.x schema — no other removals
- [ ] CI: Electron smoke tests pass on macOS and Windows