### PR TITLE
feat(image): bake openssh-client into the container image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- `openssh-client` is baked into the container image, giving agents `ssh`/`scp`/`sftp` for remote host management and git-over-ssh
 - Long-term memory is enabled by default on fresh installs. Facts are extracted with your configured chat provider and stored locally (self-hosted mem0 + embedded Qdrant under the instance data volume). Embeddings are computed entirely on-device by a bundled local model (nomic-embed-text-v1.5, llama.cpp) — no extra API key required; works with any provider, including OpenRouter-only, Anthropic-only, direct OpenAI (openai-api), AWS Bedrock, and local Ollama/LM Studio/vLLM setups
 - Memory state is visible in Settings and on /readyz: active, off (with the reason), or error — never a silent no-op. Providers without a static API key (e.g. OAuth-based) show memory as off with a one-line override to use a different provider for memory. Existing installs opt in with one line: `memory: provider: mem0_oss`
 - Canonical Fox branding across all surfaces: new app icons (macOS/Windows/Linux), full WebUI favicon set (ico/svg/png + apple-touch), browser and PWA titles now read "Fox in the Box"

--- a/packages/integration/Dockerfile
+++ b/packages/integration/Dockerfile
@@ -37,6 +37,8 @@ ARG FITB_DEV=0
 # ── system dependencies ───────────────────────────────────────────────────────
 # libgomp1 + libcurl4 are runtime deps for the bundled llama.cpp llama-server
 # binary (issue #9). Both are small (libgomp1 ~150 KB, libcurl4 ~400 KB).
+# openssh-client gives agents ssh/scp/sftp for remote host management and
+# git-over-ssh (subagent VPS ops, demo box rollouts).
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         ca-certificates \
@@ -47,6 +49,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         iptables \
         libgomp1 \
         libcurl4 \
+        openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
 # ── Node.js (LTS) — required for npx-based MCP servers (e.g. Brave Search) ───


### PR DESCRIPTION
## What

Adds `openssh-client` to the base image's system dependencies in `packages/integration/Dockerfile`, so every Fox install ships `ssh`/`scp`/`sftp` without needing a custom overlay.

## Why

The `cloud:stable` base image only installs `curl`, `ca-certificates`, `gnupg`, `git`, `lsb-release`, `iproute2`, `iptables`, `libgomp1`, and `libcurl4`. SSH is missing entirely, which forces agent remote-host workflows (VPS ops, demo-box rollouts, git-over-ssh) into paramiko-only or per-install overlay hacks. Baking it into the base image benefits all downstream installs.

## Notes

- Package is small (~1.5 MB with deps) and standard on Debian trixie (the base is `python:3.11-slim`).
- Also adds a changelog entry under Unreleased → Added.
- No behavior change for existing images; takes effect on next image build.

## Tests

- Dockerfile is a one-line package addition; no build/test matrix changes. Existing container smoke covers boot.