### PR TITLE
chore: release v0.7.59

### DIFF
--- a/.github/workflows/option-b-diff-guard.yml
+++ b/.github/workflows/option-b-diff-guard.yml
@@ -50,7 +50,7 @@ jobs:
           #   file regenerated when upstream dependency pins change.
           # - This workflow file itself may need updating when the set of
           #   allowed paths evolves alongside upstream bumps.
-          ALLOWED_RE='^(forks/hermes-(agent|webui)|packages/(fox-overlay/|integration/requirements\.lock$)|\.github/workflows/option-b-diff-guard\.yml$)'
+          ALLOWED_RE='^(forks/hermes-(agent|webui)$|packages/(fox-overlay/|integration/requirements\.lock$)|\.github/workflows/option-b-diff-guard\.yml$)'
 
           changed=$(git diff --name-only "$BASE_SHA".."$HEAD_SHA")
           echo "----- Changed files in this Option B PR -----"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
+## [0.7.59] — 2026-07-10
+
+### Changed
+- Upstream bump: hermes-webui v0.51.537 → v0.52.0, hermes-agent v2026.6.19 → v2026.7.7.2
+- Monkey-patches retargeted for v0.52.0 upstream refactors: `reload_config` → `_refresh_config_cache`, `get_available_models` gained `force_refresh` parameter, `_run_agent_streaming` gained `moa_config` parameter, `save_settings` anchors updated for new upstream helper calls
+- All 9 webui overlay patches regenerated with v0.52.0 line numbers
+- Bumped Electron 42.4.1 → 42.5.1, dockerode 5.0.0 → 5.0.1, @playwright/test 1.61.0 → 1.61.1
+- Bumped 9 CI actions (actions/cache v5→v6, docker/login-action v4.2→v4.4, docker/setup-buildx-action v4.1→v4.2, github/codeql-action v4.36.2→v4.36.3, actions/setup-python v6.2→v6.3, and others)
+
+### Fixed
+- Option B diff guard regex now allows overlay package changes alongside upstream bumps (previously only `versions.toml` was allowed, blocking legitimate patch regeneration)
+- Added `$` anchor to `forks/hermes-(agent|webui)` in Option B guard regex (defense-in-depth hardening)
+
+### Security
+- Updated pip constraints: cryptography 49.0.0 → 46.0.7 (upstream hermes-agent hard-pin for CVE-2026-39892, CVE-2026-34073). Note: 46.0.7 is below the fix for GHSA-537c-gmf6-5ccf (vulnerable OpenSSL in wheels, fixed in 48.0.1); this is an upstream constraint that cannot be overridden without pip resolution failure — tracked for upstream remediation
+
+---
+
 ## [0.7.58] — 2026-06-20
 
 ### Security

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fox-in-the-box/electron",
   "productName": "fox-in-the-box",
-  "version": "0.7.58",
+  "version": "0.7.59",
   "description": "Fox in the box desktop app",
   "author": "Vulpy, Inc.",
   "main": "src/main.js",

--- a/packages/fox-overlay/fox_overlay/webui_patches/config.py
+++ b/packages/fox-overlay/fox_overlay/webui_patches/config.py
@@ -1,21 +1,29 @@
 """Fox webui patch: config.py — settings defaults + cache invalidation + save-gate validation.
 
 Re-applies the Fox edits to ``api/config.py``. Originally targeted Fox
-merge-base 9e31a2a; refreshed for v0.51.84 in Phase 8 follow-up #238.
+merge-base 9e31a2a; refreshed through v0.52.0.
 
-## Phase 8 refresh notes
+## Upstream refresh history
 
-v0.51.84's upstream changes:
+v0.51.84 (Phase 8 follow-up #238):
 
 1. **``get_config()``** — upstream NOW implements mtime-based cache
    invalidation NATIVELY (with a more sophisticated ``_cfg_fingerprint``
    mechanism). Fox's patch is REDUNDANT. The get_config substitution
    is dropped from this version.
 2. **``reload_config()``** — upstream refactored into a thin wrapper
-   delegating to ``_refresh_config_cache()``. Fox's anchors retarget
-   ``_refresh_config_cache`` (v0.52.0).
-3. **``save_settings()``** — unchanged in v0.51.84; all 3 substitutions
-   apply with their original anchors.
+   delegating to ``_refresh_config_cache()``.
+
+v0.52.0:
+
+3. **``_refresh_config_cache()``** — Fox's anchors retarget this
+   function (indentation shifted from 8-space inside ``with _cfg_lock:``
+   to 4-space at function body level).
+4. **``save_settings()``** — upstream added ``_read_raw_settings_file()``
+   and ``_extract_persisted_speech_keys()`` calls; Fox's anchors updated
+   to include these in the search/replace pair.
+5. **``get_available_models()``** — gained ``force_refresh`` keyword
+   parameter; Fox's wrapper passes it through.
 4. **``_SETTINGS_DEFAULTS`` + ``_SETTINGS_BOOL_KEYS``** — still
    module-scope; dict/set additions still work.
 
@@ -45,9 +53,9 @@ v0.51.84's upstream changes:
 
 ### Function patches
 
-* ``reload_config()`` — evict the in-memory ``_available_models_cache``
-  after on-disk cache delete (#138 chat-model-picker stale-after-
-  Ollama-switch fix).
+* ``_refresh_config_cache()`` — evict the in-memory
+  ``_available_models_cache`` after on-disk cache delete (#138
+  chat-model-picker stale-after-Ollama-switch fix).
 * ``save_settings()`` — three additions:
   - Validate Tailscale power-user fields at the save gate
   - Validate Ollama custom URL + normalize + remember the change

--- a/packages/fox-overlay/fox_overlay/webui_patches/streaming.py
+++ b/packages/fox-overlay/fox_overlay/webui_patches/streaming.py
@@ -69,8 +69,8 @@ _log = logging.getLogger("fox_overlay.webui_patches.streaming")
 _RUN_AGENT_STREAMING_SENTINEL = "_fox_patched_run_agent_streaming"
 
 # Expected upstream signature for _run_agent_streaming.
-# v0.51.84 added `goal_related=False`. Refresh both this and any anchors
-# when upstream renames a parameter.
+# v0.51.84 added `goal_related=False`; v0.52.0 added `moa_config=None`.
+# Refresh both this and any anchors when upstream renames a parameter.
 _EXPECTED_RUN_AGENT_STREAMING_SIG = (
     "(session_id, msg_text, model, workspace, stream_id, attachments=None, "
     "*, ephemeral=False, model_provider=None, goal_related=False, moa_config=None)"

--- a/packages/fox-overlay/tests/test_streaming_patch.py
+++ b/packages/fox-overlay/tests/test_streaming_patch.py
@@ -21,9 +21,9 @@ import sys
 import pytest
 
 
-# Minimal upstream streaming.py stub matching v0.51.84 around the
+# Minimal upstream streaming.py stub matching v0.52.0 around the
 # remaining (FITB#9 plumbing) anchor only. Includes upstream's
-# `goal_related=False` kwarg added in v0.51.x.
+# `goal_related=False` (v0.51.84) and `moa_config=None` (v0.52.0).
 _UPSTREAM_STREAMING_SOURCE = '''\
 def _run_agent_streaming(
     session_id,
@@ -36,8 +36,9 @@ def _run_agent_streaming(
     ephemeral=False,
     model_provider=None,
     goal_related=False,
+    moa_config=None,
 ):
-    """Stub matching upstream v0.51.84 anchor region only."""
+    """Stub matching upstream v0.52.0 anchor region only."""
     _fallback_resolved = None
     if True:
         _fb_entry = None

--- a/packages/integration/requirements.lock
+++ b/packages/integration/requirements.lock
@@ -1,6 +1,11 @@
 # Frozen Python dependencies for the Fox container image.
 # Generated from ghcr.io/fox-in-the-box-ai/cloud:v0.7.51 on 2026-06-20,
 # then patched for hermes-agent v2026.7.7.2 (cryptography 49.0.0 -> 46.0.7).
+# hermes-agent hard-pins cryptography==46.0.7 in pyproject.toml (citing
+# CVE-2026-39892, CVE-2026-34073). 46.0.7 is below the fix for
+# GHSA-537c-gmf6-5ccf (vulnerable OpenSSL in wheels, fixed in 48.0.1);
+# this is an upstream constraint we cannot override without pip resolution
+# failure. Tracked for upstream remediation.
 #
 # This file pins every transitive dependency resolved during container build.
 # It is used as a pip constraints file (-c) to prevent silent dependency drift


### PR DESCRIPTION
## Summary

Release prep for v0.7.59 — addresses findings from a 4-perspective adversarial review panel (SECURITY / CORRECTNESS / TEST DISCIPLINE / CODE QUALITY) run against the v0.7.58..HEAD diff.

- **Docstring refresh** — config.py and streaming.py comments updated to accurately reflect v0.52.0 upstream changes (stale v0.51.84 references corrected)
- **Guard regex hardening** — added `$` anchor to `forks/hermes-(agent|webui)` in Option B diff guard (defense-in-depth, prevents hypothetical path suffix bypass)
- **Test stub fix** — streaming test stub updated with `moa_config=None` parameter to match v0.52.0 upstream signature
- **Security documentation** — requirements.lock header now documents GHSA-537c-gmf6-5ccf accepted risk (cryptography 46.0.7 is below the 48.0.1 fix boundary; upstream hermes-agent hard-pins this version)
- **Version bump** — 0.7.58 → 0.7.59, CHANGELOG entry added

### Deferred / out of scope

- cryptography upgrade to ≥48.0.1 (blocked by upstream hermes-agent hard-pin `cryptography==46.0.7`)
- Full requirements.lock regeneration from fresh container build (manual patch only; regeneration deferred to next upstream bump)

## Test plan

- [x] Local quality gate green: `pytest` (315 passed, 1 skipped)
- [x] All review panel findings addressed (6/6)
- [ ] CI: validate-overlay, build-container, smoke, CodeQL, Trivy

Closes no issues (release prep only).