### PR TITLE
chore(ci): run validate-overlay under Python 3.11 to match the container

### DIFF
--- a/.github/workflows/validate-overlay.yml
+++ b/.github/workflows/validate-overlay.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Python (for bootstrap import smoke + unit tests)
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: '3.12'
+          python-version: '3.11'
 
       - name: Install pytest + coverage + overlay deps
         run: pip install pytest pytest-cov pyyaml pillow --quiet


### PR DESCRIPTION
## Summary

Board follow-up from #714: `validate-overlay.yml` pinned setup-python to 3.12 while the shipped container runs `python:3.11-slim`. The validator's bootstrap smoke asserts `inspect.getsource` anchors against upstream code, so running it off the target runtime leaves the stdlib-layout-drift failure class (#704's `pathlib._local` case) covered only at Docker build time. One-line change: `python-version: '3.12'` → `'3.11'`.

## Test plan

- [x] Single-line workflow change; the `validate` check on this PR runs under 3.11 and is itself the verification
- [ ] CI green