### PR TITLE
feat(memory): bake mem0_oss deps and enable by default

### DIFF
--- a/packages/install-core/install-core.sh
+++ b/packages/install-core/install-core.sh
@@ -274,8 +274,8 @@ _pip_install() {
         _log "Using pip constraints: $FITB_PIP_CONSTRAINTS"
     fi
 
-    _log "Installing hermes-agent[anthropic,bedrock,google]..."
-    "$pip_cmd" install -e "$FITB_APP_DIR/hermes-agent[anthropic,bedrock,google]" \
+    _log "Installing hermes-agent[anthropic,bedrock,google,mem0]..."
+    "$pip_cmd" install -e "$FITB_APP_DIR/hermes-agent[anthropic,bedrock,google,mem0]" \
         "${constraints_flag[@]}" --quiet --no-cache-dir
 
     _log "Installing hermes-webui..."

--- a/packages/integration/default-configs/hermes.yaml
+++ b/packages/integration/default-configs/hermes.yaml
@@ -14,6 +14,15 @@ logging:
   level: info
   file: /data/logs/hermes.log
 
+# ── Memory ────────────────────────────────────────────────────────────────────
+# Self-hosted long-term memory via the mem0_oss provider (mem0ai + Qdrant,
+# no cloud account, no API key). Deps are baked into the image by the [mem0]
+# extra in install-core.sh. The LLM/embedder are auto-detected from the
+# configured provider (OPENROUTER_API_KEY / ANTHROPIC_API_KEY /
+# OPENAI_API_KEY / AWS Bedrock) — see fox-overlay/agent_memory_plugins/mem0_oss.
+memory:
+  provider: mem0_oss
+
 # ── MCP Servers ───────────────────────────────────────────────────────────────
 # Brave Search MCP — enables real-time web search and grounding.
 # Set BRAVE_API_KEY in /data/config/hermes.env to activate.

--- a/packages/integration/requirements.lock
+++ b/packages/integration/requirements.lock
@@ -16,16 +16,22 @@
 #
 # Editable packages (hermes-agent, hermes-webui, fox-overlay) are excluded —
 # they are installed from local source, not PyPI.
+
+# 2026-08-11: +mem0ai==2.0.10 (hermes-agent [mem0] extra, mem0_oss memory
+# provider) + transitive deps; protobuf 7.35.1 -> 6.33.6 because mem0ai 2.0.10
+# requires protobuf<7.0.0 (pip check clean on the full set).
 Jinja2==3.1.6
 Markdown==3.10.2
 MarkupSafe==3.0.3
 PyJWT==2.13.0
 PyYAML==6.0.3
 Pygments==2.20.0
+SQLAlchemy==2.0.52
 annotated-doc==0.0.4
 annotated-types==0.7.0
 anthropic==0.87.0
 anyio==4.14.0
+backoff==2.2.1
 boto3==1.42.89
 botocore==1.42.97
 certifi==2026.5.20
@@ -44,24 +50,33 @@ google-auth-httplib2==0.3.1
 google-auth-oauthlib==1.3.1
 google-auth==2.55.0
 googleapis-common-protos==1.75.0
+greenlet==3.5.5
+grpcio==1.83.0
 h11==0.16.0
+h2==4.4.1
+hpack==4.2.0
 httpcore==1.0.9
 httplib2==0.31.2
 httptools==0.8.0
 httpx==0.28.1
+hyperframe==6.1.0
 idna==3.18
 jiter==0.15.0
 jmespath==1.1.0
 markdown-it-py==4.2.0
 mdurl==0.1.2
+mem0ai==2.0.10
+numpy==2.4.6
 oauthlib==3.3.1
 openai==2.24.0
 packaging==26.0
 pathspec==1.1.1
 pillow==12.2.0
+portalocker==3.2.0
+posthog==7.38.4
 prompt_toolkit==3.0.52
 proto-plus==1.28.0
-protobuf==7.35.1
+protobuf==6.33.6
 psutil==7.2.2
 ptyprocess==0.7.0
 pyasn1==0.6.3
@@ -74,6 +89,7 @@ python-dateutil==2.9.0.post0
 python-dotenv==1.2.2
 python-multipart==0.0.32
 pytz==2026.2
+qdrant-client==1.19.0
 requests-oauthlib==2.0.0
 requests==2.33.0
 rich==14.3.3


### PR DESCRIPTION
## Summary

Enable the self-hosted **mem0_oss** memory provider by default in the Fox image: bake the `[mem0]` Python extra (mem0ai + Qdrant) at build time and set `memory.provider: mem0_oss` in the default agent config.

mem0_oss is a fully local long-term memory plugin (mem0ai + Qdrant, no cloud account) that already ships in `packages/fox-overlay/agent_memory_plugins/mem0_oss/`. Today its Python deps are excluded from the base install (`[mem0]` extra, lazy-installed at first use) and the provider is off by default — so Fox memory is only the built-in curator store unless the operator opts in.

## Changes

| File | Change |
|---|---|
| `packages/install-core/install-core.sh` | Install `hermes-agent[anthropic,bedrock,google,mem0]` so mem0ai==2.0.10 (pinned in hermes-agent pyproject) ships in the image |
| `packages/integration/default-configs/hermes.yaml` | `memory.provider: mem0_oss` — long-term memory on for every fresh install (LLM/embedder auto-detect from the configured provider) |
| `packages/integration/requirements.lock` | Pin mem0ai + transitive deps (qdrant-client, posthog, grpcio, numpy, h2/hpack/hyperframe, SQLAlchemy, backoff, greenlet, portalocker); **protobuf 7.35.1 → 6.33.6** because mem0ai 2.0.10 requires `protobuf>=5.29.6,<7.0.0` |

## Verification

- Full constraint set (existing lock + new pins) resolves and installs on Python 3.11: `pip check` → **No broken requirements found**
- `protobuf` downgrade is the only version change; no other pinned package conflicts
- Plugin itself is unchanged — it was already discoverable (see `packages/fox-overlay/agent_memory_plugins/mem0_oss/`), only deps + config default were missing
- Qdrant binary version in the image is untouched (client 1.19.0 is backward-compatible with the bundled server)

## Notes

- The [mem0] extra remains a separate extra upstream (deliberately excluded from `[all]` to quarantine bad releases) — this PR only adds it to the Fox image install, which is exactly what the lazy-install comment anticipated.
- Existing installs are unaffected: config defaults only apply to fresh `/data`; operators can still opt out by setting `memory.provider: ""` or another provider.
