### PR TITLE
chore(ci): upstream-watch dedupe + tripwire false-positive fixes

### DIFF
--- a/.github/scripts/tripwire-branch-watch.sh
+++ b/.github/scripts/tripwire-branch-watch.sh
@@ -45,10 +45,12 @@ check_repo() {
 Branch: **\`$branch\`**
 
 The regex \`$regex\` flags branches that historically signal:
-- A framework rewrite (\`react\`, \`vue\`, \`svelte\`, \`preact\`)
 - A major version bump (\`v2\`, \`v3\`, etc.)
-- A long-running rewrite (\`rewrite\`, \`major\`)
+- A long-running rewrite (\`rewrite\`, \`major\` as a path segment)
 - An upstream "next-gen" branch (\`next\`)
+- On the webui repo only: a frontend-framework rewrite (\`react\`, \`vue\`, \`svelte\`, \`preact\`)
+
+Maintenance-prefixed branches (\`fix/\`, \`chore/\`, \`docs/\`, \`test/\`, \`ci/\`) are excluded.
 
 **Why this matters:** if upstream merges a rewrite branch to default, the Fox overlay's anchors will catastrophically fail — most or all monkey-patch substitutions will miss. Plan a strategic re-evaluation before that merge lands.
 

--- a/.github/scripts/tripwire-branch-watch.sh
+++ b/.github/scripts/tripwire-branch-watch.sh
@@ -8,14 +8,27 @@
 set -eu
 source "$(dirname "$0")/tripwire-common.sh"
 
-REWRITE_REGEX='react|vue|svelte|preact|rewrite|^v[0-9]+$|^next$|major'
+# Rewrite-signal regexes, tightened after three false positives on
+# 2026-08-14 (#722 'centaur-port/slack-reaction-context' — 'react' inside
+# 'reaction'; #724 'feat/skill-react-best-practices' — a skill doc, not a
+# frontend rewrite of a Python backend; #726 'fix/electron-41-major' — a
+# fix branch, not a major rewrite):
+# - tokens must be whole path segments (bounded by / _ - or string edge),
+# - frontend-framework tokens apply only to the webui repo — the agent
+#   repo is a Python backend where such branch names are docs/skills,
+# - conventional maintenance prefixes are excluded outright.
+COMMON_REGEX='(^|[/_-])(rewrite|major)([/_-]|$)|^v[0-9]+$|^next$'
+WEBUI_REGEX="$COMMON_REGEX|(^|[/_-])(react|vue|svelte|preact)([/_-]|\$)"
+EXCLUDE_REGEX='^(fix|chore|docs|test|ci)/'
 
 check_repo() {
     local repo="$1"
+    local regex="$2"
     local matches
     matches=$(git ls-remote --heads "https://github.com/$repo.git" 2>/dev/null \
               | awk '{sub("refs/heads/", "", $2); print $2}' \
-              | grep -iE "$REWRITE_REGEX" \
+              | grep -ivE "$EXCLUDE_REGEX" \
+              | grep -iE "$regex" \
               | grep -vE '^(master|main)$' \
               || true)
 
@@ -31,7 +44,7 @@ check_repo() {
 
 Branch: **\`$branch\`**
 
-The regex \`$REWRITE_REGEX\` flags branches that historically signal:
+The regex \`$regex\` flags branches that historically signal:
 - A framework rewrite (\`react\`, \`vue\`, \`svelte\`, \`preact\`)
 - A major version bump (\`v2\`, \`v3\`, etc.)
 - A long-running rewrite (\`rewrite\`, \`major\`)
@@ -55,5 +68,5 @@ EOF
     done <<<"$matches"
 }
 
-check_repo "$WEBUI_REPO"
-check_repo "$AGENT_REPO"
+check_repo "$WEBUI_REPO" "$WEBUI_REGEX"
+check_repo "$AGENT_REPO" "$COMMON_REGEX"

--- a/.github/scripts/tripwire-maintainer-absence.sh
+++ b/.github/scripts/tripwire-maintainer-absence.sh
@@ -22,9 +22,14 @@ since=$(date -u -v-${WINDOW_DAYS}d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
 
 count=0
 for acct in $MAINTAINER_ACCOUNTS; do
-    c=$(gh api -X GET "repos/$WEBUI_REPO/commits" \
-          -f sha="$WEBUI_BRANCH" -f author="$acct" -f since="$since" --paginate 2>/dev/null \
-          | jq -r '.[].sha' | wc -l | tr -d ' ')
+    # An API failure must read as "cannot evaluate", not as zero commits —
+    # otherwise a transient GitHub outage fires a false absence alarm.
+    if ! resp=$(gh api -X GET "repos/$WEBUI_REPO/commits" \
+          -f sha="$WEBUI_BRANCH" -f author="$acct" -f since="$since" --paginate 2>&1); then
+        echo "[tripwire/absence] gh api failed for $acct — cannot evaluate: $resp"
+        exit 0
+    fi
+    c=$(printf '%s' "$resp" | jq -r '.[].sha' | wc -l | tr -d ' ')
     count=$((count + c))
 done
 

--- a/.github/scripts/tripwire-maintainer-absence.sh
+++ b/.github/scripts/tripwire-maintainer-absence.sh
@@ -9,27 +9,37 @@ set -eu
 source "$(dirname "$0")/tripwire-common.sh"
 
 MAINTAINER="nesquena"
+# The maintainer commits under two accounts: the human account and the
+# nesquena-hermes automation/release account (confirmed 2026-08-18 —
+# daily activity moved to nesquena-hermes while the human account went
+# quiet on 2026-07-31, firing #720 as a false positive). Either account
+# counts as presence.
+MAINTAINER_ACCOUNTS="nesquena nesquena-hermes"
 WINDOW_DAYS=5
 
 since=$(date -u -v-${WINDOW_DAYS}d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
         || date -u -d "$WINDOW_DAYS days ago" +%Y-%m-%dT%H:%M:%SZ)
 
-count=$(gh api -X GET "repos/$WEBUI_REPO/commits" \
-          -f sha="$WEBUI_BRANCH" -f author="$MAINTAINER" -f since="$since" --paginate 2>/dev/null \
+count=0
+for acct in $MAINTAINER_ACCOUNTS; do
+    c=$(gh api -X GET "repos/$WEBUI_REPO/commits" \
+          -f sha="$WEBUI_BRANCH" -f author="$acct" -f since="$since" --paginate 2>/dev/null \
           | jq -r '.[].sha' | wc -l | tr -d ' ')
+    count=$((count + c))
+done
 
 if [ "$count" -gt 0 ]; then
     echo "[tripwire/absence] $MAINTAINER: $count commits in last $WINDOW_DAYS days; condition clear"
     tripwire_clear \
         "[tripwire/absence] $MAINTAINER silent for $WINDOW_DAYS+ days on $WEBUI_REPO" \
-        "$MAINTAINER has $count commits in the last $WINDOW_DAYS days."
+        "Maintainer accounts (nesquena + nesquena-hermes) have $count commits in the last $WINDOW_DAYS days."
     exit 0
 fi
 
 body=$(cat <<EOF
 ## \`$MAINTAINER\` silent for $WINDOW_DAYS+ days on \`$WEBUI_REPO\`
 
-Baseline at v0.6.0: zero gaps of $WINDOW_DAYS+ silent days in 48 observed days. Today's run finds zero \`$MAINTAINER\`-authored commits to \`$WEBUI_BRANCH\` since $since.
+Baseline at v0.6.0: zero gaps of $WINDOW_DAYS+ silent days in 48 observed days. Today's run finds zero commits authored by any maintainer account (\`nesquena\`, \`nesquena-hermes\`) to \`$WEBUI_BRANCH\` since $since.
 
 ## Why this matters
 

--- a/.github/scripts/tripwire-rebase-clock.sh
+++ b/.github/scripts/tripwire-rebase-clock.sh
@@ -28,6 +28,11 @@ if [ -n "$pinned_at" ]; then
                    || date -u -d "$pinned_at" +%s 2>/dev/null \
                    || echo 0)
 fi
+if [ "$pinned_epoch" -eq 0 ]; then
+    # Fail loud in the log: without the floor the #734 false-positive
+    # class silently returns.
+    echo "[tripwire/rebase-clock] WARN: could not parse pinned_at from versions.toml — verification floor disabled, ages are raw file ages"
+fi
 
 stale=()
 for series_dir in packages/fox-overlay/patches/webui packages/fox-overlay/patches/agent; do

--- a/.github/scripts/tripwire-rebase-clock.sh
+++ b/.github/scripts/tripwire-rebase-clock.sh
@@ -15,6 +15,20 @@ source "$(dirname "$0")/tripwire-common.sh"
 
 THRESHOLD_DAYS=90
 
+# The freshness clock measures verification recency, not file churn: an
+# upstream bump re-validates the ENTIRE patch series against the new tags
+# (check-overlay-basis + CI), including patches whose files didn't need
+# regenerating. Floor every patch's age at versions.toml pinned_at so a
+# just-verified series doesn't fire on untouched files (#734 fired on a
+# patch verified the same week).
+pinned_at=$(grep -E '^pinned_at\s*=' packages/fox-overlay/versions.toml | awk -F'"' '{print $2}' || true)
+pinned_epoch=0
+if [ -n "$pinned_at" ]; then
+    pinned_epoch=$(date -u -j -f '%Y-%m-%d' "$pinned_at" +%s 2>/dev/null \
+                   || date -u -d "$pinned_at" +%s 2>/dev/null \
+                   || echo 0)
+fi
+
 stale=()
 for series_dir in packages/fox-overlay/patches/webui packages/fox-overlay/patches/agent; do
     [ -d "$series_dir" ] || continue
@@ -26,10 +40,11 @@ for series_dir in packages/fox-overlay/patches/webui packages/fox-overlay/patche
         last_epoch=$(date -u -j -f '%Y-%m-%dT%H:%M:%S%z' "$last_iso" +%s 2>/dev/null \
                      || date -u -d "$last_iso" +%s 2>/dev/null \
                      || echo 0)
+        [ "$pinned_epoch" -gt "$last_epoch" ] && last_epoch=$pinned_epoch
         now_epoch=$(date -u +%s)
         age_days=$(( (now_epoch - last_epoch) / 86400 ))
         if [ "$age_days" -gt "$THRESHOLD_DAYS" ]; then
-            stale+=("\`$patch\` ($age_days days since last touch)")
+            stale+=("\`$patch\` ($age_days days since last touch or pin-verification)")
         fi
     done
 done

--- a/.github/scripts/tripwire-stage-batch-gap.sh
+++ b/.github/scripts/tripwire-stage-batch-gap.sh
@@ -19,7 +19,7 @@ source "$(dirname "$0")/tripwire-common.sh"
 # what this tripwire watches (outage, not stable-promotion cadence).
 THRESHOLD_HOURS=48
 
-last_stamp_iso=$(gh api -X GET "repos/$WEBUI_REPO/releases" -f per_page=30 2>/dev/null \
+last_stamp_iso=$(gh api -X GET "repos/$WEBUI_REPO/releases" -f per_page=100 2>/dev/null \
                    | jq -r '[.[] | select(.draft == false)] | sort_by(.published_at) | last | .published_at // empty' \
                    || true)
 

--- a/.github/scripts/tripwire-stage-batch-gap.sh
+++ b/.github/scripts/tripwire-stage-batch-gap.sh
@@ -1,53 +1,55 @@
 #!/usr/bin/env bash
 # Tripwire #213 — stage-batch monitoring.
 #
-# nesquena's release cadence stamps commits with messages like
-# "Stamp CHANGELOG for v0.51.84 (Release BH / stage-377)".
-# If the gap between the most-recent such stamp and now > $THRESHOLD_HOURS
-# AND there have been non-stamp commits since (unreleased activity), the
+# Watches nesquena's release pipeline: if the gap between the newest
+# published release (any kind, prereleases included) and now exceeds
+# $THRESHOLD_HOURS AND commits have landed since (unreleased activity), the
 # release pipeline is likely down. Early signal of maintainer outage.
 
 set -eu
 source "$(dirname "$0")/tripwire-common.sh"
 
-STAMP_REGEX='Stamp CHANGELOG'
+# 2026-08-18 rework: the original detector keyed on "Stamp CHANGELOG"
+# commit messages, but nesquena's release flow stopped producing those
+# (releases now come via the exp-series process with occasional stable
+# promotions) — #727 fired with an 823h "gap" while stable v0.52.113 had
+# shipped days earlier. The pipeline-alive signal is now the newest
+# *published release* of any kind: prereleases count, because an
+# exp-series prerelease proves the release pipeline is running, which is
+# what this tripwire watches (outage, not stable-promotion cadence).
 THRESHOLD_HOURS=48
 
-last_stamp_iso=$(gh api -X GET "repos/$WEBUI_REPO/commits" \
-                   -f sha="$WEBUI_BRANCH" -f per_page=100 --paginate 2>/dev/null \
-                   | jq -r '.[] | select(.commit.message | test("'"$STAMP_REGEX"'")) | .commit.committer.date' \
-                   2>/dev/null \
-                   | head -1 || true)
+last_stamp_iso=$(gh api -X GET "repos/$WEBUI_REPO/releases" -f per_page=30 2>/dev/null \
+                   | jq -r '[.[] | select(.draft == false)] | sort_by(.published_at) | last | .published_at // empty' \
+                   || true)
 
 if [ -z "$last_stamp_iso" ]; then
-    echo "[tripwire/stage-batch] no stamp commit found in recent history; cannot evaluate"
+    echo "[tripwire/stage-batch] no published release found; cannot evaluate"
     exit 0
 fi
 
-# Hours since last stamp.
+# Hours since the newest published release.
 now_epoch=$(date -u +%s)
 last_stamp_epoch=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$last_stamp_iso" +%s 2>/dev/null \
                    || date -u -d "$last_stamp_iso" +%s)
 gap_hours=$(( (now_epoch - last_stamp_epoch) / 3600 ))
 
-# Commits since the last stamp (i.e. unreleased work).
+# Commits since the newest release (i.e. unreleased work).
 unreleased=$(gh api -X GET "repos/$WEBUI_REPO/commits" \
                -f sha="$WEBUI_BRANCH" -f since="$last_stamp_iso" --paginate 2>/dev/null \
                | jq -r '.[].sha' | wc -l | tr -d ' ')
-# Subtract 1 (the stamp itself is in the range).
-unreleased=$((unreleased - 1))
 [ "$unreleased" -lt 0 ] && unreleased=0
 
 CLEAR_TITLE="[tripwire/stage-batch] $WEBUI_REPO release stamp gap >${THRESHOLD_HOURS}h"
 
 if [ "$gap_hours" -lt "$THRESHOLD_HOURS" ]; then
-    echo "[tripwire/stage-batch] last stamp $gap_hours h ago (< $THRESHOLD_HOURS h); condition clear"
-    tripwire_clear "$CLEAR_TITLE" "Last stamp was $gap_hours h ago (under ${THRESHOLD_HOURS}h threshold)."
+    echo "[tripwire/stage-batch] newest release $gap_hours h ago (< $THRESHOLD_HOURS h); condition clear"
+    tripwire_clear "$CLEAR_TITLE" "Newest published release was $gap_hours h ago (under ${THRESHOLD_HOURS}h threshold)."
     exit 0
 fi
 
 if [ "$unreleased" -eq 0 ]; then
-    echo "[tripwire/stage-batch] $gap_hours h since last stamp BUT no unreleased commits; condition clear (quiet period)"
+    echo "[tripwire/stage-batch] $gap_hours h since newest release BUT no unreleased commits; condition clear (quiet period)"
     tripwire_clear "$CLEAR_TITLE" "No unreleased commits — quiet period, not a stall."
     exit 0
 fi
@@ -55,7 +57,7 @@ fi
 body=$(cat <<EOF
 ## Stage-batch release stamp gap on \`$WEBUI_REPO\`
 
-Last \`$STAMP_REGEX\` commit on \`$WEBUI_BRANCH\` was **$gap_hours hours ago** ($last_stamp_iso). Since then, **$unreleased non-stamp commits** have landed without a new release stamp.
+Newest published release on \`$WEBUI_REPO\` (prereleases included) was **$gap_hours hours ago** ($last_stamp_iso). Since then, **$unreleased commits** have landed on \`$WEBUI_BRANCH\` without a new release of any kind.
 
 Threshold: $THRESHOLD_HOURS hours.
 

--- a/.github/workflows/upstream-tripwires.yml
+++ b/.github/workflows/upstream-tripwires.yml
@@ -114,8 +114,9 @@ jobs:
         run: bash .github/scripts/tripwire-nous-ui-watch.sh
 
   # ── #211 — Maintainer absence canary (nesquena) ────────────────────────
-  # Baseline at v0.6.0: 0 gaps of 5+ silent days in 48 days. Fires if
-  # nesquena has zero commits to upstream/master for 5 consecutive days.
+  # Baseline at v0.6.0: 0 gaps of 5+ silent days in 48 days. Fires only if
+  # BOTH maintainer accounts (nesquena + the nesquena-hermes automation
+  # account) have zero commits to upstream/master for 5 consecutive days.
   # Debounce note: during 5-week migrations (rare), suppress manually by
   # closing the issue.
   maintainer_absence:
@@ -142,11 +143,11 @@ jobs:
         run: bash .github/scripts/tripwire-cve-feed.sh
 
   # ── #213 — Stage-batch monitoring ──────────────────────────────────────
-  # nesquena's release cadence stamps commits like
-  # "Stamp CHANGELOG for v0.51.84 (Release BH / stage-377)". If the gap
-  # between the most recent such stamp and now exceeds 48h while there
-  # is unreleased commit activity, the release pipeline likely broke —
-  # early signal of maintainer outage.
+  # Watches the release pipeline's pulse: if the newest published release
+  # (any kind — exp-series prereleases count as pipeline-alive) is older
+  # than 48h while commits keep landing, the release pipeline likely
+  # broke — early signal of maintainer outage. (Originally keyed on
+  # "Stamp CHANGELOG" commits; that pattern was retired upstream.)
   stage_batch_gap:
     if: github.event.inputs.only == '' || github.event.inputs.only == 'stage_batch_gap'
     name: "#213 stage-batch gap"

--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -197,6 +197,15 @@ jobs:
         run: |
           set -eu
           title="[upstream-watch] Update available: webui ${{ steps.pinned.outputs.webui_tag }} → ${{ steps.latest.outputs.webui }}, agent ${{ steps.pinned.outputs.agent_tag }} → ${{ steps.latest.outputs.agent }}"
+          # Dedupe: an open issue with this exact title means the same
+          # update is already reported — re-fire as a comment, don't stack.
+          existing=$(gh issue list --label "upstream-update-available" --state open \
+                       --json number,title -q ".[] | select(.title == \"$title\") | .number" | head -1)
+          if [ -n "$existing" ]; then
+              gh issue comment "$existing" --body "Still available as of run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}."
+              echo "[upstream-watch] re-fired existing issue #$existing"
+              exit 0
+          fi
           body=$(cat <<EOF
           ## Upstream tag updates available
 
@@ -219,6 +228,15 @@ jobs:
           EOF
           )
           gh issue create --title "$title" --body "$body" --label "upstream-update-available"
+          # Supersede older update-available reports (different title =
+          # older target versions) so exactly one stays open.
+          gh issue list --label "upstream-update-available" --state open \
+              --json number,title -q ".[] | select(.title != \"$title\") | .number" \
+          | while read -r n; do
+              [ -z "$n" ] && continue
+              gh issue close "$n" --reason "not planned" \
+                  --comment "Superseded by a newer update-available report: $title"
+          done
 
       - name: Open issue — basis drift (refresh required)
         if: steps.drift.outputs.no_drift != 'yes' && steps.basis.outputs.basis_rc != '0'
@@ -227,6 +245,15 @@ jobs:
         run: |
           set -eu
           title="[upstream-drift] Overlay anchors drift against webui ${{ steps.latest.outputs.webui }} / agent ${{ steps.latest.outputs.agent }}"
+          # Dedupe: same drift target already reported → re-fire as a
+          # comment instead of stacking a duplicate issue per nightly run.
+          existing=$(gh issue list --label "upstream-drift" --state open \
+                       --json number,title -q ".[] | select(.title == \"$title\") | .number" | head -1)
+          if [ -n "$existing" ]; then
+              gh issue comment "$existing" --body "Still drifted as of run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}."
+              echo "[upstream-watch] re-fired existing drift issue #$existing"
+              exit 0
+          fi
           body=$(cat <<EOF
           ## Overlay basis drift detected
 
@@ -253,6 +280,15 @@ jobs:
           EOF
           )
           gh issue create --title "$title" --body "$body" --label "upstream-drift" --label "P2"
+          # Supersede older drift reports (different title = older upstream
+          # targets) so exactly one drift issue stays open.
+          gh issue list --label "upstream-drift" --state open \
+              --json number,title -q ".[] | select(.title != \"$title\") | .number" \
+          | while read -r n; do
+              [ -z "$n" ] && continue
+              gh issue close "$n" --reason "not planned" \
+                  --comment "Superseded by a newer drift report: $title"
+          done
 
       - name: Open issue — workflow itself failed
         if: failure()

--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -199,8 +199,12 @@ jobs:
           title="[upstream-watch] Update available: webui ${{ steps.pinned.outputs.webui_tag }} → ${{ steps.latest.outputs.webui }}, agent ${{ steps.pinned.outputs.agent_tag }} → ${{ steps.latest.outputs.agent }}"
           # Dedupe: an open issue with this exact title means the same
           # update is already reported — re-fire as a comment, don't stack.
-          existing=$(gh issue list --label "upstream-update-available" --state open \
-                       --json number,title -q ".[] | select(.title == \"$title\") | .number" | head -1)
+          # Title goes to jq via the environment (env.WATCH_TITLE), not
+          # string-splicing — upstream tag names may contain jq-significant
+          # characters.
+          export WATCH_TITLE="$title"
+          existing=$(gh issue list --label "upstream-update-available" --state open --limit 100 \
+                       --json number,title -q '.[] | select(.title == env.WATCH_TITLE) | .number' | head -1)
           if [ -n "$existing" ]; then
               gh issue comment "$existing" --body "Still available as of run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}."
               echo "[upstream-watch] re-fired existing issue #$existing"
@@ -230,12 +234,15 @@ jobs:
           gh issue create --title "$title" --body "$body" --label "upstream-update-available"
           # Supersede older update-available reports (different title =
           # older target versions) so exactly one stays open.
-          gh issue list --label "upstream-update-available" --state open \
-              --json number,title -q ".[] | select(.title != \"$title\") | .number" \
+          # A failing close must not fail the step (the primary issue is
+          # already created; a step failure here would trip the
+          # workflow-failed handler and open the very noise this fixes).
+          gh issue list --label "upstream-update-available" --state open --limit 100 \
+              --json number,title -q '.[] | select(.title != env.WATCH_TITLE) | .number' \
           | while read -r n; do
               [ -z "$n" ] && continue
               gh issue close "$n" --reason "not planned" \
-                  --comment "Superseded by a newer update-available report: $title"
+                  --comment "Superseded by a newer update-available report: $title" || true
           done
 
       - name: Open issue — basis drift (refresh required)
@@ -247,8 +254,10 @@ jobs:
           title="[upstream-drift] Overlay anchors drift against webui ${{ steps.latest.outputs.webui }} / agent ${{ steps.latest.outputs.agent }}"
           # Dedupe: same drift target already reported → re-fire as a
           # comment instead of stacking a duplicate issue per nightly run.
-          existing=$(gh issue list --label "upstream-drift" --state open \
-                       --json number,title -q ".[] | select(.title == \"$title\") | .number" | head -1)
+          # Title via env for jq — see the update-available step.
+          export WATCH_TITLE="$title"
+          existing=$(gh issue list --label "upstream-drift" --state open --limit 100 \
+                       --json number,title -q '.[] | select(.title == env.WATCH_TITLE) | .number' | head -1)
           if [ -n "$existing" ]; then
               gh issue comment "$existing" --body "Still drifted as of run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}."
               echo "[upstream-watch] re-fired existing drift issue #$existing"
@@ -282,12 +291,12 @@ jobs:
           gh issue create --title "$title" --body "$body" --label "upstream-drift" --label "P2"
           # Supersede older drift reports (different title = older upstream
           # targets) so exactly one drift issue stays open.
-          gh issue list --label "upstream-drift" --state open \
-              --json number,title -q ".[] | select(.title != \"$title\") | .number" \
+          gh issue list --label "upstream-drift" --state open --limit 100 \
+              --json number,title -q '.[] | select(.title != env.WATCH_TITLE) | .number' \
           | while read -r n; do
               [ -z "$n" ] && continue
               gh issue close "$n" --reason "not planned" \
-                  --comment "Superseded by a newer drift report: $title"
+                  --comment "Superseded by a newer drift report: $title" || true
           done
 
       - name: Open issue — workflow itself failed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - js-yaml resolved to 4.3.1 in both lockfiles (root pnpm-lock.yaml and packages/electron/package-lock.json), clearing all four open js-yaml advisories. Corrects the 0.7.60 record: that entry listed js-yaml 4.3.1 in its security batch, but the lockfiles still resolved 4.2.0 at release time — this change is what lands it.
 - protobufjs resolved to 7.6.5 in both lockfiles, clearing the last two open dependabot alerts; with the js-yaml 4.3.1 bump this takes the open alert count to zero
 
+### Fixed
+
+- Upstream-watch and tripwire detectors no longer spam the issue tracker: nightly watch reports dedupe by title and supersede older reports (previously up to one duplicate per night), the branch rewrite-regex requires whole path segments with frontend-framework tokens scoped to the webui repo, maintainer-absence recognizes both maintainer accounts, stage-batch keys on published releases instead of the retired Stamp-CHANGELOG commit pattern, and the patch rebase-clock floors ages at the last upstream-pin verification date
+
 ---
 
 ## [0.7.60] — 2026-08-14


### PR DESCRIPTION
## Summary
Fixes the detectors behind this week's issue-noise wave (35 duplicate [upstream-watch]/[upstream-drift] issues + 4 tripwire false positives, all closed manually today):

1. **upstream-watch.yml** — exact-title dedupe (re-fire as comment) + auto-supersede of older same-label reports. Exactly one update-available and one drift issue can be open at a time.
2. **branch-watch** — path-segment-bounded tokens, frontend-framework tokens scoped to the webui repo only, maintenance prefixes excluded. Kills the #722/#724/#726 class; positive controls still fire (see test table in the commit).
3. **maintainer-absence** — counts nesquena + nesquena-hermes (activity moved to the automation account; #720 was a false absence).
4. **stage-batch** — keys on newest published release (prereleases included) instead of the retired 'Stamp CHANGELOG' commit pattern (#727 phantom 823h gap; real gap 1h).
5. **rebase-clock** — patch age floors at versions.toml pinned_at, since a bump re-verifies the whole series (#734 fired on a patch verified the same week).

## Test plan
- [x] bash -n on bash 5 (CI runtime) + shellcheck clean on all four scripts; workflow YAML parses
- [x] Live dry-run against both upstreams: old regex fires 3 false positives, new fires 0; 10-case positive/negative control table all correct
- [x] Live absence count = 32 commits in window (quiet, correct); live release gap = 1h (quiet, correct)
- [ ] CI green
- [ ] Post-merge: next nightly runs produce no new duplicate/false-positive issues