### PR TITLE
chore(ci): acknowledged-dedupe for subject-specific tripwires

### DIFF
--- a/.github/scripts/tripwire-branch-watch.sh
+++ b/.github/scripts/tripwire-branch-watch.sh
@@ -66,7 +66,8 @@ EOF
         tripwire_fire \
             "[tripwire/branch] $repo has rewrite-regex branch: $branch" \
             "$body" \
-            "tripwire-fire,tripwire/branch,P1"
+            "tripwire-fire,tripwire/branch,P1" \
+            ack_dedupe
     done <<<"$matches"
 }
 

--- a/.github/scripts/tripwire-branch-watch.sh
+++ b/.github/scripts/tripwire-branch-watch.sh
@@ -2,8 +2,11 @@
 # Tripwire #209 — branch-creation watch.
 #
 # Lists upstream branches; fires on any branch name matching the rewrite-
-# regex. Stateless — dedupe is by branch name in the issue title, so once
-# fired for "react", the issue gets re-fired (comment) not re-created.
+# regex. Stateless — dedupe is by branch name in the issue title: an OPEN
+# same-title issue gets a re-fire comment; a CLOSED one is a standing
+# acknowledgement of that branch (ack_dedupe) and suppresses re-fire.
+# Accepted tradeoff: a dispositioned branch deleted and later re-created
+# under the same name will not alert again.
 
 set -eu
 source "$(dirname "$0")/tripwire-common.sh"

--- a/.github/scripts/tripwire-common.sh
+++ b/.github/scripts/tripwire-common.sh
@@ -30,12 +30,19 @@ tripwire_fire() {
     local labels="$3"
     local mode="${4:-}"
 
+    # Titles reach jq via the environment (env.TW_TITLE), never by
+    # splicing into the program text: branch-watch titles embed
+    # upstream-controlled branch names, and a crafted name containing
+    # jq-significant characters must not be able to break the filter —
+    # in the ack path that breakage would SUPPRESS a P1 fire.
+    export TW_TITLE="$title"
+
     if [ "$mode" = "ack_dedupe" ]; then
         local acked
-        acked=$(gh issue list --repo "$REPO" --state closed \
+        acked=$(gh issue list --repo "$REPO" --state closed --limit 100 \
                   --search "in:title \"$title\"" \
                   --json number,title \
-                  -q ".[] | select(.title == \"$title\") | .number" \
+                  -q '.[] | select(.title == env.TW_TITLE) | .number' \
                   2>/dev/null | head -1)
         if [ -n "$acked" ]; then
             echo "[tripwire] condition previously acknowledged in closed #$acked — skipping re-fire"
@@ -44,10 +51,10 @@ tripwire_fire() {
     fi
 
     local existing
-    existing=$(gh issue list --repo "$REPO" --state open \
+    existing=$(gh issue list --repo "$REPO" --state open --limit 100 \
                  --search "in:title \"$title\"" \
                  --json number,title \
-                 -q ".[] | select(.title == \"$title\") | .number" \
+                 -q '.[] | select(.title == env.TW_TITLE) | .number' \
                  2>/dev/null | head -1)
 
     if [ -n "$existing" ]; then
@@ -91,11 +98,12 @@ tripwire_clear() {
     local title="$1"
     local reason="$2"
 
+    export TW_TITLE="$title"
     local numbers
-    numbers=$(gh issue list --repo "$REPO" --state open \
+    numbers=$(gh issue list --repo "$REPO" --state open --limit 100 \
                  --search "in:title \"$title\"" \
                  --json number,title \
-                 -q ".[] | select(.title == \"$title\") | .number" \
+                 -q '.[] | select(.title == env.TW_TITLE) | .number' \
                  2>/dev/null)
 
     if [ -z "$numbers" ]; then

--- a/.github/scripts/tripwire-common.sh
+++ b/.github/scripts/tripwire-common.sh
@@ -11,14 +11,37 @@ RUN_URL="${GITHUB_SERVER_URL:-https://github.com}/${REPO}/actions/runs/${GITHUB_
 # Open or re-fire an issue. De-dupe by exact title match.
 #
 # Usage:
-#   tripwire_fire "<exact-title>" "<body markdown>" "<comma,sep,labels>"
+#   tripwire_fire "<exact-title>" "<body markdown>" "<comma,sep,labels>" [ack_dedupe]
 #
 # If an open issue with the same title exists, comment "Re-fired on
 # <RUN_URL>" + the new body on it. Otherwise create.
+#
+# Pass "ack_dedupe" as the 4th arg for tripwires whose titles name a
+# SPECIFIC subject (an upstream issue number, a branch name): a CLOSED
+# issue with the same title then counts as a human acknowledgement and
+# the fire is skipped instead of re-created (#747 re-fired nightly after
+# #723 was dispositioned). A different subject produces a different
+# title, so genuinely new conditions still fire. Do NOT use it for
+# recurring-condition tripwires with stable titles (absence, stage-batch)
+# — there a past closed issue must not suppress a future real fire.
 tripwire_fire() {
     local title="$1"
     local body="$2"
     local labels="$3"
+    local mode="${4:-}"
+
+    if [ "$mode" = "ack_dedupe" ]; then
+        local acked
+        acked=$(gh issue list --repo "$REPO" --state closed \
+                  --search "in:title \"$title\"" \
+                  --json number,title \
+                  -q ".[] | select(.title == \"$title\") | .number" \
+                  2>/dev/null | head -1)
+        if [ -n "$acked" ]; then
+            echo "[tripwire] condition previously acknowledged in closed #$acked — skipping re-fire"
+            return 0
+        fi
+    fi
 
     local existing
     existing=$(gh issue list --repo "$REPO" --state open \

--- a/.github/scripts/tripwire-cve-feed.sh
+++ b/.github/scripts/tripwire-cve-feed.sh
@@ -45,10 +45,14 @@ check_repo_advisories() {
 
 EOF
 )
+        # ack_dedupe: the GHSA id in the title is an immutable subject —
+        # a not-affected disposition (closing the issue) is permanent for
+        # that advisory; a new advisory has a new id and still fires.
         tripwire_fire \
             "[tripwire/cve] $repo — $ghsa_id ($severity)" \
             "$body" \
-            "tripwire-fire,tripwire/cve,security,P0"
+            "tripwire-fire,tripwire/cve,security,P0" \
+            ack_dedupe
     done
 }
 

--- a/.github/scripts/tripwire-issue-age.sh
+++ b/.github/scripts/tripwire-issue-age.sh
@@ -78,7 +78,7 @@ Issue accretion in young projects signals maintainer triage capacity is below in
 - [ ] Inspect $oldest_url — is it truly neglected or just a low-priority enhancement?
 - [ ] Skim the upstream's recent issue activity — is overall response time degrading?
 - [ ] If yes: re-evaluate dependence on this upstream in v0.7.x planning
-- [ ] If no (one-off neglected enhancement): close this issue; tripwire will re-fire if the new oldest issue also exceeds threshold
+- [ ] If no (one-off neglected enhancement): close this issue — closing acknowledges THIS oldest issue permanently; the tripwire fires again only when a different issue becomes the >threshold oldest
 
 EOF
 )
@@ -86,7 +86,8 @@ EOF
     tripwire_fire \
         "[tripwire/issue-age] $repo oldest open issue >${THRESHOLD_DAYS}d (#$oldest_num)" \
         "$body" \
-        "tripwire-fire,tripwire/issue-age,P2"
+        "tripwire-fire,tripwire/issue-age,P2" \
+        ack_dedupe
 }
 
 check_repo "$WEBUI_REPO"

--- a/.github/workflows/upstream-tripwires.yml
+++ b/.github/workflows/upstream-tripwires.yml
@@ -10,8 +10,11 @@
 # Each tripwire is its own job. All jobs are independent; one failing does
 # not skip the others. A job's "fire" condition opens (or reuses) one issue
 # with a stable title; subsequent fires bump the existing issue rather than
-# stack. Issue closes happen by human inspection after the upstream condition
-# clears.
+# stack. Recurring-condition tripwires re-fire after a close once the
+# condition recurs; subject-specific tripwires (issue-age, branch-watch,
+# cve-feed — the title names an issue number / branch / GHSA id) treat a
+# closed same-title issue as a standing human acknowledgement and stay
+# quiet for that subject (tripwire_fire ack_dedupe mode).
 #
 # Tripwires implemented:
 #   #207  upstream_commit_digest   — daily commits + keyword/file flagging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- Upstream-watch and tripwire detectors no longer spam the issue tracker: nightly watch reports dedupe by title and supersede older reports (previously up to one duplicate per night), the branch rewrite-regex requires whole path segments with frontend-framework tokens scoped to the webui repo, maintainer-absence recognizes both maintainer accounts, stage-batch keys on published releases instead of the retired Stamp-CHANGELOG commit pattern, and the patch rebase-clock floors ages at the last upstream-pin verification date
+- Upstream-watch and tripwire detectors no longer spam the issue tracker: nightly watch reports dedupe by title and supersede older reports (previously up to one duplicate per night), the branch rewrite-regex requires whole path segments with frontend-framework tokens scoped to the webui repo, maintainer-absence recognizes both maintainer accounts, stage-batch keys on published releases instead of the retired Stamp-CHANGELOG commit pattern, and the patch rebase-clock floors ages at the last upstream-pin verification date; closing a subject-specific fire (issue-age, branch-watch, CVE-feed — the title names an issue number, branch, or advisory id) now counts as a standing acknowledgement and suppresses nightly re-creation of the same subject
 
 ---
 


### PR DESCRIPTION
## Summary
Fixes the #747 recurrence class: closing a subject-specific tripwire fire (issue-age, branch-watch — titles carry the upstream issue number / branch name) now counts as a standing acknowledgement. `tripwire_fire` gains an opt-in `ack_dedupe` 4th arg: a **closed** issue with the identical title suppresses re-creation; a different subject produces a different title and still fires. Recurring-condition tripwires (absence, stage-batch, rebase-clock) deliberately keep the open-only dedupe — a past closed issue must not mask a future real fire.

Follow-up to #742 (which fixed the other five detector classes but not this one). #747 will be closed as acknowledged once this merges.

## Test plan
- [x] bash -n (bash 5) + shellcheck clean on all three scripts
- [x] Live semantics check: closed #723 exists with the exact #747 title → ack path would skip; a hypothetical (#999) title finds no closed match → fires
- [ ] CI green; next nightly produces no issue-age re-fire