### PR TITLE
feat: split issue templates and add PR template checklist (#431)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,7 +63,7 @@ body:
         - Windows desktop app
         - macOS desktop app (Apple Silicon)
         - macOS desktop app (Intel)
-        - Linux (.deb)
+        - Linux (install script / .deb)
         - Docker (manual)
         - Not platform-specific
     validations:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,20 +1,7 @@
-name: Open an issue
-description: Bug, feature, task, or docs change — one form for everything.
-title: ""
+name: Bug report
+description: Something is broken or not behaving as expected
+labels: ["bug"]
 body:
-  - type: dropdown
-    id: type
-    attributes:
-      label: Type
-      description: What kind of issue is this?
-      options:
-        - Bug — something is broken or not behaving as expected
-        - Feature — new capability or improvement
-        - Task — chore, refactor, internal cleanup
-        - Docs — README, CHANGELOG, contributor docs
-    validations:
-      required: true
-
   - type: dropdown
     id: priority
     attributes:
@@ -34,21 +21,13 @@ body:
   - type: textarea
     id: description
     attributes:
-      label: Description
+      label: What happened?
       description: |
-        For bugs: what happened, what you expected, steps to reproduce.
-        For features: the problem this solves, who benefits, how it should behave.
-        For tasks/docs: what needs to change and why.
+        Describe the bug. What happened, what you expected, and steps to reproduce.
       placeholder: |
-        # Bug example
         Setup window stayed at "Step 5/6 — Wait for services" even after
         the container booted. curl http://127.0.0.1:8787/health returned
         {"status":"ok"} but the Electron app never closed the window.
-
-        # Feature example
-        Users with Ollama already installed have no discoverable way to
-        use it. Adding a dedicated "Local Ollama" provider tile would
-        let them chat without an OpenRouter key.
     validations:
       required: true
 
@@ -57,40 +36,38 @@ body:
     attributes:
       label: Acceptance criteria
       description: |
-        Checklist of conditions that, when all true, mean this is done.
-        Optional but very helpful — it pins down what "shipped" means.
+        Checklist of conditions that, when all true, mean this is fixed.
+        Optional but helpful — it pins down what "shipped" means.
       placeholder: |
         - [ ] Setup window closes within ~1s of /health returning 200
         - [ ] Polling validates body contains `"status":"ok"`, not just status code
-        - [ ] Existing tests still pass; new test covers the body-validation branch
     validations:
       required: false
 
   - type: input
     id: version
     attributes:
-      label: App version (for bugs)
+      label: App version
       description: |
         Visible in the chat UI footer, or run `cat ~/.foxinthebox/data/version.txt`.
-        Skip this for features / tasks / docs.
-      placeholder: e.g. 0.3.1
+      placeholder: e.g. 0.7.54
     validations:
-      required: false
+      required: true
 
   - type: dropdown
     id: platform
     attributes:
-      label: Platform (for bugs)
-      description: Where the issue surfaced. Skip for features / tasks / docs.
+      label: Platform
+      description: Where the issue surfaced.
       options:
         - Windows desktop app
         - macOS desktop app (Apple Silicon)
         - macOS desktop app (Intel)
-        - Linux (install.sh)
+        - Linux (.deb)
         - Docker (manual)
         - Not platform-specific
     validations:
-      required: false
+      required: true
 
   - type: checkboxes
     id: checklist
@@ -99,5 +76,3 @@ body:
       options:
         - label: I searched existing open and closed issues; this is not a duplicate
           required: true
-        - label: For bugs — I included version + platform above (or it's not platform-specific)
-          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,11 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
-  - name: Discussions
-    url: https://github.com/fox-in-the-box-ai/fox-in-the-box/discussions
-    about: Questions, ideas, or general help — start here if you're not sure it's a bug
+  - name: Ask a question
+    url: https://github.com/fox-in-the-box-ai/fox-in-the-box/discussions/categories/q-a
+    about: Questions and troubleshooting — get help from the community
+  - name: Share an idea
+    url: https://github.com/fox-in-the-box-ai/fox-in-the-box/discussions/categories/ideas
+    about: Brainstorm features or discuss design directions before opening a formal request
   - name: Documentation
     url: https://github.com/fox-in-the-box-ai/fox-in-the-box/tree/main/docs
     about: Reading the docs may answer your question faster

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Ask a question
     url: https://github.com/fox-in-the-box-ai/fox-in-the-box/discussions/categories/q-a

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,51 @@
+name: Feature request
+description: Suggest a new capability or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: |
+        What problem does this solve? Who benefits? Describe the pain point,
+        not just the solution — this helps us evaluate whether the feature
+        fits the project's direction.
+      placeholder: |
+        Users with Ollama already installed have no discoverable way to
+        use it. Adding a dedicated "Local Ollama" provider tile would
+        let them chat without an OpenRouter key.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: |
+        How should it work? Include UI sketches, API surface, or config
+        examples if applicable. Optional — the problem statement is the
+        important part.
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: |
+        Checklist of conditions that, when all true, mean this is done.
+      placeholder: |
+        - [ ] Ollama tile appears in Settings → Providers when Ollama is detected
+        - [ ] User can select a local Ollama model in the model picker
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submit checklist
+      options:
+        - label: I searched existing open and closed issues; this is not a duplicate
+          required: true
+        - label: This is a single feature, not multiple features bundled together
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 
 ## Checklist
 
-- [ ] CI green: all required status checks pass (Build & Push, Smoke, validate, CodeQL, Trivy)
+- [ ] CI green: all required status checks pass (Build & Push, Merge into manifest list, Smoke, validate)
 - [ ] Tests: coverage stays above 45% threshold (enforced by CI via pytest-cov)
 - [ ] Startup time: container starts within 45s warn / 90s fail threshold (enforced by CI smoke)
 - [ ] CHANGELOG entry added for any user-visible change

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,21 @@
 ## Summary
 
+<!-- What does this PR do and why? 1-3 sentences. -->
+
 ## Ticket
+
+<!-- Closes #NNN -->
 
 ## Checklist
 
-- [ ] Local quality gate green (`pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build`)
-- [ ] Ticket ID cited above
-- [ ] No new warnings introduced
-- [ ] CI status: all required checks green (Build & Push amd64/arm64, Merge manifest, Smoke amd64/arm64, smoke, validate)
+- [ ] CI green: all required status checks pass (Build & Push, Smoke, validate, CodeQL, Trivy)
+- [ ] Tests: coverage stays above 45% threshold (enforced by CI via pytest-cov)
+- [ ] Startup time: container starts within 45s warn / 90s fail threshold (enforced by CI smoke)
 - [ ] CHANGELOG entry added for any user-visible change
-- [ ] No internal/private content added to this public repo (audits, panels, working notes → fox-private-docs)
+- [ ] No hardcoded secrets, tokens, or API keys
+- [ ] No internal/private content in this public repo (audits, panels, working notes belong in fox-private-docs)
+- [ ] Commit messages follow Conventional Commits format
 
 ## Deferred / out of scope
 
+<!-- Anything you intentionally didn't do, with reason. Delete section if N/A. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,14 +10,18 @@ Thank you for your interest in contributing. This document explains how to get i
 
 Search [existing issues](https://github.com/fox-in-the-box-ai/fox-in-the-box/issues) before opening a new one. If you find a match, add any additional information as a comment rather than opening a duplicate.
 
-When opening a bug report, use the bug report template and include:
+Use the **Bug report** template and include:
 - steps to reproduce the problem
 - your OS, installation method, and Fox in the Box version
 - relevant log output (`docker logs fox-in-the-box`)
 
 ### Requesting features
 
-Open a feature request issue using the feature request template. Describe the problem you are trying to solve, not just the solution. This helps us evaluate whether the feature fits the project's direction.
+Use the **Feature request** template. Describe the problem you are trying to solve, not just the solution. This helps us evaluate whether the feature fits the project's direction.
+
+### Questions and ideas
+
+For questions, troubleshooting, or early-stage ideas, start a [Discussion](https://github.com/fox-in-the-box-ai/fox-in-the-box/discussions) instead of an issue. Issues are for defined, actionable work.
 
 ### Submitting pull requests
 
@@ -63,8 +67,8 @@ Open [http://localhost:8787](http://localhost:8787) and complete the setup wizar
 ### Running tests
 
 ```bash
-# Python integration tests
-pytest tests/ -v
+# Fox overlay tests (with coverage — CI enforces 45% minimum)
+cd packages/fox-overlay && pytest tests/ -v --cov=. --cov-report=term-missing
 
 # Electron unit tests
 cd packages/electron && pnpm test
@@ -73,7 +77,14 @@ cd packages/electron && pnpm test
 cd tests/container && bats test_install.bats
 ```
 
-See [AGENTS.md](AGENTS.md) for the full development workflow used by coding agents in this repo.
+### Quality gates
+
+CI enforces these automatically on every PR:
+
+- **Test coverage**: fox-overlay tests must maintain at least 45% line coverage (pytest-cov)
+- **Startup time**: container must start and pass health check within 45s (warning) / 90s (hard fail)
+- **Static analysis**: CodeQL and Trivy scans must pass
+- **Container build**: multi-arch (amd64 + arm64) build and smoke test must succeed
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ Open [http://localhost:8787](http://localhost:8787) and complete the setup wizar
 
 ```bash
 # Fox overlay tests (with coverage — CI enforces 45% minimum)
-cd packages/fox-overlay && pytest tests/ -v --cov=. --cov-report=term-missing
+cd packages/fox-overlay && pytest tests/ -v --cov=fox_overlay --cov-report=term-missing
 
 # Electron unit tests
 cd packages/electron && pnpm test


### PR DESCRIPTION
## Summary

Splits the single catch-all issue template into focused bug report and feature request forms. Updates the PR template with quality gate references from Wave 5 (#408, #429). Disables blank issues and adds discussion redirects for questions and ideas.

- **bug_report.yml** — focused bug form with required version + platform fields
- **feature_request.yml** — feature form emphasizing problem statement over solution
- **config.yml** — blank issues disabled; Q&A and Ideas discussion redirects added
- **PR template** — adds coverage threshold (45%) and startup SLO (45s/90s) to checklist
- **CONTRIBUTING.md** — adds discussion guidance and quality gate documentation

Closes #431

## Test plan

- [x] Templates render correctly (verified format against GitHub YAML schema)
- [x] config.yml redirects point to valid discussion categories (Q&A, Ideas)
- [x] CONTRIBUTING.md references match new template names
- [x] No internal/private content in public repo