### PR TITLE
docs: sweep all docs to v0.7.59 state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,16 +31,21 @@ fox-in-the-box/             ← monorepo root
 ├── packages/
 │   ├── integration/        ← Dockerfile, supervisord, entrypoint, default-configs
 │   ├── electron/           ← Electron desktop app
+│   ├── deb/                ← .deb package build + apt repo publish
+│   ├── install-core/       ← Core install scripts
 │   ├── scripts/            ← install.sh, dev utilities
-│   └── fox-overlay/        ← sibling overlay for hermes-{agent,webui} (v0.6.0 migration; phases 2-10 populate it)
+│   └── fox-overlay/        ← sibling overlay for hermes-{agent,webui} (v0.6.0 migration)
 ├── docs/
 │   ├── tasks/              ← One task doc per feature (your specs live here)
 │   ├── archive/            ← Frozen design docs (REQUIREMENTS.md, ROADMAP.md)
-│   └── GATEWAY.md, RESET.md, GETTING_STARTED.md, …
-├── tests/
+│   └── DEV_MODE.md, RESET.md, RELEASE_WORKFLOW.md, SECURITY_POSTURE.md, …
+├── qa/
+│   ├── playwright/         ← Playwright end-to-end specs
 │   ├── integration/        ← Full-stack tests
 │   ├── electron/           ← Electron unit tests (jest)
-│   └── container/          ← Shell/bats tests
+│   ├── container/          ← Shell/bats tests
+│   ├── SMOKE_CHECKLIST.md  ← Manual smoke gate
+│   └── SMOKE_LOG.md        ← Per-release smoke entries (release gate)
 ├── README.md               ← Live roadmap lives in README's Roadmap section
 └── AGENTS.md               ← This file
 ```

--- a/README.md
+++ b/README.md
@@ -303,12 +303,13 @@ The app itself is free and open source. You only pay for AI usage at your provid
 What we're working on next. No promises on dates — this is a small team — but this is the direction.
 
 **Recently shipped**
+- **Upstream bump** — hermes-webui v0.52.0, hermes-agent v2026.7.7.2 (v0.7.59)
+- **Security alert triage** — resolved 24 supply-chain alerts via npm overrides + Dockerfile upgrade (v0.7.55–v0.7.57)
+- **Apt repository** — `.deb` packages published to `apt.foxinthebox.ai` for headless Linux installs (v0.7.59)
+- **Playwright smoke specs** — automated E2E tests for critical Fox surfaces (v0.7.55)
 - **CI quality gates** — test coverage threshold (45% minimum) and container startup time regression gate (v0.7.54)
 - **Custom provider UI** — add, edit, test, and delete OpenAI-compatible providers (llama.cpp, LM Studio, vLLM) from Settings → Providers (v0.7.53)
-- **Diagnostic report** — one-click "Send diagnostic report" in the launcher and via Ctrl+Shift+D (v0.7.53)
-- **Approval card explanations** — plain-English explanation of flagged commands before approval (v0.7.53)
 - **Electron 42 + supply-chain hardening** — Electron 28→42, Python dependency lock, unsigned artifact labeling (v0.7.52)
-- **Upstream bump** — hermes-webui v0.51.528, hermes-agent v2026.6.19 (v0.7.51)
 - **Upstream separation** — Fox overlays cleanly separated from upstream Hermes codebase (v0.6.0)
 
 **v0.8.0 — ships when these criteria are met:**

--- a/docs/DEV_MODE.md
+++ b/docs/DEV_MODE.md
@@ -17,7 +17,7 @@ pnpm build:docker:dev
 ```
 
 What this does:
-- Reads `VERSION` (repo root) — currently `0.7.44`
+- Reads `VERSION` (repo root) — currently `0.7.59`
 - Builds with `--build-arg FITB_DEV=1`
 - Tags the image as `fox-in-the-box:dev`
 - Skips the `_clone_app hermes-agent` / `_clone_app hermes-webui` calls in `entrypoint.sh` — the container will use bind-mounted submodules instead
@@ -68,7 +68,7 @@ If a mount is missing:
 |---|---|---|
 | Build flag | `FITB_DEV=1` | `FITB_DEV=0` (default) |
 | Submodule source | Bind-mounted from your host | Cloned from a git tag at build time |
-| Tag | `dev` | semver e.g. `0.7.44` |
+| Tag | `dev` | semver e.g. `0.7.59` |
 | Use case | Iterating on submodule code | Released artifact, CI, what users run |
 
 ## Common workflows
@@ -100,7 +100,7 @@ When dev mode hides the bug, you need the actual built image. Build the producti
 
 ```bash
 docker build -f packages/integration/Dockerfile \
-  -t fitb:repro --build-arg FITB_VERSION=v0.7.44 .
+  -t fitb:repro --build-arg FITB_VERSION=v0.7.59 .
 docker run --rm --cap-add=NET_ADMIN --device /dev/net/tun \
   --sysctl net.ipv4.ip_forward=1 \
   -p 127.0.0.1:8788:8787 \

--- a/docs/SECURITY_POSTURE.md
+++ b/docs/SECURITY_POSTURE.md
@@ -1,6 +1,6 @@
 # Fox in the Box — Security Posture
 
-Last updated: v0.7.57 (2026-06-20)
+Last updated: v0.7.59 (2026-07-10)
 
 ## Threat model
 

--- a/docs/ops/apt-repo-setup.md
+++ b/docs/ops/apt-repo-setup.md
@@ -113,8 +113,8 @@ apt.foxinthebox.ai/
 ├── pool/
 │   └── main/
 │       └── f/foxinthebox/
-│           ├── foxinthebox_0.7.44_amd64.deb
-│           └── foxinthebox_0.7.44_arm64.deb
+│           ├── foxinthebox_0.7.59_amd64.deb
+│           └── foxinthebox_0.7.59_arm64.deb
 ├── gpg                              ← public signing key
 └── conf/                            ← reprepro metadata (not user-facing)
 ```

--- a/docs/plans/bare-metal-deb/03-install-core.md
+++ b/docs/plans/bare-metal-deb/03-install-core.md
@@ -96,8 +96,8 @@ Do NOT mark `/etc/foxinthebox/supervisord.conf` as a dpkg conffile. It is genera
 `packages/fox-overlay/versions.toml` contains:
 ```toml
 [hermes]
-agent_tag  = "v2026.5.16"
-webui_tag  = "v0.51.124"
+agent_tag  = "v2026.7.7.2"
+webui_tag  = "v0.52.0"
 ```
 install-core.sh parses this with pure bash (grep + sed) — no toml parser needed. Pattern: `grep "^agent_tag" versions.toml | sed 's/.*= *"\(.*\)"/\1/'`
 

--- a/docs/specs/do-droplet-1click.md
+++ b/docs/specs/do-droplet-1click.md
@@ -331,7 +331,7 @@ Source: https://github.com/digitalocean/marketplace-partners/blob/master/scripts
 | Field | Value | Status |
 |-------|-------|--------|
 | App name | Fox in the Box | Ready |
-| Version | 0.7.44 (or current at submission) | Ready |
+| Version | 0.7.59 (or current at submission) | Ready |
 | OS | Ubuntu 24.04 LTS | Ready |
 | Software included | Docker CE, Caddy, Fox in the Box (list with versions) | To build |
 | Short description | Private AI assistant with memory, local AI, and secure remote access | Ready |

--- a/qa/SMOKE_CHECKLIST.md
+++ b/qa/SMOKE_CHECKLIST.md
@@ -10,8 +10,8 @@ Pull the image you're testing — **don't `docker build` locally** (a local buil
 
 ```bash
 # Pick ONE of the three IMAGE variants below depending on what you're smoking:
-IMAGE=ghcr.io/fox-in-the-box-ai/cloud:stable      # the just-released version (today: v0.7.44)
-# IMAGE=ghcr.io/fox-in-the-box-ai/cloud:v0.7.44   # explicit pin (use during a multi-version comparison)
+IMAGE=ghcr.io/fox-in-the-box-ai/cloud:stable      # the just-released version (today: v0.7.59)
+# IMAGE=ghcr.io/fox-in-the-box-ai/cloud:v0.7.59   # explicit pin (use during a multi-version comparison)
 # IMAGE=ghcr.io/fox-in-the-box-ai/cloud:latest    # the candidate built from main, pre-tag
 
 docker pull "$IMAGE"
@@ -29,7 +29,7 @@ sleep 15   # extra time for entrypoint operator-grant + supervisord settle
 
 **The smoke container is at `http://127.0.0.1:8788`. Your real install (port 8787) is unaffected.**
 
-**Currently testing:** v0.7.44 (= `:stable` once tagged). Use `docker manifest inspect "$IMAGE" | jq -r '.manifests[0].digest'` to capture the digest for the current run; record it in the SMOKE log if a release is on the line.
+**Currently testing:** v0.7.59 (= `:stable` once tagged). Use `docker manifest inspect "$IMAGE" | jq -r '.manifests[0].digest'` to capture the digest for the current run; record it in the SMOKE log if a release is on the line.
 
 ---
 


### PR DESCRIPTION
## Summary

Update all stale version references, repo layout diagrams, and release pointers
across documentation to reflect the current v0.7.59 ship state (deployed 2026-07-10).

- **AGENTS.md** — fix repo layout tree: add `packages/deb/` + `packages/install-core/`, rename `tests/` → `qa/`, remove deleted `GATEWAY.md` + nonexistent `GETTING_STARTED.md` refs
- **README.md** — update "Recently shipped" section with v0.7.55–v0.7.59 items (upstream bump, security triage, apt repo, Playwright specs)
- **docs/DEV_MODE.md** — version refs `0.7.44` → `0.7.59` (3 occurrences)
- **docs/SECURITY_POSTURE.md** — header `v0.7.57` → `v0.7.59`
- **qa/SMOKE_CHECKLIST.md** — version refs `v0.7.44` → `v0.7.59` (3 occurrences)

### Deferred / out of scope

- FOX_TECHNICAL_REFERENCE.md and CLAUDE.md are gitignored/untracked — updated locally only

## Test plan

- [x] No code changes — docs only
- [x] All version references verified against `packages/electron/package.json` (0.7.59) and `packages/fox-overlay/versions.toml` (hermes-webui v0.52.0, hermes-agent v2026.7.7.2)
- [x] AGENTS.md layout tree verified against actual `ls` of `packages/`, `docs/`, `qa/`