### PR TITLE
feat(image): bake openssh-client and rsync into the container image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- `openssh-client` is baked into the container image, giving agents `ssh`/`scp`/`sftp` for remote host management and git-over-ssh
+- `openssh-client` and `rsync` are baked into the container image, giving agents `ssh`/`scp`/`sftp`/`rsync` for remote host management, git-over-ssh, and patch-sync flows (~15–20 MB installed)
 - Long-term memory is enabled by default on fresh installs. Facts are extracted with your configured chat provider and stored locally (self-hosted mem0 + embedded Qdrant under the instance data volume). Embeddings are computed entirely on-device by a bundled local model (nomic-embed-text-v1.5, llama.cpp) — no extra API key required; works with any provider, including OpenRouter-only, Anthropic-only, direct OpenAI (openai-api), AWS Bedrock, and local Ollama/LM Studio/vLLM setups
 - Memory state is visible in Settings and on /readyz: active, off (with the reason), or error — never a silent no-op. Providers without a static API key (e.g. OAuth-based) show memory as off with a one-line override to use a different provider for memory. Existing installs opt in with one line: `memory: provider: mem0_oss`
 - Canonical Fox branding across all surfaces: new app icons (macOS/Windows/Linux), full WebUI favicon set (ico/svg/png + apple-touch), browser and PWA titles now read "Fox in the Box"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- `openssh-client` is baked into the container image, giving agents `ssh`/`scp`/`sftp` for remote host management and git-over-ssh
 - Long-term memory is enabled by default on fresh installs. Facts are extracted with your configured chat provider and stored locally (self-hosted mem0 + embedded Qdrant under the instance data volume). Embeddings are computed entirely on-device by a bundled local model (nomic-embed-text-v1.5, llama.cpp) — no extra API key required; works with any provider, including OpenRouter-only, Anthropic-only, direct OpenAI (openai-api), AWS Bedrock, and local Ollama/LM Studio/vLLM setups
 - Memory state is visible in Settings and on /readyz: active, off (with the reason), or error — never a silent no-op. Providers without a static API key (e.g. OAuth-based) show memory as off with a one-line override to use a different provider for memory. Existing installs opt in with one line: `memory: provider: mem0_oss`
 - Canonical Fox branding across all surfaces: new app icons (macOS/Windows/Linux), full WebUI favicon set (ico/svg/png + apple-touch), browser and PWA titles now read "Fox in the Box"

--- a/packages/integration/Dockerfile
+++ b/packages/integration/Dockerfile
@@ -37,6 +37,8 @@ ARG FITB_DEV=0
 # ── system dependencies ───────────────────────────────────────────────────────
 # libgomp1 + libcurl4 are runtime deps for the bundled llama.cpp llama-server
 # binary (issue #9). Both are small (libgomp1 ~150 KB, libcurl4 ~400 KB).
+# openssh-client gives agents ssh/scp/sftp for remote host management and
+# git-over-ssh (subagent VPS ops, demo box rollouts).
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         ca-certificates \
@@ -47,6 +49,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         iptables \
         libgomp1 \
         libcurl4 \
+        openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
 # ── Node.js (LTS) — required for npx-based MCP servers (e.g. Brave Search) ───

--- a/packages/integration/Dockerfile
+++ b/packages/integration/Dockerfile
@@ -38,7 +38,10 @@ ARG FITB_DEV=0
 # libgomp1 + libcurl4 are runtime deps for the bundled llama.cpp llama-server
 # binary (issue #9). Both are small (libgomp1 ~150 KB, libcurl4 ~400 KB).
 # openssh-client gives agents ssh/scp/sftp for remote host management and
-# git-over-ssh (subagent VPS ops, demo box rollouts).
+# git-over-ssh (subagent VPS ops, demo box rollouts); rsync pairs with it
+# for the vps-patch-sync flow. Baking BOTH keeps the entrypoint tool-heal
+# a true no-op on fresh images (~15-20 MB installed with the krb5/gnutls
+# dependency train — shared in part with git).
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         ca-certificates \
@@ -50,6 +53,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libgomp1 \
         libcurl4 \
         openssh-client \
+        rsync \
     && rm -rf /var/lib/apt/lists/*
 
 # ── Node.js (LTS) — required for npx-based MCP servers (e.g. Brave Search) ───


### PR DESCRIPTION
## Summary

Supersedes #728 (fork CI could not push to GHCR, so the Image self-test never ran there) with the original commit cherry-picked intact plus the review board's corrections. Credit to the original author for the change.

- `openssh-client` **and `rsync`** join the existing apt RUN (with cleanup, no new layer): the paired entrypoint tool-heal covers both tools, so baking both keeps the heal a true no-op on fresh images. Consumers: agents' ssh/scp/sftp for remote host management, git-over-ssh, and the rsync-based vps-patch-sync flow — both tools are baked by the upstream hermes Dockerfiles as well
- Size claim corrected: ~15–20 MB installed with the krb5/gnutls dependency train (partially shared with git), not the ~1.5 MB originally stated
- Merge order: this PR first, then the heal PR rebases on it

## Test plan

- [x] Board-reviewed (8 perspectives) as a pair with the heal PR; all findings addressed
- [ ] CI green incl. Image self-test on the actual built image (in-repo branch — GHCR push works)

Closes #728.