### PR TITLE
feat(ci): startup time regression gate (#429)

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -330,9 +330,11 @@ jobs:
           echo "✅ Index-digest pull resolved to $ARCH on ${{ matrix.platform.short }} runner"
 
       - name: Start container
+        id: start
         env:
           DIGEST: ${{ needs.merge.outputs.digest }}
         run: |
+          echo "start_epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
           docker run -d \
             --name test-fox \
             --cap-add=NET_ADMIN \
@@ -342,15 +344,17 @@ jobs:
             "${IMAGE}@${DIGEST}"
 
       - name: Wait for /health to return 200 with healthy body
-        # Validates BOTH the HTTP status AND that the body contains
-        # `"status": "ok"`. v0.2.0 (#57) showed status-code-only checks
-        # can mask body-shape divergence — don't repeat that.
+        id: health
+        env:
+          START_EPOCH: ${{ steps.start.outputs.start_epoch }}
         run: |
           set -euo pipefail
           for i in $(seq 1 36); do
             RESP=$(curl -fsS http://localhost:8787/health 2>/dev/null) || RESP=""
             if [[ -n "$RESP" ]] && echo "$RESP" | grep -q '"status": "ok"'; then
-              echo "✅ /health returned 200 with healthy body on attempt $i"
+              ELAPSED=$(( $(date +%s) - START_EPOCH ))
+              echo "startup_seconds=$ELAPSED" >> "$GITHUB_OUTPUT"
+              echo "✅ /health returned 200 with healthy body on attempt $i (${ELAPSED}s)"
               echo "Body: $RESP"
               exit 0
             fi
@@ -363,6 +367,67 @@ jobs:
             sleep 5
           done
           echo "::error::Container did not return a healthy /health body within 3 minutes on ${{ matrix.platform.short }}"
+          docker logs test-fox
+          exit 1
+
+      - name: Startup time regression gate (#429)
+        env:
+          STARTUP_SECONDS: ${{ steps.health.outputs.startup_seconds }}
+          ARCH: ${{ matrix.platform.short }}
+          DIGEST: ${{ needs.merge.outputs.digest }}
+          # Thresholds in seconds. Set conservatively until baseline data
+          # from ~10 CI runs establishes p50/p95. Then tighten to
+          # p95 * 1.20 per the SLO definition.
+          STARTUP_WARN_THRESHOLD: '45'
+          STARTUP_FAIL_THRESHOLD: '90'
+        run: |
+          set -euo pipefail
+          echo "Startup time on ${ARCH}: ${STARTUP_SECONDS}s (warn=${STARTUP_WARN_THRESHOLD}s, fail=${STARTUP_FAIL_THRESHOLD}s)"
+
+          if (( STARTUP_SECONDS <= STARTUP_WARN_THRESHOLD )); then
+            echo "::notice title=startup-time-${ARCH}::Container started in ${STARTUP_SECONDS}s on ${ARCH} (within ${STARTUP_WARN_THRESHOLD}s warn threshold)"
+            exit 0
+          fi
+
+          if (( STARTUP_SECONDS <= STARTUP_FAIL_THRESHOLD )); then
+            echo "::warning title=startup-time-${ARCH}::Container started in ${STARTUP_SECONDS}s on ${ARCH} — above ${STARTUP_WARN_THRESHOLD}s warn threshold (hard limit: ${STARTUP_FAIL_THRESHOLD}s)"
+            exit 0
+          fi
+
+          # Over hard threshold — retry once (flake resistance).
+          echo "::warning title=startup-time-${ARCH}::First attempt: ${STARTUP_SECONDS}s exceeds ${STARTUP_FAIL_THRESHOLD}s hard threshold — retrying"
+          docker stop test-fox || true
+          docker rm test-fox || true
+
+          RETRY_START=$(date +%s)
+          docker run -d \
+            --name test-fox \
+            --cap-add=NET_ADMIN \
+            --device /dev/net/tun \
+            --sysctl net.ipv4.ip_forward=1 \
+            -p 127.0.0.1:8787:8787 \
+            "${IMAGE}@${DIGEST}"
+
+          for i in $(seq 1 36); do
+            RESP=$(curl -fsS http://localhost:8787/health 2>/dev/null) || RESP=""
+            if [[ -n "$RESP" ]] && echo "$RESP" | grep -q '"status": "ok"'; then
+              RETRY_ELAPSED=$(( $(date +%s) - RETRY_START ))
+              echo "Retry startup time on ${ARCH}: ${RETRY_ELAPSED}s"
+              if (( RETRY_ELAPSED <= STARTUP_FAIL_THRESHOLD )); then
+                echo "::warning title=startup-time-${ARCH}::Retry passed: ${RETRY_ELAPSED}s (first attempt was ${STARTUP_SECONDS}s — likely cold-cache flake)"
+                exit 0
+              fi
+              echo "::error title=startup-time-${ARCH}::Startup regression on ${ARCH}: both attempts exceeded ${STARTUP_FAIL_THRESHOLD}s (first: ${STARTUP_SECONDS}s, retry: ${RETRY_ELAPSED}s)"
+              exit 1
+            fi
+            if ! docker inspect test-fox --format '{{.State.Running}}' | grep -q true; then
+              echo "::error::Container exited during retry on ${ARCH}"
+              docker logs test-fox
+              exit 1
+            fi
+            sleep 5
+          done
+          echo "::error::Container did not become healthy during retry on ${ARCH}"
           docker logs test-fox
           exit 1
 

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -334,7 +334,6 @@ jobs:
         env:
           DIGEST: ${{ needs.merge.outputs.digest }}
         run: |
-          echo "start_epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
           docker run -d \
             --name test-fox \
             --cap-add=NET_ADMIN \
@@ -342,8 +341,12 @@ jobs:
             --sysctl net.ipv4.ip_forward=1 \
             -p 127.0.0.1:8787:8787 \
             "${IMAGE}@${DIGEST}"
+          echo "start_epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
 
       - name: Wait for /health to return 200 with healthy body
+        # Validates BOTH the HTTP status AND that the body contains
+        # `"status": "ok"`. v0.2.0 (#57) showed status-code-only checks
+        # can mask body-shape divergence — don't repeat that.
         id: health
         env:
           START_EPOCH: ${{ steps.start.outputs.start_epoch }}
@@ -382,6 +385,10 @@ jobs:
           STARTUP_FAIL_THRESHOLD: '90'
         run: |
           set -euo pipefail
+          if [[ -z "$STARTUP_SECONDS" ]]; then
+            echo "::error::No startup time recorded — health step may have failed"
+            exit 1
+          fi
           echo "Startup time on ${ARCH}: ${STARTUP_SECONDS}s (warn=${STARTUP_WARN_THRESHOLD}s, fail=${STARTUP_FAIL_THRESHOLD}s)"
 
           if (( STARTUP_SECONDS <= STARTUP_WARN_THRESHOLD )); then
@@ -395,9 +402,12 @@ jobs:
           fi
 
           # Over hard threshold — retry once (flake resistance).
+          # Downstream steps (pip lock, container logs, stop) operate on
+          # whichever test-fox instance is running — the retry container
+          # if this path fires.
           echo "::warning title=startup-time-${ARCH}::First attempt: ${STARTUP_SECONDS}s exceeds ${STARTUP_FAIL_THRESHOLD}s hard threshold — retrying"
-          docker stop test-fox || true
-          docker rm test-fox || true
+          docker rm -f test-fox || true
+          sleep 1
 
           RETRY_START=$(date +%s)
           docker run -d \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 - Test coverage gate in CI — fox-overlay tests enforce 45% minimum line coverage via pytest-cov, fails the PR if coverage drops below threshold (#408)
+- Startup time regression gate in CI — smoke job measures wall-clock time from container start to first healthy `/health` response per architecture, warns above 45s, fails above 90s with single-retry flake resistance (#429)
 
 ### Fixed
 - Electron build failure on electron-builder 26 — removed deprecated `publisherName` from win config (publisher name now derived from signing certificate)


### PR DESCRIPTION
## Summary

Adds a startup-time regression gate to the container smoke job in `build-container.yml`. Every PR now measures the wall-clock time from `docker run` to the first healthy `/health` response, per architecture (amd64/arm64).

- **Timing measurement** — records epoch-second timestamp at container start, computes elapsed when `/health` returns `"status": "ok"`, outputs as step annotation
- **Threshold enforcement** — warn above 45s, hard-fail above 90s
- **Flake resistance** — if first attempt exceeds the hard threshold, the gate stops and restarts the container for a single retry; fails only if both attempts exceed the threshold (guards against cold-cache outliers on CI runners)

### Thresholds

Initial thresholds (45s warn / 90s fail) are conservative estimates. Once ~10 CI runs have collected baseline data, the thresholds should be calibrated to p95 × 1.20 per the SLO definition. Per-arch thresholds can be set independently if arm64 runners show consistently different startup characteristics.

### Deferred / out of scope

- Baseline data collection and threshold calibration (needs data from several merged PRs first)
- Per-arch threshold differentiation (same thresholds for both architectures initially)
- `/health` response `uptime_seconds` field analysis (secondary signal, not gated on)

## Test plan

- [x] Workflow YAML syntax valid
- [x] CHANGELOG entry added
- [ ] On-target verification:
  - CI smoke job runs on this PR's container build and reports timing in annotations
  - Timing values appear in the step output for both amd64 and arm64
  - If startup is under 45s, notice-level annotation emitted
  - If startup is between 45–90s, warning annotation emitted
  - If startup exceeds 90s, retry logic triggers (unlikely on healthy image)

Closes #429