### PR TITLE
feat(entrypoint): self-heal missing ssh/rsync on stale images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - `openssh-client` and `rsync` are baked into the container image, giving agents `ssh`/`scp`/`sftp`/`rsync` for remote host management, git-over-ssh, and patch-sync flows (~15–20 MB installed)
+- Container entrypoint self-heals missing `ssh`/`rsync` on stale pre-bake images (best-effort apt install at boot with a 5 s network timeout; warns loudly, never blocks startup; bridge code tracked for removal in #736)
 - Long-term memory is enabled by default on fresh installs. Facts are extracted with your configured chat provider and stored locally (self-hosted mem0 + embedded Qdrant under the instance data volume). Embeddings are computed entirely on-device by a bundled local model (nomic-embed-text-v1.5, llama.cpp) — no extra API key required; works with any provider, including OpenRouter-only, Anthropic-only, direct OpenAI (openai-api), AWS Bedrock, and local Ollama/LM Studio/vLLM setups
 - Memory state is visible in Settings and on /readyz: active, off (with the reason), or error — never a silent no-op. Providers without a static API key (e.g. OAuth-based) show memory as off with a one-line override to use a different provider for memory. Existing installs opt in with one line: `memory: provider: mem0_oss`
 - Canonical Fox branding across all surfaces: new app icons (macOS/Windows/Linux), full WebUI favicon set (ico/svg/png + apple-touch), browser and PWA titles now read "Fox in the Box"

--- a/packages/integration/entrypoint.sh
+++ b/packages/integration/entrypoint.sh
@@ -158,6 +158,29 @@ chown root:root /data/run /data/data/tailscale
 mkdir -p /app/workspace
 chown -R foxinthebox:foxinthebox /app/workspace
 
+# ── 4a. Dev toolbelt self-heal ────────────────────────────────────────────────
+# Best-effort: if a stale or partial image is missing ssh/rsync (built before
+# openssh-client was baked, interrupted installs), install them at boot. Never
+# fail boot on apt problems — the tools are optional for the core service.
+_ensure_dev_toolbelt() {
+    local missing_apt=() missing_names=()
+    command -v ssh   >/dev/null 2>&1 || { missing_apt+=(openssh-client); missing_names+=(ssh);   }
+    command -v rsync >/dev/null 2>&1 || { missing_apt+=(rsync);          missing_names+=(rsync); }
+    if [ "${#missing_apt[@]}" -eq 0 ]; then
+        echo "[entrypoint] Dev toolbelt: ssh + rsync present."
+        return 0
+    fi
+    echo "[entrypoint] Installing missing dev tools: ${missing_names[*]}"
+    if apt-get update -qq 2>/dev/null && \
+       apt-get install -y --no-install-recommends "${missing_apt[@]}" -qq 2>/dev/null; then
+        echo "[entrypoint] Installed: ${missing_names[*]}"
+    else
+        echo "[entrypoint] WARN: apt-get failed — dev tools unavailable: ${missing_names[*]}" >&2
+    fi
+}
+_ensure_dev_toolbelt
+unset -f _ensure_dev_toolbelt
+
 # ── 5. Load environment ────────────────────────────────────────────────────────
 HERMES_ENV="/data/config/hermes.env"
 if [ -f "$HERMES_ENV" ]; then

--- a/packages/integration/entrypoint.sh
+++ b/packages/integration/entrypoint.sh
@@ -159,23 +159,27 @@ mkdir -p /app/workspace
 chown -R foxinthebox:foxinthebox /app/workspace
 
 # ── 4a. Dev toolbelt self-heal ────────────────────────────────────────────────
-# Best-effort: if a stale or partial image is missing ssh/rsync (built before
-# openssh-client was baked, interrupted installs), install them at boot. Never
-# fail boot on apt problems — the tools are optional for the core service.
+# Best-effort BRIDGE CODE for stale images built before ssh/rsync were baked
+# (removal tracked in #736 — delete once the deployed fleet rolls past the
+# bake release). On healthy images this is a cheap command -v no-op. Never
+# fail boot on apt problems; short network timeouts keep offline boots fast.
 _ensure_dev_toolbelt() {
-    local missing_apt=() missing_names=()
+    local missing_apt=() missing_names=() apt_err
     command -v ssh   >/dev/null 2>&1 || { missing_apt+=(openssh-client); missing_names+=(ssh);   }
     command -v rsync >/dev/null 2>&1 || { missing_apt+=(rsync);          missing_names+=(rsync); }
     if [ "${#missing_apt[@]}" -eq 0 ]; then
         echo "[entrypoint] Dev toolbelt: ssh + rsync present."
         return 0
     fi
-    echo "[entrypoint] Installing missing dev tools: ${missing_names[*]}"
-    if apt-get update -qq 2>/dev/null && \
-       apt-get install -y --no-install-recommends "${missing_apt[@]}" -qq 2>/dev/null; then
+    echo "[entrypoint] Stale image detected — installing missing dev tools: ${missing_names[*]} (pull a current image to avoid this per-boot install)"
+    if apt_err=$(apt-get update -qq \
+            -o Acquire::http::Timeout=5 -o Acquire::https::Timeout=5 -o Acquire::Retries=1 2>&1 >/dev/null) && \
+       apt_err=$(apt-get install -y --no-install-recommends "${missing_apt[@]}" -qq \
+            -o Acquire::http::Timeout=5 -o Acquire::https::Timeout=5 -o Acquire::Retries=1 2>&1 >/dev/null); then
+        rm -rf /var/lib/apt/lists/*
         echo "[entrypoint] Installed: ${missing_names[*]}"
     else
-        echo "[entrypoint] WARN: apt-get failed — dev tools unavailable: ${missing_names[*]}" >&2
+        echo "[entrypoint] WARN: dev-tool heal failed — ${missing_names[*]} unavailable this boot. apt said: ${apt_err:-no error output}" >&2
     fi
 }
 _ensure_dev_toolbelt

--- a/tests/integration/test_task03_integration_files.py
+++ b/tests/integration/test_task03_integration_files.py
@@ -143,8 +143,14 @@ class TestEntrypoint(unittest.TestCase):
         self.assertIn("openssh-client", self.sh)
         self.assertIn("rsync", self.sh)
         self.assertIn("apt-get install -y --no-install-recommends", self.sh)
-        # Must never fail boot when apt is unavailable
-        self.assertIn("WARN: apt-get failed", self.sh)
+        # Must never fail boot when apt is unavailable, and the warning must
+        # carry apt's actual error text for operators
+        self.assertIn("WARN: dev-tool heal failed", self.sh)
+        self.assertIn("apt said:", self.sh)
+        # Offline boots must not stall on apt's default timeouts
+        self.assertIn("Acquire::http::Timeout=5", self.sh)
+        # Bridge code carries its removal tracker
+        self.assertIn("#736", self.sh)
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_task03_integration_files.py
+++ b/tests/integration/test_task03_integration_files.py
@@ -137,6 +137,15 @@ class TestEntrypoint(unittest.TestCase):
             ),
         )
 
+    def test_dev_toolbelt_self_heal(self) -> None:
+        """Entrypoint self-heals missing ssh/rsync on stale images (best-effort)."""
+        self.assertIn("_ensure_dev_toolbelt", self.sh)
+        self.assertIn("openssh-client", self.sh)
+        self.assertIn("rsync", self.sh)
+        self.assertIn("apt-get install -y --no-install-recommends", self.sh)
+        # Must never fail boot when apt is unavailable
+        self.assertIn("WARN: apt-get failed", self.sh)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Supersedes #730 (fork CI could not push to GHCR, so the Image self-test never ran there). The original heal commit is cherry-picked intact — credit to the original author — plus the review board's hardening:

- Bridge code for images built before the ssh/rsync bake (#737): on a healthy image the check is a `command -v` no-op; on a stale image it apt-installs the missing tools with a **loud stale-image message** naming the fix (pull a current image)
- apt stderr is captured into the WARN so operators can distinguish offline vs DNS vs mirror failures; 5-second Acquire timeouts plus one retry keep offline boots fast; apt lists cleaned after a successful heal; never blocks boot under `set -euo pipefail`
- Removal tracked in #736 (bridge code sunsets when the deployed fleet rolls past the bake release), referenced in the block
- String test updated to the hardened block

Reviewed as a pair with #737 by the 8-perspective board; all findings addressed (the rsync-never-baked gap that would have made this heal fire on every fresh boot was fixed on the bake side).

## Test plan

- [x] `bash -n`; string test green (the one unrelated pre-existing failure in this non-CI suite is tracked separately)
- [ ] CI green incl. Image self-test on the built image

Closes #730.