### PR TITLE
fix(qa): consistent pytest-capable interpreter in validate-overlay.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Default WebUI theme is now light (brand palette `#FAF7F0`), replacing the previous dark default; existing installs keep their saved theme preference
 
 ### Fixed
+- `validate-overlay.sh` now selects one pytest-capable interpreter for the whole run (container target 3.11 preferred) instead of the first interpreter found; previously a bare python3.13 without pytest silently skipped the unit tests and failed the bootstrap smoke on 3.13-only stdlib layout drift
 
 - An EC2/Lightsail IMDS instance role is no longer treated as Bedrock OAuth authentication. Previously the provider card showed "Authenticated via OAuth" on any AWS VM and then failed with 403 at invoke time. Instance-role auth is now rejected by default; set `HERMES_BEDROCK_ALLOW_INSTANCE_ROLE=1` to opt back in. Explicit keys, `AWS_PROFILE`, shared credentials files, ECS task roles, and IRSA are unaffected
 - Tightened the mem0-oss memory write-discipline prompt: `mem0_oss_add` guidance now enumerates what to store (preferences, environment details, decisions, corrections) and what to skip (session events, completed-work logs, commit SHAs, short-lived state), replacing the permissive "any important detail" wording that invited noisy entries

--- a/packages/fox-overlay/scripts/validate-overlay.sh
+++ b/packages/fox-overlay/scripts/validate-overlay.sh
@@ -47,16 +47,37 @@ ok() {
     echo "✅ $1"
 }
 
-# ── 0. Python unit tests ──────────────────────────────────────────────────────
-echo "[0/3] Running Python unit tests (packages/fox-overlay/tests/)..."
-
-PYTHON_BIN_EARLY=""
-for candidate in python3.13 python3.12 python3.11 python3 python; do
-    if command -v "$candidate" >/dev/null 2>&1; then
-        PYTHON_BIN_EARLY="$candidate"
+# ── Interpreter selection (shared by sections 0 and 3) ────────────────────────
+# One interpreter for the whole script (#704): prefer the container's target
+# runtime (python:3.11-slim) first, and prefer an interpreter that can actually
+# run pytest over one that merely exists — a bare python3.13 without pytest
+# previously won selection, silently skipped the tests, and then failed the
+# bootstrap smoke on 3.13-only stdlib layout drift (pathlib._local).
+PYTHON_CANDIDATES="python3.11 python3.12 python3.13 python3 python"
+PYTHON_BIN=""
+for candidate in $PYTHON_CANDIDATES; do
+    if command -v "$candidate" >/dev/null 2>&1 \
+        && "$candidate" -m pytest --version >/dev/null 2>&1; then
+        PYTHON_BIN="$candidate"
         break
     fi
 done
+if [ -z "$PYTHON_BIN" ]; then
+    # No pytest anywhere — fall back to the first interpreter that exists
+    # (tests are skipped below, matching the old behavior).
+    for candidate in $PYTHON_CANDIDATES; do
+        if command -v "$candidate" >/dev/null 2>&1; then
+            PYTHON_BIN="$candidate"
+            break
+        fi
+    done
+fi
+[ -n "$PYTHON_BIN" ] && echo "Using interpreter: $PYTHON_BIN ($("$PYTHON_BIN" --version 2>&1))"
+
+# ── 0. Python unit tests ──────────────────────────────────────────────────────
+echo "[0/3] Running Python unit tests (packages/fox-overlay/tests/)..."
+
+PYTHON_BIN_EARLY="$PYTHON_BIN"
 
 if [ -n "$PYTHON_BIN_EARLY" ]; then
     if "$PYTHON_BIN_EARLY" -m pytest --version >/dev/null 2>&1; then
@@ -108,14 +129,8 @@ ok "Overlay basis clean"
 # a real container boot.
 echo "[3/3] Smoke-testing fox_overlay.bootstrap.install() locally..."
 
-# Try multiple Python interpreters in order of preference.
-PYTHON_BIN=""
-for candidate in python3.13 python3.12 python3.11 python3 python; do
-    if command -v "$candidate" >/dev/null 2>&1; then
-        PYTHON_BIN="$candidate"
-        break
-    fi
-done
+# Reuse the interpreter selected at the top of the script so the smoke runs
+# under the same Python that ran (or would have run) the unit tests.
 
 if [ -z "$PYTHON_BIN" ]; then
     echo "   ⚠️  No Python interpreter found — skipping bootstrap smoke."


### PR DESCRIPTION
## Summary

Fixes the interpreter-selection half of #704: both selection loops previously took the first interpreter that *existed* (preferring 3.13), so a bare `python3.13` without pytest silently skipped the unit tests and then failed the bootstrap smoke on 3.13-only stdlib layout drift (`pathlib` → `pathlib._local` breaks the `inspect.getsource` anchors, which target the container's 3.11 runtime). The script now selects **one** interpreter for the whole run — target runtime (3.11) first, pytest-capable preferred — and section 3 reuses it.

On the second half of #704 (clean-main failures in `test_agent_overlay.py` / `test_version_endpoint.py`): this does **not** reproduce on a clean main at the current pins — both files pass (15 passed, 1 skipped) under a pytest-capable interpreter with pristine submodules at v0.52.0 / v2026.7.7.2. The reported symptoms (stale expected versions + anchor drift) match a stale `fox_overlay`/hermes install shadowing the repo copy in the aliased environment. If it still reproduces after this fix with `Using interpreter:` output attached, please reopen with the printed interpreter path.

## Test plan

- [x] Full `validate-overlay.sh` run on clean main with the fix: 328 passed, submodules clean, overlay basis clean, bootstrap smoke passed — one interpreter throughout
- [x] Fallback preserved: with no pytest anywhere, tests are skipped exactly as before