### PR TITLE
feat(ci): enforce test coverage threshold in validate-overlay (#408)

### DIFF
--- a/.github/workflows/validate-overlay.yml
+++ b/.github/workflows/validate-overlay.yml
@@ -39,8 +39,8 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install pytest
-        run: pip install pytest --quiet
+      - name: Install pytest + coverage
+        run: pip install pytest pytest-cov --quiet
 
       - name: Run validate-overlay
         run: bash packages/fox-overlay/scripts/validate-overlay.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+- Test coverage gate in CI — fox-overlay tests enforce 45% minimum line coverage via pytest-cov, fails the PR if coverage drops below threshold (#408)
+
 ### Fixed
 - Electron build failure on electron-builder 26 — removed deprecated `publisherName` from win config (publisher name now derived from signing certificate)
 

--- a/packages/fox-overlay/pyproject.toml
+++ b/packages/fox-overlay/pyproject.toml
@@ -12,6 +12,17 @@ dependencies = []
 # that hermes-agent invokes once per process at plugin-load time.
 fox_overlay = "fox_overlay.agent_plugins:register"
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.coverage.run]
+source = ["fox_overlay"]
+
+[tool.coverage.report]
+fail_under = 45
+show_missing = true
+skip_empty = true
+
 [build-system]
 requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/packages/fox-overlay/scripts/validate-overlay.sh
+++ b/packages/fox-overlay/scripts/validate-overlay.sh
@@ -60,8 +60,12 @@ done
 
 if [ -n "$PYTHON_BIN_EARLY" ]; then
     if "$PYTHON_BIN_EARLY" -m pytest --version >/dev/null 2>&1; then
+        COV_ARGS=""
+        if "$PYTHON_BIN_EARLY" -c "import pytest_cov" 2>/dev/null; then
+            COV_ARGS="--cov=fox_overlay --cov-report=term-missing --cov-config=packages/fox-overlay/pyproject.toml"
+        fi
         PYTHONPATH="packages/fox-overlay:forks/hermes-webui" \
-        "$PYTHON_BIN_EARLY" -m pytest packages/fox-overlay/tests/ -q --tb=short 2>&1 \
+        "$PYTHON_BIN_EARLY" -m pytest packages/fox-overlay/tests/ -q --tb=short $COV_ARGS 2>&1 \
             || fail "Python unit tests failed — see output above"
         ok "Python unit tests passed"
     else


### PR DESCRIPTION
## Summary

Adds a test coverage gate to the fox-overlay CI pipeline. The validate-overlay workflow now measures line coverage via pytest-cov and fails the PR if coverage drops below the configured threshold.

- **Threshold: 45%** — current coverage is 48% (295 tests, 1196/2522 statements). Floor set at current minus ~3% buffer. Honest baseline from measurement, not inflated.
- **pytest-cov** added to CI pip install alongside pytest
- **validate-overlay.sh** detects pytest-cov and adds `--cov` flags when available — graceful degradation for local dev without it installed
- **pyproject.toml** gets `[tool.pytest.ini_options]`, `[tool.coverage.run]`, and `[tool.coverage.report]` sections

### Coverage breakdown

| Tier | Files | Coverage |
|------|-------|----------|
| Full (100%) | dispatch, version, auth, csrf, streaming, _helpers, __init__ | 100% |
| Good (80%+) | approval_explain, capabilities, config, custom_providers, readyz, bootstrap | 82–97% |
| Moderate (40%+) | test_hooks, _substitute, onboarding | 47–66% |
| Low (<40%) | hostname, ollama, local_fallback, models_download, tailscale | 25–34% |
| Zero | agent_plugins subtree | 0% |

Low-coverage modules are runtime integration code (Tailscale, Ollama, local fallback) that require heavier mocking or real-container testing. Coverage for these will improve as the Playwright E2E suite (#266) matures.

### Deferred / out of scope

- HTML coverage report artifact upload — can add later if useful for PR review
- Branch coverage threshold — line coverage is the first gate; branch coverage can follow

## Test plan

- [x] Local: `pytest --cov=fox_overlay --cov-config=pyproject.toml` passes with 48% > 45% threshold
- [x] Verified `fail_under=45` message: "Required test coverage of 45.0% reached"
- [ ] CI: validate-overlay job passes with coverage output visible in logs

Closes #408