### PR TITLE
chore(ci): main-push failure visibility + on-demand Trivy re-scan

### DIFF
--- a/.github/scripts/tripwire-common.sh
+++ b/.github/scripts/tripwire-common.sh
@@ -7,6 +7,11 @@ set -eu
 
 REPO="${GITHUB_REPOSITORY:-fox-in-the-box-ai/fox-in-the-box}"
 RUN_URL="${GITHUB_SERVER_URL:-https://github.com}/${REPO}/actions/runs/${GITHUB_RUN_ID:-local}"
+# Actions sets GITHUB_WORKFLOW to the calling workflow's name; issues and
+# labels created by the helpers cite it so callers outside
+# upstream-tripwires.yml (e.g. build-container.yml's main_push_health)
+# carry correct provenance.
+SOURCE_WORKFLOW="${GITHUB_WORKFLOW:-upstream-tripwires.yml}"
 
 # Open or re-fire an issue. De-dupe by exact title match.
 #
@@ -77,13 +82,13 @@ tripwire_fire() {
         # permissions issue (the issue creation will surface the error).
         gh label create "$l" --repo "$REPO" --force \
             --color "$(tripwire_label_color "$l")" \
-            --description "auto-created by upstream-tripwires.yml" >/dev/null 2>&1 || true
+            --description "auto-created by $SOURCE_WORKFLOW" >/dev/null 2>&1 || true
         label_args+=("--label" "$l")
     done
 
     gh issue create --repo "$REPO" \
         --title "$title" \
-        --body "$(printf '%s\n\n_Fired by upstream-tripwires.yml run %s_' "$body" "$RUN_URL")" \
+        --body "$(printf '%s\n\n_Fired by %s run %s_' "$body" "$SOURCE_WORKFLOW" "$RUN_URL")" \
         "${label_args[@]}"
 }
 
@@ -112,7 +117,7 @@ tripwire_clear() {
 
     echo "$numbers" | while read -r num; do
         gh issue comment "$num" --repo "$REPO" \
-            --body "$(printf 'Condition cleared: %s\n\n_Auto-closed by upstream-tripwires.yml run %s_' "$reason" "$RUN_URL")" \
+            --body "$(printf 'Condition cleared: %s\n\n_Auto-closed by %s run %s_' "$reason" "$SOURCE_WORKFLOW" "$RUN_URL")" \
             || echo "[tripwire] warning: failed to comment on #$num"
         gh issue close "$num" --repo "$REPO" --reason "completed" \
             || echo "[tripwire] warning: failed to close #$num"
@@ -125,6 +130,7 @@ tripwire_label_color() {
     case "$1" in
         tripwire-fire)         echo "d73a4a" ;;  # red
         tripwire-self-health)  echo "fbca04" ;;  # yellow
+        ci-health)             echo "b60205" ;;  # dark red — main-push pipeline failures
         tripwire/cve|security) echo "b60205" ;;  # dark red
         tripwire/license)      echo "5319e7" ;;  # purple
         tripwire/branch|tripwire/nous-ui) echo "d93f0b" ;;  # orange

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -686,3 +686,43 @@ jobs:
       - name: Stop container
         if: always()
         run: docker stop selftest-fox || true
+
+  # ── Main-push failure visibility ──────────────────────────────────────
+  # A failed run on a main push dies silently: no PR to go red, nobody
+  # watching. That silence cost real money once — the bump(upstream) #740
+  # merge-push failed at the arm64 checkout (GitHub 429), the merge job
+  # (and with it the Option B :stable auto-bump) never ran, and :stable
+  # sat on the previous image undetected for hours until a Trivy alert
+  # audit exposed stale package versions. This job opens (or re-fires)
+  # one issue whenever any job in a main-push run fails.
+  main_push_health:
+    name: main-push failure handler
+    needs: [build, merge, smoke, image-selftest]
+    if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          source .github/scripts/tripwire-common.sh
+          title="[main-push] build-container failed on main (rolling)"
+          body=$(cat <<BODY_EOF
+          ## A main-push build-container run failed
+
+          Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          Commit: \`${{ github.sha }}\` — $(git log -1 --format=%s "${{ github.sha }}" 2>/dev/null || echo "(subject unavailable)")
+
+          Consequences to check:
+          - **No fresh \`:latest\`** was tagged from this commit.
+          - If the commit subject starts with \`bump(upstream):\`, the **Option B \`:stable\` auto-bump did NOT run** — \`:stable\` is stale until this run is re-run to completion (\`gh run rerun <id> --failed\`).
+
+          ## Resolution
+          - Inspect the failing job; transient infra (429 / mirror hang) → \`gh run rerun --failed\` and confirm the merge job completes.
+          - Close this issue once a run for this or a newer main commit is fully green.
+          BODY_EOF
+          )
+          tripwire_fire "$title" "$body" "ci-health,P1"

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -698,14 +698,15 @@ jobs:
   main_push_health:
     name: main-push failure handler
     needs: [build, merge, smoke, image-selftest]
-    if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(needs.*.result, 'failure')
+    if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
       issues: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - env:
+      - name: Open or re-fire the rolling ci-health issue
+        env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           source .github/scripts/tripwire-common.sh

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -7,6 +7,10 @@ on:
     branches: [main]
   schedule:
     - cron: '0 5 * * 1'
+  # On-demand re-scan — e.g. right after :stable advances, so the
+  # code-scanning alert set reflects the new image without waiting for
+  # the next push or the Monday cron.
+  workflow_dispatch: {}
 
 concurrency:
   group: trivy-${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Failed CI runs on main pushes are no longer silent: build-container opens a rolling `ci-health` issue naming the run, the commit, and the `:latest`/`:stable` consequences (a failed merge-push once skipped the Option B `:stable` advance undetected for hours); the container vulnerability scan can also be re-run on demand now
 - Upstream-watch and tripwire detectors no longer spam the issue tracker: nightly watch reports dedupe by title and supersede older reports (previously up to one duplicate per night), the branch rewrite-regex requires whole path segments with frontend-framework tokens scoped to the webui repo, maintainer-absence recognizes both maintainer accounts, stage-batch keys on published releases instead of the retired Stamp-CHANGELOG commit pattern, and the patch rebase-clock floors ages at the last upstream-pin verification date; closing a subject-specific fire (issue-age, branch-watch, CVE-feed — the title names an issue number, branch, or advisory id) now counts as a standing acknowledgement and suppresses nightly re-creation of the same subject
 
 ---


### PR DESCRIPTION
## Summary
Closes the observability gap behind tonight's silent `:stable` miss: #740's merge-push run failed at the arm64 submodule checkout (GitHub 429), the merge job never ran, and the Option B `:stable` auto-bump was skipped with nothing watching — discovered only via a Trivy alert audit hours later.

- **build-container.yml**: new `main_push_health` job — on any main-push run with a failed job, opens/re-fires one rolling `ci-health` issue (reuses `tripwire_fire` dedupe) that names the run, the commit, the `:latest`/`:stable` consequences, and the `gh run rerun --failed` playbook.
- **trivy.yml**: `workflow_dispatch` trigger so the code-scanning alert set can be refreshed immediately after `:stable` advances (484 open alerts currently describe the pre-#740 image).

## Test plan
- [x] YAML parses; handler condition is push+main+any-failure only (PR runs untouched)
- [x] tripwire_fire dedupe verified live earlier tonight (same helper, same call shape)
- [ ] CI green