### PR TITLE
feat(entrypoint): self-heal missing ssh/rsync on stale images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Container entrypoint self-heals missing `ssh`/`rsync` on stale or partial images (best-effort apt install at boot; never blocks startup)
 - Long-term memory is enabled by default on fresh installs. Facts are extracted with your configured chat provider and stored locally (self-hosted mem0 + embedded Qdrant under the instance data volume). Embeddings are computed entirely on-device by a bundled local model (nomic-embed-text-v1.5, llama.cpp) — no extra API key required; works with any provider, including OpenRouter-only, Anthropic-only, direct OpenAI (openai-api), AWS Bedrock, and local Ollama/LM Studio/vLLM setups
 - Memory state is visible in Settings and on /readyz: active, off (with the reason), or error — never a silent no-op. Providers without a static API key (e.g. OAuth-based) show memory as off with a one-line override to use a different provider for memory. Existing installs opt in with one line: `memory: provider: mem0_oss`
 - Canonical Fox branding across all surfaces: new app icons (macOS/Windows/Linux), full WebUI favicon set (ico/svg/png + apple-touch), browser and PWA titles now read "Fox in the Box"

--- a/packages/integration/entrypoint.sh
+++ b/packages/integration/entrypoint.sh
@@ -158,6 +158,29 @@ chown root:root /data/run /data/data/tailscale
 mkdir -p /app/workspace
 chown -R foxinthebox:foxinthebox /app/workspace
 
+# ── 4a. Dev toolbelt self-heal ────────────────────────────────────────────────
+# Best-effort: if a stale or partial image is missing ssh/rsync (built before
+# openssh-client was baked, interrupted installs), install them at boot. Never
+# fail boot on apt problems — the tools are optional for the core service.
+_ensure_dev_toolbelt() {
+    local missing_apt=() missing_names=()
+    command -v ssh   >/dev/null 2>&1 || { missing_apt+=(openssh-client); missing_names+=(ssh);   }
+    command -v rsync >/dev/null 2>&1 || { missing_apt+=(rsync);          missing_names+=(rsync); }
+    if [ "${#missing_apt[@]}" -eq 0 ]; then
+        echo "[entrypoint] Dev toolbelt: ssh + rsync present."
+        return 0
+    fi
+    echo "[entrypoint] Installing missing dev tools: ${missing_names[*]}"
+    if apt-get update -qq 2>/dev/null && \
+       apt-get install -y --no-install-recommends "${missing_apt[@]}" -qq 2>/dev/null; then
+        echo "[entrypoint] Installed: ${missing_names[*]}"
+    else
+        echo "[entrypoint] WARN: apt-get failed — dev tools unavailable: ${missing_names[*]}" >&2
+    fi
+}
+_ensure_dev_toolbelt
+unset -f _ensure_dev_toolbelt
+
 # ── 5. Load environment ────────────────────────────────────────────────────────
 HERMES_ENV="/data/config/hermes.env"
 if [ -f "$HERMES_ENV" ]; then

--- a/tests/integration/test_task03_integration_files.py
+++ b/tests/integration/test_task03_integration_files.py
@@ -137,6 +137,15 @@ class TestEntrypoint(unittest.TestCase):
             ),
         )
 
+    def test_dev_toolbelt_self_heal(self) -> None:
+        """Entrypoint self-heals missing ssh/rsync on stale images (best-effort)."""
+        self.assertIn("_ensure_dev_toolbelt", self.sh)
+        self.assertIn("openssh-client", self.sh)
+        self.assertIn("rsync", self.sh)
+        self.assertIn("apt-get install -y --no-install-recommends", self.sh)
+        # Must never fail boot when apt is unavailable
+        self.assertIn("WARN: apt-get failed", self.sh)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

Adds a best-effort dev-toolbelt self-heal to `packages/integration/entrypoint.sh`: at boot, if `ssh` or `rsync` is missing (stale image built before the bake, or interrupted install), the entrypoint apt-installs `openssh-client` + `rsync` — and never blocks startup if apt fails.

## Why

The Dockerfile bake in #728 fixes **fresh** images, but existing installs running pre-bake images (or partial installs) still boot without ssh/rsync. This makes the container self-heal on the next start — no rebuild required. Same pattern already proven in production by Vulpy's `hermes-fox-entrypoint.sh` (this exact mechanism fixed a stale image on 2026-08-14).

## Notes

- Runs as root (entrypoint context), before supervisord handoff — matches the existing chown/config-backfill sections.
- **Non-fatal by design**: apt failure logs a WARN and boot continues. `set -euo pipefail` is respected via the guarded `if`.
- Complements #728 (bake) — both are independent and mergeable in either order.
- Added `test_dev_toolbelt_self_heal` to `tests/integration/test_task03_integration_files.py` (passing).

## Pre-existing failure note

`test_non_root_user_named_foxinthebox` fails on **pristine main** too (verified via stash): the Dockerfile references `fox-in-the-box.css` in `HERMES_WEBUI_EXTENSION_STYLESHEET_URLS`, which trips `assertNotIn("fox-in-the-box", self.df)`. Unrelated to this PR — flagging so it isn't blamed on this change.