### PR TITLE
chore(deps): bump js-yaml to 4.3.1 across both lockfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Security
+
+- js-yaml resolved to 4.3.1 in both lockfiles (root pnpm-lock.yaml and packages/electron/package-lock.json), clearing all four open js-yaml advisories. Corrects the 0.7.60 record: that entry listed js-yaml 4.3.1 in its security batch, but the lockfiles still resolved 4.2.0 at release time — this change is what lands it.
+
 ---
 
 ## [0.7.60] — 2026-08-14

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
       "protobufjs": "^7.6.3",
       "@grpc/grpc-js": "^1.14.4",
       "form-data": "^4.0.6",
-      "js-yaml": "^4.2.0",
+      "js-yaml": "^4.3.1",
       "tmp": "^0.2.6",
       "@babel/core": "^7.29.6"
     }

--- a/packages/electron/package-lock.json
+++ b/packages/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fox-in-the-box/electron",
-  "version": "0.7.59",
+  "version": "0.7.60",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fox-in-the-box/electron",
-      "version": "0.7.59",
+      "version": "0.7.60",
       "dependencies": {
         "docker-modem": "^5.0.7",
         "dockerode": "^5.0.1",
@@ -5685,9 +5685,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   protobufjs: ^7.6.3
   '@grpc/grpc-js': ^1.14.4
   form-data: ^4.0.6
-  js-yaml: ^4.2.0
+  js-yaml: ^4.3.1
   tmp: ^0.2.6
   '@babel/core': ^7.29.6
 
@@ -1590,10 +1590,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
-    hasBin: true
 
   js-yaml@4.3.1:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
@@ -3628,7 +3624,7 @@ snapshots:
     dependencies:
       builder-util-runtime: 9.7.0
       fs-extra: 10.1.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       lazy-val: 1.0.5
       lodash.escaperegexp: 4.1.2
       lodash.isequal: 4.5.0
@@ -4333,10 +4329,6 @@ snapshots:
   jiti@2.7.0: {}
 
   js-tokens@4.0.0: {}
-
-  js-yaml@4.2.0:
-    dependencies:
-      argparse: 2.0.1
 
   js-yaml@4.3.1:
     dependencies:


### PR DESCRIPTION
## Summary
Clears **four** of the six open dependabot alerts — both js-yaml advisories in both lockfiles (#124/#125 HIGH fixed-in 4.3.1, #90/#91 HIGH fixed-in 4.3.0). The two protobufjs MEDIUM alerts (#71/#72, fixed-in 7.6.5) are queued as a follow-up chore PR.

- Root: pnpm override floor raised `^4.2.0` → `^4.3.1`; `pnpm install --lockfile-only` refresh — 4.2.0 fully gone from pnpm-lock.yaml
- Electron package: `npm update js-yaml --package-lock-only` — resolves 4.3.1 (dep range `^4.1.0` already permitted it)
- **Incidental, verified-correct hunk:** the electron package-lock's own `version` fields resync 0.7.59 → 0.7.60 — the lockfile was stale from the v0.7.60 release (package.json was bumped without the lock); `npm update` heals that drift. Not a version bump by this PR.
- CHANGELOG: \[Unreleased\] Security entry recording the landing — also corrects the 0.7.60 entry, which listed js-yaml 4.3.1 in its batch while the lockfiles still resolved 4.2.0 at release time.

No code changes; no version bump per Option B (dependency-only).

## Test plan
- [x] pnpm-lock refresh resolves cleanly (573 packages, no conflicts)
- [x] Board pass: integrity/resolved fields verified against npmjs; no unexpected package changes
- [ ] CI green (the cancelled `validate` run was an infra flake — checkout hung; re-run triggered)