### PR TITLE
docs(qa): v0.7.60 SMOKE_LOG closeout — startup delta + release CI status

### DIFF
--- a/qa/SMOKE_LOG.md
+++ b/qa/SMOKE_LOG.md
@@ -53,7 +53,18 @@ Findings:
 - spaCy/fastembed optional-extras notices appear on plugin ops — cosmetic, semantic search unaffected
 - Smoke-run OpenRouter key passed through the session transcript; rotate after the release
 
-Startup-delta and CI-status sections: populated at closeout after the tag run.
+Startup delta (measured 2026-08-18, keyless boot to `/readyz` `ready:true`, fresh volume, two runs per tag on the same Docker host):
+
+- v0.7.59: 4s / 3s — v0.7.60: 3s / 4s. **No boot-latency regression from memory default-on** — the embed model loads lazily and idle-unloads (`--sleep-idle-seconds 120`), so keyless/idle boots pay nothing; the memory readiness component participates in `/readyz` from first boot.
+
+CI status (release tag run 32086093272, `v0.7.60`, 2026-08-18, conclusion **success** — every job green, none skipped):
+
+- Build & Push amd64+arm64, Merge into manifest list, Smoke amd64+arm64, Image self-test: success
+- Build Electron macOS + Windows (signed): success
+- Build .deb amd64+arm64, .deb smoke test (22.04 constrained + 24.04 unconstrained legs — step 12 above): success
+- Publish to apt.foxinthebox.ai: success; Promote container image (`:v0.7.60` + `:stable`, both multi-arch verified): success; Create GitHub Release (7 assets): success
+
+Post-release addendum (2026-08-18): the pinned-upstream note in step 11's context changed the same day — #740 advanced the container pins to webui v0.52.113 / agent v2026.8.16.2 as a container-only Option B update (`:stable` auto-advanced; no DMG/exe rebuild). Desktop v0.7.60 artifacts are unaffected.
 
 ---
 

--- a/qa/SMOKE_LOG.md
+++ b/qa/SMOKE_LOG.md
@@ -51,7 +51,7 @@ Findings:
 - Post-idle wake behavior (the design's last open runtime question) settles cleanly — keep `--sleep-idle-seconds 120`
 - Raw `Memory.add` bypasses the breaker by design (harness detail); the plugin's own op wrappers surface errors correctly
 - spaCy/fastembed optional-extras notices appear on plugin ops — cosmetic, semantic search unaffected
-- Smoke-run OpenRouter key passed through the session transcript; rotate after the release
+- Smoke-run OpenRouter key passed through the session transcript; rotate after the release — tracked as #746 (still pending at closeout, founder action)
 
 Startup delta (measured 2026-08-18, keyless boot to `/readyz` `ready:true`, fresh volume, two runs per tag on the same Docker host):
 
@@ -61,10 +61,10 @@ CI status (release tag run 32086093272, `v0.7.60`, 2026-08-18, conclusion **succ
 
 - Build & Push amd64+arm64, Merge into manifest list, Smoke amd64+arm64, Image self-test: success
 - Build Electron macOS + Windows (signed): success
-- Build .deb amd64+arm64, .deb smoke test (22.04 constrained + 24.04 unconstrained legs — step 12 above): success
+- Build .deb amd64+arm64: success; `.deb smoke test (amd64)` (a single job — the 22.04-constrained and 24.04-unconstrained legs of step 12 run as steps inside `test_deb_install.sh`): success
 - Publish to apt.foxinthebox.ai: success; Promote container image (`:v0.7.60` + `:stable`, both multi-arch verified): success; Create GitHub Release (7 assets): success
 
-Post-release addendum (2026-08-18): the pinned-upstream note in step 11's context changed the same day — #740 advanced the container pins to webui v0.52.113 / agent v2026.8.16.2 as a container-only Option B update (`:stable` auto-advanced; no DMG/exe rebuild). Desktop v0.7.60 artifacts are unaffected.
+Post-release addendum (2026-08-18): the upstream pins this entry's smoke ran against (the entry preamble's "main @ the v0.7.60 release cut") advanced the same day — #740 moved the container to webui v0.52.113 / agent v2026.8.16.2 as a container-only Option B update (`:stable` auto-advanced; no DMG/exe rebuild). Desktop v0.7.60 artifacts are unaffected.
 
 ---
 


### PR DESCRIPTION
## Summary
Fills the two sections the v0.7.60 SMOKE_LOG entry deferred to closeout, per the mandatory-CI-status override in §19.8:

- **Startup delta**, measured today (2 runs per tag, keyless boot to `/readyz` ready, fresh volumes): v0.7.59 4s/3s vs v0.7.60 3s/4s — no regression from memory default-on (lazy embed load + idle unload).
- **CI status** of release run 32086093272: success across all 14 jobs (container amd64+arm64+self-test, Electron macOS+Windows, deb build+smoke, apt publish, container promotion, GitHub Release).
- Post-release addendum noting the same-day #740 container-only pin advance.

Docs-only.

## Test plan
- [x] Data verified against the actual run (gh run view 32086093272) and live boot measurements
- [ ] CI green