### PR TITLE
chore: lift v0.7.60 release freeze

### DIFF
--- a/.release-freeze
+++ b/.release-freeze
@@ -1,1 +1,0 @@
-v0.7.60 release freeze: no bump(upstream) merges until the v0.7.60 tag lands and the post-tag lift PR removes this file.


### PR DESCRIPTION
Single change per the freeze protocol: delete `.release-freeze` now that the v0.7.60 tag is pushed, the release run is green end-to-end, and every artifact is verified (7 desktop/deb assets, container `v0.7.60` + `:stable` manifests, `releases/latest`, apt publish). Checklist ordering honored: tag push → artifact verification → this lift. `bump(upstream):` merges unblock on merge.