### PR TITLE
feat(desktop): bump bundled Electron to 43.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- Bundled desktop Electron 42.8.0 → 43.4.0 (Chromium 150, Node 24). Verified with a packaged-app launch smoke on macOS arm64 (window renders, startup orchestrator runs, zero renderer errors, clean exit) plus the full startup test suite; Windows coverage is the CI dev-mode startup smoke — no packaged-exe install test exists yet
+
 ### Security
 
 - js-yaml resolved to 4.3.1 in both lockfiles (root pnpm-lock.yaml and packages/electron/package-lock.json), clearing all four open js-yaml advisories. Corrects the 0.7.60 record: that entry listed js-yaml 4.3.1 in its security batch, but the lockfiles still resolved 4.2.0 at release time — this change is what lands it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
-- Bundled desktop Electron 42.8.0 → 43.4.0 (Chromium 150, Node 24). Verified with a packaged-app launch smoke on macOS arm64 (window renders, startup orchestrator runs, zero renderer errors, clean exit) plus the full startup test suite; Windows coverage is the CI dev-mode startup smoke — no packaged-exe install test exists yet
+- Bundled desktop Electron → 43.4.0 (Chromium 150, Node 24), from 42.8.0 in the npm lockfile and 42.5.1 in the pnpm lockfile — the bump also heals that pre-existing cross-lockfile skew. Verified with a packaged-app launch smoke on macOS arm64 (window renders, startup orchestrator runs, zero renderer errors, clean exit) plus the full startup test suite; Windows coverage is the CI dev-mode startup smoke — no packaged-exe install test exists yet
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ Fox in the Box bundles a full AI assistant — agent, chat UI, persistent memory
 
 There are several good self-hosted AI assistants. Here's how Fox compares on the dimensions that matter most for a personal, private setup:
 
-| | **Fox in the Box** | **Open WebUI** | **AnythingLLM** | **Jan** | **LibreChat** |
-|---|---|---|---|---|---|
-| **License** | MIT | Custom (branding clause, 50+ users) | MIT | Apache 2.0 | MIT |
-| **Desktop installer** | Windows, macOS, Linux | Alpha (v0.0.x) | Windows, macOS, Linux | Windows, macOS, Linux | No (Docker / npm) |
-| **No-terminal setup** | Guided wizard in browser | Docker or pip (terminal) | Guided desktop app | Guided desktop app | Docker Compose |
-| **Memory across sessions** | Semantic (mem0 + Qdrant) | Workspace + global memories | Workspace + global memories | Conversation history | Conversation history |
-| **Remote access built-in** | Tailscale (one toggle) | Manual setup | No | No | No |
-| **Local models** | Auto-detects Ollama, one-click switch | Built-in llama.cpp + Ollama | Built-in Ollama support | Native inference (llama.cpp) + model hub | Ollama supported |
+|                            | **Fox in the Box**                    | **Open WebUI**                      | **AnythingLLM**             | **Jan**                                  | **LibreChat**        |
+| -------------------------- | ------------------------------------- | ----------------------------------- | --------------------------- | ---------------------------------------- | -------------------- |
+| **License**                | MIT                                   | Custom (branding clause, 50+ users) | MIT                         | Apache 2.0                               | MIT                  |
+| **Desktop installer**      | Windows, macOS, Linux                 | Alpha (v0.0.x)                      | Windows, macOS, Linux       | Windows, macOS, Linux                    | No (Docker / npm)    |
+| **No-terminal setup**      | Guided wizard in browser              | Docker or pip (terminal)            | Guided desktop app          | Guided desktop app                       | Docker Compose       |
+| **Memory across sessions** | Semantic (mem0 + Qdrant)              | Workspace + global memories         | Workspace + global memories | Conversation history                     | Conversation history |
+| **Remote access built-in** | Tailscale (one toggle)                | Manual setup                        | No                          | No                                       | No                   |
+| **Local models**           | Auto-detects Ollama, one-click switch | Built-in llama.cpp + Ollama         | Built-in Ollama support     | Native inference (llama.cpp) + model hub | Ollama supported     |
 
 **Fox's angle:** a private assistant that just works — install it, paste a key, start talking. Semantic memory that carries across sessions, remote access without port forwarding, and a standard MIT license.
 
@@ -177,18 +177,18 @@ For local iteration on the bundled `hermes-agent` / `hermes-webui` submodules, s
 - **Windows: Linux-containers mode is required** (Docker Desktop's default). If you've previously switched to Windows-containers mode, Fox detects it and exits with an actionable error — right-click the Docker Desktop tray icon → **Switch to Linux containers...** and relaunch Fox.
 - **Windows: the WSL 2 backend is required.** Docker Desktop's installer enables it for you. In Docker Desktop settings make sure **General → "Use the WSL 2 based engine"** is checked. If WSL2 isn't installed when Fox launches, it'll attempt the repair automatically (may require a reboot).
 
-**CPU virtualization** *(Windows only)*
+**CPU virtualization** _(Windows only)_
 
 - **Hardware virtualization must be enabled in BIOS/UEFI** — `VT-x` on Intel CPUs, `AMD-V` / `SVM Mode` on AMD CPUs. Required by both Docker Desktop and WSL2.
 - Most consumer PCs ship with it enabled. If Docker reports "WSL2 backend not running" or "virtualization disabled," reboot into BIOS, look for **Intel Virtualization Technology** / **SVM Mode** / **VT-x**, enable it, save, reboot.
 - Apple Silicon and Intel Macs have virtualization on by default — nothing to configure.
 
-**Provider API key** *(at least one)*
+**Provider API key** _(at least one)_
 
 - An **[OpenRouter](https://openrouter.ai)** API key (recommended — one key gives you hundreds of models, no per-provider setup).
 - Or any other supported provider — Anthropic, OpenAI, Google Gemini, DeepSeek, Mistral, etc. Configurable in Settings after install. See [Supported providers](#supported-providers) below.
 
-**Ollama** *(optional — only if you want local models)*
+**Ollama** _(optional — only if you want local models)_
 
 - To run local AI models, install **[Ollama](https://ollama.com/download)** separately on your host machine — Ollama runs on your computer, not inside the Fox container.
 - Fox auto-detects a running Ollama daemon via `host.docker.internal:11434` and surfaces every installed model in **Settings → Providers → Local Ollama** with one-click switching.
@@ -221,42 +221,42 @@ The setup wizard runs once. After that the app handles itself — but a few thin
 
 Most users start with **OpenRouter** — one key, hundreds of models. Add more from Settings → Providers when you need direct access or specific pricing.
 
-| Provider | How to add | Notes |
-|---|---|---|
-| **OpenRouter** | Onboarding wizard, then Settings | Recommended starting point. Hundreds of models via a single API. |
-| **Anthropic** | Settings → Providers | Direct Claude API |
-| **OpenAI** | Settings → Providers | Direct GPT API |
-| **Google Gemini** | Settings → Providers | Google AI Studio |
-| **xAI (Grok)** | Settings → Providers | Direct xAI API |
-| **DeepSeek** | Settings → Providers | Direct |
-| **Mistral AI** | Settings → Providers | Direct |
-| **Z.ai (GLM)** | Settings → Providers | Direct |
-| **Kimi** | Settings → Providers | Coding-tuned models |
-| **MiniMax** | Settings → Providers | Global + China endpoints |
-| **NVIDIA NIM** | Settings → Providers | Hosted NIM endpoints |
-| **OpenCode-Zen / Go** | Settings → Providers | Code-specialized providers |
-| **Ollama Cloud** | Settings → Providers | Hosted Ollama (`ollama.com`) |
-| **Local Ollama** | Auto-detected — no key needed | Fox probes `host.docker.internal:11434` then `localhost:11434` on Settings open. If a daemon is running, it appears as its own tile with installed models, one-click switching, **one-click pull from a recommended set** when no models are installed, and delete from inside the chat (since v0.3.1). Linux requires Fox v0.3.0+ (containers built before then need to be re-created — they're missing the `--add-host=host.docker.internal:host-gateway` flag). |
-| **LM Studio** | Settings → Providers | Local OpenAI-compatible endpoint |
-| **GitHub Copilot, Nous Portal, Codex, Qwen** | `hermes` CLI inside the container | OAuth-only — managed via the bundled Hermes CLI, not the Settings UI |
+| Provider                                     | How to add                        | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| -------------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **OpenRouter**                               | Onboarding wizard, then Settings  | Recommended starting point. Hundreds of models via a single API.                                                                                                                                                                                                                                                                                                                                                                                                   |
+| **Anthropic**                                | Settings → Providers              | Direct Claude API                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| **OpenAI**                                   | Settings → Providers              | Direct GPT API                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| **Google Gemini**                            | Settings → Providers              | Google AI Studio                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| **xAI (Grok)**                               | Settings → Providers              | Direct xAI API                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| **DeepSeek**                                 | Settings → Providers              | Direct                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| **Mistral AI**                               | Settings → Providers              | Direct                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| **Z.ai (GLM)**                               | Settings → Providers              | Direct                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| **Kimi**                                     | Settings → Providers              | Coding-tuned models                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| **MiniMax**                                  | Settings → Providers              | Global + China endpoints                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| **NVIDIA NIM**                               | Settings → Providers              | Hosted NIM endpoints                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| **OpenCode-Zen / Go**                        | Settings → Providers              | Code-specialized providers                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| **Ollama Cloud**                             | Settings → Providers              | Hosted Ollama (`ollama.com`)                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| **Local Ollama**                             | Auto-detected — no key needed     | Fox probes `host.docker.internal:11434` then `localhost:11434` on Settings open. If a daemon is running, it appears as its own tile with installed models, one-click switching, **one-click pull from a recommended set** when no models are installed, and delete from inside the chat (since v0.3.1). Linux requires Fox v0.3.0+ (containers built before then need to be re-created — they're missing the `--add-host=host.docker.internal:host-gateway` flag). |
+| **LM Studio**                                | Settings → Providers              | Local OpenAI-compatible endpoint                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| **GitHub Copilot, Nous Portal, Codex, Qwen** | `hermes` CLI inside the container | OAuth-only — managed via the bundled Hermes CLI, not the Settings UI                                                                                                                                                                                                                                                                                                                                                                                               |
 
 ---
 
 ## Architecture
 
-| Component | Purpose |
-|-----------|---------|
+| Component                                                    | Purpose                                                                                                                                |
+| ------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
 | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | AI agent core — LLM orchestration, tools, skills (Fox tracks virgin upstream via overlay; see `docs/architecture/upstream-overlay.md`) |
-| [Hermes WebUI](https://github.com/nesquena/hermes-webui) | Browser-based chat interface (Fox tracks virgin upstream via overlay; see `docs/architecture/upstream-overlay.md`) |
-| mem0 + Qdrant | Persistent memory with local vector search |
-| Tailscale | Optional VPN tunneling and automatic HTTPS |
-| supervisord | Process management inside the container |
+| [Hermes WebUI](https://github.com/nesquena/hermes-webui)     | Browser-based chat interface (Fox tracks virgin upstream via overlay; see `docs/architecture/upstream-overlay.md`)                     |
+| mem0 + Qdrant                                                | Persistent memory with local vector search                                                                                             |
+| Tailscale                                                    | Optional VPN tunneling and automatic HTTPS                                                                                             |
+| supervisord                                                  | Process management inside the container                                                                                                |
 
 > **Developer tools.** The `forks/figma-mcp` submodule is a [Figma MCP server](https://github.com/nicekid1/Figma-Context-MCP) fork used for design-to-code workflows during development. It is not part of the runtime — it's a developer tool for extracting Figma context into code. Initialize it separately if needed: `git submodule update --init forks/figma-mcp`.
 
 **Container vs. data:** the published Docker image bundles Hermes agent and webui source (from `forks/` submodules) at **build** time. The container's `/data` volume holds your config, databases, logs, and Tailscale state. Updating Hermes for end users means pulling a newer image, not re-cloning at runtime.
 
-**Tech stack:** Electron 42 (desktop wrapper) · Python 3.11 (Hermes Agent + WebUI) · Qdrant (vector DB) · mem0 (memory layer) · supervisord (process management) · Tailscale (remote access) · Docker (packaging). Hermes WebUI is intentionally vanilla — Python `http.server` + plain JavaScript, no SPA framework — so the chat UI loads instantly on any device.
+**Tech stack:** Electron 43 (desktop wrapper) · Python 3.11 (Hermes Agent + WebUI) · Qdrant (vector DB) · mem0 (memory layer) · supervisord (process management) · Tailscale (remote access) · Docker (packaging). Hermes WebUI is intentionally vanilla — Python `http.server` + plain JavaScript, no SPA framework — so the chat UI loads instantly on any device.
 
 ---
 
@@ -303,6 +303,7 @@ The app itself is free and open source. You only pay for AI usage at your provid
 What we're working on next. No promises on dates — this is a small team — but this is the direction.
 
 **Recently shipped**
+
 - **Upstream bump** — hermes-webui v0.52.0, hermes-agent v2026.7.7.2 (v0.7.59)
 - **Security alert triage** — resolved 24 supply-chain alerts via npm overrides + Dockerfile upgrade (v0.7.55–v0.7.57)
 - **Apt repository** — `.deb` packages published to `apt.foxinthebox.ai` for headless Linux installs (v0.7.59)
@@ -313,12 +314,14 @@ What we're working on next. No promises on dates — this is a small team — bu
 - **Upstream separation** — Fox overlays cleanly separated from upstream Hermes codebase (v0.6.0)
 
 **v0.8.0 — ships when these criteria are met:**
+
 - Playwright E2E covers all critical user paths (provider setup, chat, model switching, failover)
 - Zero open P0 bugs
 - Container image passes clean Trivy scan
 - On-device smoke checklist fully green for two consecutive releases
 
 **Beyond v0.8.0**
+
 - Network isolation mode for enterprise — air-gapped Docker deployment
 - Routines — teach Fox multi-step workflows via conversation, runs on a schedule
 - Knowledge RAG — batch-ingest document collections for semantic retrieval

--- a/packages/electron/package-lock.json
+++ b/packages/electron/package-lock.json
@@ -14,7 +14,7 @@
         "electron-updater": "^6.8.9"
       },
       "devDependencies": {
-        "electron": "^42.5.1",
+        "electron": "^43.4.0",
         "electron-builder": "^26.15.3",
         "electron-builder-squirrel-windows": "26.15.3",
         "jest": "^30.0.0",
@@ -3758,9 +3758,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "42.8.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-42.8.0.tgz",
-      "integrity": "sha512-lgeUDjUuUzUSBchBudmjCZ8ApeYdVneMi17nLRMdfxGw7FyLFligsLtIF+dL3UoNnOsupAwdqVNJCK5MFE82kQ==",
+      "version": "43.4.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.4.0.tgz",
+      "integrity": "sha512-3qxGF0CeQbiox5oWV1JlbWGQ1VerbmDhTFqW4sJ8h7uqTHniFYPObXJcDna0DMh32et0fFyKzz0YY8lJv3t5jg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -23,7 +23,7 @@
     "electron-updater": "^6.8.9"
   },
   "devDependencies": {
-    "electron": "^42.5.1",
+    "electron": "^43.4.0",
     "electron-builder": "^26.15.3",
     "electron-builder-squirrel-windows": "26.15.3",
     "jest": "^30.0.0",
@@ -37,7 +37,9 @@
   },
   "jest": {
     "rootDir": "../..",
-    "testMatch": ["**/tests/electron/**/*.test.js"],
+    "testMatch": [
+      "**/tests/electron/**/*.test.js"
+    ],
     "moduleDirectories": [
       "<rootDir>/packages/electron/node_modules",
       "node_modules"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         version: 6.8.9
     devDependencies:
       electron:
-        specifier: ^42.5.1
-        version: 42.5.1
+        specifier: ^43.4.0
+        version: 43.4.0
       electron-builder:
         specifier: ^26.15.3
         version: 26.15.3(electron-builder-squirrel-windows@26.15.3(dmg-builder@26.15.3))
@@ -1109,8 +1109,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@42.5.1:
-    resolution: {integrity: sha512-2VFNJcHHbrhIpGsJHdkLoi/nWPZPxN3GHVPe+9At3Oz3/TJRwpr+7JL97ddBDbKyLmHGx3GfI2jvzcEQL28uFw==}
+  electron@43.4.0:
+    resolution: {integrity: sha512-3qxGF0CeQbiox5oWV1JlbWGQ1VerbmDhTFqW4sJ8h7uqTHniFYPObXJcDna0DMh32et0fFyKzz0YY8lJv3t5jg==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
@@ -3645,7 +3645,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@42.5.1:
+  electron@43.4.0:
     dependencies:
       '@electron-internal/extract-zip': 1.0.4
       '@electron/get': 5.0.0


### PR DESCRIPTION
## Summary
Lands the held Electron 43 major (supersedes dependabot #711/#712, which each covered one lockfile while overlapping on the same package.json — this branch bumps `packages/electron/package.json` `^42.5.1` → `^43.4.0` with **both** lockfiles refreshed together). Runtime: Chromium 150, Node 24.

## The desktop smoke that was holding this
Run on macOS arm64 against the **packaged** app (electron-builder 26.15.3, unsigned local build from this branch):

- Launched via Playwright's Electron driver with an isolated HOME; `process.versions.electron = 43.4.0` confirmed inside the packaged app
- Main window renders the startup orchestrator (branded header, checklist progressing, live diagnostics pane) — screenshot captured
- Zero page errors, zero console errors, zero fatal stderr across an 8 s dwell; clean quit
- Full startup unit suite: 138/138 pass on the clean tree

**Build-hygiene note from the smoke:** the first build silently used a stale physical `packages/electron/node_modules` tree from May (electron-builder 24.13.3 bundling Electron 28.3.3!) that shadowed the pnpm workspace. Local-only hazard — CI's fresh checkouts are immune — but worth knowing if anyone builds desktop artifacts locally: `rm -rf packages/electron/node_modules && pnpm install` first.

**Two pre-existing findings filed during the smoke (both version-independent):** #748 (unguarded EPIPE crash when stdout closes — electron-log console transport) and #749 (startup orchestrator auto-upgrades Docker Desktop via brew without confirmation).

**Windows caveat (documented, accepted at the original hold):** CI's electron-smoke runs the dev-mode startup suite on windows-latest with this PR's Electron; no packaged-exe install test exists (windows-real-smoke.yml is container-scoped, v1). The exe gets its real exercise at the next release's signed build.

## Versioning
No VERSION bump in this PR — the Electron runtime change ships to users with the next Fox release (same pattern as 42.4.1 → 42.8.0, which rode the v0.7.60 release). CHANGELOG \[Unreleased\] entry included.

## Test plan
- [x] Packaged-app launch smoke (above)
- [x] 138/138 startup tests on Electron 43.4.0
- [ ] CI green incl. electron-smoke macOS + Windows