### PR TITLE
chore(deps): bump protobufjs to 7.6.5 across both lockfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Security
 
 - js-yaml resolved to 4.3.1 in both lockfiles (root pnpm-lock.yaml and packages/electron/package-lock.json), clearing all four open js-yaml advisories. Corrects the 0.7.60 record: that entry listed js-yaml 4.3.1 in its security batch, but the lockfiles still resolved 4.2.0 at release time — this change is what lands it.
+- protobufjs resolved to 7.6.5 in both lockfiles, clearing the last two open dependabot alerts; with the js-yaml 4.3.1 bump this takes the open alert count to zero
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "pnpm": {
     "overrides": {
       "tar": "^7.5.16",
-      "protobufjs": "^7.6.3",
+      "protobufjs": "^7.6.5",
       "@grpc/grpc-js": "^1.14.4",
       "form-data": "^4.0.6",
       "js-yaml": "^4.3.1",

--- a/packages/electron/package-lock.json
+++ b/packages/electron/package-lock.json
@@ -6664,9 +6664,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   tar: ^7.5.16
-  protobufjs: ^7.6.3
+  protobufjs: ^7.6.5
   '@grpc/grpc-js': ^1.14.4
   form-data: ^4.0.6
   js-yaml: ^4.3.1
@@ -1921,8 +1921,8 @@ packages:
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
-  protobufjs@7.6.4:
-    resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
   pump@3.0.4:
@@ -2661,14 +2661,14 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.6.4
+      protobufjs: 7.6.5
       yargs: 17.7.3
 
   '@grpc/proto-loader@0.8.1':
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.6.4
+      protobufjs: 7.6.5
       yargs: 17.7.3
 
   '@isaacs/cliui@8.0.2':
@@ -3550,7 +3550,7 @@ snapshots:
       '@grpc/grpc-js': 1.14.4
       '@grpc/proto-loader': 0.7.15
       docker-modem: 5.0.7
-      protobufjs: 7.6.4
+      protobufjs: 7.6.5
       tar-fs: 2.1.5
     transitivePeerDependencies:
       - supports-color
@@ -4619,7 +4619,7 @@ snapshots:
       retry: 0.12.0
       signal-exit: 3.0.7
 
-  protobufjs@7.6.4:
+  protobufjs@7.6.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2


### PR DESCRIPTION
## Summary
Clears the last two open dependabot alerts (#71/#72, MEDIUM protobufjs, fixed-in 7.6.5) — the remainder flagged during the #741 board. Root pnpm override floor `^7.6.3` → `^7.6.5` + `pnpm install --lockfile-only`, and `npm update protobufjs --package-lock-only` in packages/electron. Both lockfiles previously **resolved 7.6.4** (the ^7.6.3 floor never pinned 7.6.3); the actual resolution change is 7.6.4 → 7.6.5. With this merged, open dependabot alerts = 0.

**Incidental, verified-correct hunk:** the electron package-lock's own `version` fields resync 0.7.59 → 0.7.60 — pre-existing drift from the v0.7.60 release (same hunk as in-flight #741; byte-identical, merges cleanly in either order). Not a version bump by this PR.

CHANGELOG: \[Unreleased\] Security entry added per the #741 convention.

No code changes; no version bump per Option B (dependency-only).

## Test plan
- [x] Both locks refresh cleanly; 7.6.5 resolves in both; integrity verified against npmjs by the board
- [x] Board pass: 8 hats, no blocking defects in the diff
- [ ] CI green (merge gate)