### PR TITLE
fix(security): close Dependabot #60 via npm override for js-yaml

### DIFF
--- a/packages/electron/package-lock.json
+++ b/packages/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fox-in-the-box/electron",
-  "version": "0.7.52",
+  "version": "0.7.57",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fox-in-the-box/electron",
-      "version": "0.7.52",
+      "version": "0.7.57",
       "dependencies": {
         "docker-modem": "^5.0.7",
         "dockerode": "^5.0.0",
@@ -1126,30 +1126,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@istanbuljs/schema": {
@@ -4111,20 +4087,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -5744,9 +5706,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -7163,13 +7135,6 @@
       "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
       "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
       "license": "ISC"
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/ssh2": {
       "version": "1.17.0",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -28,6 +28,9 @@
     "jest": "^30.0.0",
     "rcedit": "^5.0.0"
   },
+  "overrides": {
+    "js-yaml": "^4.1.0"
+  },
   "build": {
     "extends": "./electron-builder.yml"
   },


### PR DESCRIPTION
## Summary

Wave 7's pnpm overrides only affect `pnpm-lock.yaml`. Dependabot #60 targets `packages/electron/package-lock.json` where `js-yaml@3.14.2` was nested under `@istanbuljs/load-nyc-config`. This PR adds npm `overrides` to `packages/electron/package.json` forcing all js-yaml instances to `^4.1.0`.

- **npm override added** — `"overrides": {"js-yaml": "^4.1.0"}` in `packages/electron/package.json`
- **lockfile regenerated** — `js-yaml@3.14.2` eliminated, only `js-yaml@4.2.0` remains

### Deferred / out of scope

- Trivy race condition (`:stable` tag lag) — tracked in Wave 7 reconciliation, not this PR

## Test plan

- [x] `npm install --package-lock-only` reports 0 vulnerabilities
- [x] Verified lockfile: no `js-yaml@3.x` entries remain
- [x] Verified `js-yaml@4.x` is API-compatible (`yaml.load()` works in both 3.x and 4.x)
- [ ] CI green

Closes #60