### PR TITLE
chore(image): apply Debian security upgrades in the base layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Security
 
+- Container base layer now applies Debian security upgrades at build time (`apt-get upgrade -y`) — packages frozen at the python:3.11-slim snapshot no longer ship known-fixed CVEs; clears the fixable portion of the container-scan backlog (#755)
 - js-yaml resolved to 4.3.1 in both lockfiles (root pnpm-lock.yaml and packages/electron/package-lock.json), clearing all four open js-yaml advisories. Corrects the 0.7.60 record: that entry listed js-yaml 4.3.1 in its security batch, but the lockfiles still resolved 4.2.0 at release time — this change is what lands it.
 - protobufjs resolved to 7.6.5 in both lockfiles, clearing the last two open dependabot alerts; with the js-yaml 4.3.1 bump this takes the open alert count to zero
 

--- a/docs/SECURITY_POSTURE.md
+++ b/docs/SECURITY_POSTURE.md
@@ -1,12 +1,16 @@
 # Fox in the Box — Security Posture
 
-Last updated: v0.7.59 (2026-07-10)
+Last updated: v0.7.60 + post-release pins (2026-08-18)
 
 ## Threat model
 
 Fox in the Box is a **single-tenant, self-hosted** AI assistant. The user IS the operator. There is no multi-tenant isolation boundary, no untrusted input processing from external users, and no data leaving the user's machine unless they explicitly configure a remote model provider.
 
 The container runs on the user's infrastructure (local Docker, cloud VM, or fleet-managed host). The network attack surface is the HTTP port (8787) which should be behind TLS termination (Caddy, nginx, or fleet proxy) in any non-local deployment.
+
+### Long-term memory subsystem (default-on since v0.7.60)
+
+Conversation-derived facts are stored **locally** under the instance data volume: self-hosted mem0 (mem0ai 2.0.10) with an embedded Qdrant store. Embeddings are computed **on-device** by a llama.cpp embed-server (nomic-embed-text-v1.5 GGUF) bound to `127.0.0.1:8644` — never exposed outside the container. The only egress the feature adds is fact-extraction calls to the chat provider the user already configured. mem0's PostHog telemetry is force-disabled (`MEM0_TELEMETRY=False` at every process boundary — the posthog package is present but inert; verified zero egress in the v0.7.60 release smoke). Memory state is fail-loud (`READY`/`OFF`/`ERROR` in Settings and `/readyz`) — no silent degradation. The image also bakes `openssh-client` and `rsync` (v0.7.60) for agent remote-host workflows; both are standard Debian packages covered by Trivy scanning.
 
 ### Cloud provider credentials
 
@@ -20,24 +24,33 @@ On AWS VMs, the instance metadata service (IMDS) makes the machine's default ins
 - **Trivy** — scans the container image on every PR and release via GitHub code scanning (SARIF upload). Covers OS packages, language packages, and binary dependencies.
 - **CodeQL** — static analysis for JavaScript/TypeScript and Python on every PR.
 
-### Accepted risks
+### Current state
 
-The following alert categories have been triaged and accepted based on Fox's threat model. Each is documented with reasoning in the internal triage record.
+**Open Dependabot alerts: 0** (as of 2026-08-18 — js-yaml 4.3.1 and protobufjs 7.6.5 cleared the last npm alerts). The long-tracked **GHSA-537c-gmf6-5ccf accepted risk is CLOSED**: upstream hermes-agent previously hard-pinned `cryptography` below the 48.0.1 fix; since the v0.52.113 / v2026.8.16.2 pin bump, `requirements.lock` carries `cryptography==50.0.0`.
 
-**Ancient/disputed CVEs in system libraries (21 alerts, CVEs from 2005–2019):**
+`packages/integration/requirements.lock` is itself a supply-chain control: 94 exact pins for every Python package in the container, consumed as a pip **constraints** file (`-c`) at build time so transitive resolution cannot drift silently between builds; CI fails on freeze drift.
+
+### Triage policy for container-scan (Trivy) alert categories
+
+The following categories recur in container scans and are triaged against Fox's threat model; the reasoning applies to future alerts of the same class, not to a fixed count of open ones.
+
+**Ancient/disputed CVEs in system libraries (CVEs from 2005–2019):**
 These are long-standing CVEs in Debian system packages (glibc, tar, perl, iptables, coreutils, ldap, kerberos, systemd, git, libgcrypt) that have been open across the entire Debian ecosystem for years. None have practical exploit paths in Fox's single-tenant threat model:
 
 - Fox doesn't use LDAP, Kerberos, or Perl
 - Fox doesn't process untrusted tar archives or user-supplied regex patterns
 - Container isolation + TLS termination mitigate the remaining vectors
 
-**Debian system packages with no fix available (~336 alerts):**
-When CVEs are reported against these packages before Debian releases a fix, the alerts appear and remain open until Debian ships the patch. These auto-close on the next container rebuild after the Debian fix lands.
+**Debian system packages with no fix available:** (the base layer applies
+`apt-get upgrade -y` at build time, so every fix Debian *has* shipped enters
+the image on the next build — this class is only the remainder with no fix
+published)
+The container base image (`python:3.11-slim`, Debian trixie) includes system packages at their latest Debian patch level. When CVEs are reported against these packages before Debian releases a fix, the alerts appear and remain open until Debian ships the patch. These auto-close on the next container rebuild after the Debian fix lands.
 
-**System npm bundled dependencies (~7 alerts):**
+**System npm bundled dependencies:**
 Node.js LTS bundles npm, which bundles its own transitive dependencies (undici, tar, etc.). These can't be independently overridden — they close when the next Node.js LTS release includes a newer npm.
 
-**Tailscale binary Go stdlib (~7 alerts):**
+**Tailscale binary Go stdlib:**
 Tailscale is installed from the official Debian stable repository. Go stdlib CVEs in the compiled binary close when Tailscale releases a version compiled with a patched Go runtime.
 
 ## Dependency override policy

--- a/docs/SECURITY_POSTURE.md
+++ b/docs/SECURITY_POSTURE.md
@@ -1,16 +1,12 @@
 # Fox in the Box — Security Posture
 
-Last updated: v0.7.60 + post-release pins (2026-08-18)
+Last updated: v0.7.59 (2026-07-10)
 
 ## Threat model
 
 Fox in the Box is a **single-tenant, self-hosted** AI assistant. The user IS the operator. There is no multi-tenant isolation boundary, no untrusted input processing from external users, and no data leaving the user's machine unless they explicitly configure a remote model provider.
 
 The container runs on the user's infrastructure (local Docker, cloud VM, or fleet-managed host). The network attack surface is the HTTP port (8787) which should be behind TLS termination (Caddy, nginx, or fleet proxy) in any non-local deployment.
-
-### Long-term memory subsystem (default-on since v0.7.60)
-
-Conversation-derived facts are stored **locally** under the instance data volume: self-hosted mem0 (mem0ai 2.0.10) with an embedded Qdrant store. Embeddings are computed **on-device** by a llama.cpp embed-server (nomic-embed-text-v1.5 GGUF) bound to `127.0.0.1:8644` — never exposed outside the container. The only egress the feature adds is fact-extraction calls to the chat provider the user already configured. mem0's PostHog telemetry is force-disabled (`MEM0_TELEMETRY=False` at every process boundary — the posthog package is present but inert; verified zero egress in the v0.7.60 release smoke). Memory state is fail-loud (`READY`/`OFF`/`ERROR` in Settings and `/readyz`) — no silent degradation. The image also bakes `openssh-client` and `rsync` (v0.7.60) for agent remote-host workflows; both are standard Debian packages covered by Trivy scanning.
 
 ### Cloud provider credentials
 
@@ -24,30 +20,24 @@ On AWS VMs, the instance metadata service (IMDS) makes the machine's default ins
 - **Trivy** — scans the container image on every PR and release via GitHub code scanning (SARIF upload). Covers OS packages, language packages, and binary dependencies.
 - **CodeQL** — static analysis for JavaScript/TypeScript and Python on every PR.
 
-### Current state
+### Accepted risks
 
-**Open Dependabot alerts: 0** (as of 2026-08-18 — js-yaml 4.3.1 and protobufjs 7.6.5 cleared the last npm alerts). The long-tracked **GHSA-537c-gmf6-5ccf accepted risk is CLOSED**: upstream hermes-agent previously hard-pinned `cryptography` below the 48.0.1 fix; since the v0.52.113 / v2026.8.16.2 pin bump, `requirements.lock` carries `cryptography==50.0.0`.
+The following alert categories have been triaged and accepted based on Fox's threat model. Each is documented with reasoning in the internal triage record.
 
-`packages/integration/requirements.lock` is itself a supply-chain control: 94 exact pins for every Python package in the container, consumed as a pip **constraints** file (`-c`) at build time so transitive resolution cannot drift silently between builds; CI fails on freeze drift.
-
-### Triage policy for container-scan (Trivy) alert categories
-
-The following categories recur in container scans and are triaged against Fox's threat model; the reasoning applies to future alerts of the same class, not to a fixed count of open ones.
-
-**Ancient/disputed CVEs in system libraries (CVEs from 2005–2019):**
+**Ancient/disputed CVEs in system libraries (21 alerts, CVEs from 2005–2019):**
 These are long-standing CVEs in Debian system packages (glibc, tar, perl, iptables, coreutils, ldap, kerberos, systemd, git, libgcrypt) that have been open across the entire Debian ecosystem for years. None have practical exploit paths in Fox's single-tenant threat model:
 
 - Fox doesn't use LDAP, Kerberos, or Perl
 - Fox doesn't process untrusted tar archives or user-supplied regex patterns
 - Container isolation + TLS termination mitigate the remaining vectors
 
-**Debian system packages with no fix available:**
-The container base image (`python:3.11-slim`, Debian trixie) includes system packages at their latest Debian patch level. When CVEs are reported against these packages before Debian releases a fix, the alerts appear and remain open until Debian ships the patch. These auto-close on the next container rebuild after the Debian fix lands.
+**Debian system packages with no fix available (~336 alerts):**
+When CVEs are reported against these packages before Debian releases a fix, the alerts appear and remain open until Debian ships the patch. These auto-close on the next container rebuild after the Debian fix lands.
 
-**System npm bundled dependencies:**
+**System npm bundled dependencies (~7 alerts):**
 Node.js LTS bundles npm, which bundles its own transitive dependencies (undici, tar, etc.). These can't be independently overridden — they close when the next Node.js LTS release includes a newer npm.
 
-**Tailscale binary Go stdlib:**
+**Tailscale binary Go stdlib (~7 alerts):**
 Tailscale is installed from the official Debian stable repository. Go stdlib CVEs in the compiled binary close when Tailscale releases a version compiled with a patched Go runtime.
 
 ## Dependency override policy

--- a/packages/integration/Dockerfile
+++ b/packages/integration/Dockerfile
@@ -42,7 +42,12 @@ ARG FITB_DEV=0
 # for the vps-patch-sync flow. Baking BOTH keeps the entrypoint tool-heal
 # a true no-op on fresh images (~15-20 MB installed with the krb5/gnutls
 # dependency train — shared in part with git).
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# `upgrade -y` first: the python:3.11-slim base is a point-in-time
+# snapshot, and without it Debian security fixes published after that
+# snapshot never reach the image — this was most of the fixable Trivy
+# backlog (#755). Tailscale and Node track their own apt repos below, so
+# each rebuild already pulls their current versions.
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
         curl \
         ca-certificates \
         gnupg \

--- a/packages/integration/Dockerfile
+++ b/packages/integration/Dockerfile
@@ -42,6 +42,7 @@ ARG FITB_DEV=0
 # for the vps-patch-sync flow. Baking BOTH keeps the entrypoint tool-heal
 # a true no-op on fresh images (~15-20 MB installed with the krb5/gnutls
 # dependency train — shared in part with git).
+#
 # `upgrade -y` first: the python:3.11-slim base is a point-in-time
 # snapshot, and without it Debian security fixes published after that
 # snapshot never reach the image — this was most of the fixable Trivy


### PR DESCRIPTION
## Summary
First slice of #755: adds `apt-get upgrade -y` to the container's base apt layer. The python:3.11-slim base is a point-in-time snapshot — without the upgrade, Debian security fixes published after that snapshot never enter the image. 76 of the 515 open Trivy alerts have fixes available in Debian and clear on the next scan of an image built with this change. Tailscale and Node already install from their own apt repos (no pins), so each rebuild refreshes them for free — the tailscaled/npm-bundled alert classes shrink whenever those upstreams ship.

Not covered here (still #755): the setuptools/msgpack Python stragglers, and the no-fix-available Debian/perl classes that ride under the SECURITY_POSTURE triage policy.

## Test plan
- [x] Dockerfile parses; change is a single flag in the existing RUN
- [ ] CI image build green (Build & Push both arches + Smoke + Image self-test exercise the upgraded base)
- [ ] Post-merge: `gh workflow run trivy.yml` after the next :stable advance and re-count against the #755 table