### PR TITLE
fix(desktop): stdio EPIPE guard + no Homebrew on existing Docker installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Desktop (macOS): guided setup no longer touches Homebrew when Docker Desktop is already installed — a present-but-stopped Docker is started, not (re)installed, so an existing install can never be upgraded (and its containers restarted) without consent; Homebrew runs only when Docker Desktop is absent (#749)
+- Desktop: launching the packaged app from a terminal whose pipe later closes no longer crashes with an EPIPE uncaught-exception dialog — stdout/stderr stream errors are guarded before the first log write; file logging is unaffected (#748)
 - Failed CI runs on main pushes are no longer silent: build-container opens a rolling `ci-health` issue naming the run, the commit, and the `:latest`/`:stable` consequences (a failed merge-push once skipped the Option B `:stable` advance undetected for hours); the container vulnerability scan can also be re-run on demand now
 - Upstream-watch and tripwire detectors no longer spam the issue tracker: nightly watch reports dedupe by title and supersede older reports (previously up to one duplicate per night), the branch rewrite-regex requires whole path segments with frontend-framework tokens scoped to the webui repo, maintainer-absence recognizes both maintainer accounts, stage-batch keys on published releases instead of the retired Stamp-CHANGELOG commit pattern, and the patch rebase-clock floors ages at the last upstream-pin verification date; closing a subject-specific fire (issue-age, branch-watch, CVE-feed — the title names an issue number, branch, or advisory id) now counts as a standing acknowledgement and suppresses nightly re-creation of the same subject
 

--- a/docs/desktop-windows.md
+++ b/docs/desktop-windows.md
@@ -49,10 +49,11 @@ container is healthy; first-run setup is the native hermes-webui flow. The
 former Fox custom setup wizard and its `/setup` route were removed in favor
 of the native flow.
 
-## Known desktop issues
+## Resolved desktop issues (fixed on main, ship with the next release)
 
 - **#748** — launching the packaged app from a terminal whose stdout closes
-  produces an `EPIPE` uncaught-exception dialog (electron-log console
-  transport). Finder/Start-menu launches are unaffected.
-- **#749** — on macOS, guided setup may run `brew upgrade` on an existing
-  Docker Desktop install without asking (design decision pending).
+  no longer crashes with an `EPIPE` dialog; stream errors are guarded before
+  the first log write.
+- **#749** — guided setup on macOS never touches Homebrew when Docker
+  Desktop is already installed: a present-but-stopped Docker is started,
+  not (re)installed or upgraded.

--- a/packages/electron/src/main.js
+++ b/packages/electron/src/main.js
@@ -1,33 +1,54 @@
-'use strict';
+"use strict";
 
-const { app, BrowserWindow, dialog, shell, clipboard, ipcMain, globalShortcut } = require('electron');
-const { spawn, exec } = require('child_process');
-const path = require('path');
-const fs = require('fs');
-const os = require('os');
-const log = require('electron-log');
-const docker = require('./docker-manager');
-const { waitUntilHealthy } = require('./health-check');
-const { createTray, setRunning } = require('./tray-manager');
-const updater = require('./updater');
-const updateWindow = require('./update-window');
+// Must run before anything can write to the console (#748): a closed
+// stdout pipe otherwise crashes the app on the first log line.
+const { installStdioGuard } = require("./stdio-guard");
+installStdioGuard();
+
+const {
+  app,
+  BrowserWindow,
+  dialog,
+  shell,
+  clipboard,
+  ipcMain,
+  globalShortcut,
+} = require("electron");
+const { spawn, exec } = require("child_process");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const log = require("electron-log");
+const docker = require("./docker-manager");
+const { waitUntilHealthy } = require("./health-check");
+const { createTray, setRunning } = require("./tray-manager");
+const updater = require("./updater");
+const updateWindow = require("./update-window");
 const {
   waitForDaemon: _waitForDaemon,
   ensureDockerWindows: _ensureDockerWindows,
   runCommandVerbose: _runCommandVerbose,
-} = require('./startup');
-const { runStartup, ensureContainerHealthy, StartupPhaseError } = require('./startup-orchestrator');
-const { registerWindowsRunOnceResume } = require('./windows-run-once');
-const { APP_HOME_URL } = require('./app-urls');
-const diagnosticReport = require('./diagnostic-report');
-const APP_ICON = process.platform === 'win32'
-  ? path.join(__dirname, '..', 'assets', 'icon.ico')
-  : path.join(__dirname, '..', 'assets', 'icon.png');
+} = require("./startup");
+const {
+  runStartup,
+  ensureContainerHealthy,
+  StartupPhaseError,
+} = require("./startup-orchestrator");
+const { registerWindowsRunOnceResume } = require("./windows-run-once");
+const { APP_HOME_URL } = require("./app-urls");
+const diagnosticReport = require("./diagnostic-report");
+const APP_ICON =
+  process.platform === "win32"
+    ? path.join(__dirname, "..", "assets", "icon.ico")
+    : path.join(__dirname, "..", "assets", "icon.png");
 let _fatalStartup = false;
 let _setupInProgress = false;
 
-const resumeAfterReboot = process.platform === 'win32'
-  && process.argv.some((arg) => arg === '--resume-setup' || arg === '--resume-setup=true');
+const resumeAfterReboot =
+  process.platform === "win32" &&
+  process.argv.some(
+    (arg) => arg === "--resume-setup" || arg === "--resume-setup=true",
+  );
 
 // Prevent multiple instances
 if (!app.requestSingleInstanceLock()) {
@@ -36,7 +57,7 @@ if (!app.requestSingleInstanceLock()) {
 }
 
 // Keep app alive when all windows are closed (tray-only)
-app.on('window-all-closed', (e) => {
+app.on("window-all-closed", (e) => {
   if (_fatalStartup) return;
   e.preventDefault();
 });
@@ -49,24 +70,34 @@ app.on('window-all-closed', (e) => {
 // locks), we log and continue — Electron will create a fresh `fox-in-the-box`
 // dir and the user can manually salvage `@fox-in-the-box` via Tray → Reset.
 function migrateLegacyUserData() {
-  const newPath = app.getPath('userData');  // resolves to .../fox-in-the-box
+  const newPath = app.getPath("userData"); // resolves to .../fox-in-the-box
   let legacyPath;
   switch (process.platform) {
-    case 'win32':
-      legacyPath = path.join(os.homedir(), 'AppData', 'Roaming', '@fox-in-the-box');
+    case "win32":
+      legacyPath = path.join(
+        os.homedir(),
+        "AppData",
+        "Roaming",
+        "@fox-in-the-box",
+      );
       break;
-    case 'darwin':
-      legacyPath = path.join(os.homedir(), 'Library', 'Application Support', '@fox-in-the-box');
+    case "darwin":
+      legacyPath = path.join(
+        os.homedir(),
+        "Library",
+        "Application Support",
+        "@fox-in-the-box",
+      );
       break;
     default:
-      legacyPath = path.join(os.homedir(), '.config', '@fox-in-the-box');
+      legacyPath = path.join(os.homedir(), ".config", "@fox-in-the-box");
       break;
   }
   if (!fs.existsSync(legacyPath)) return;
   if (fs.existsSync(newPath)) {
     log.info(
       `[migration] Both legacy (${legacyPath}) and new (${newPath}) userData dirs exist — ` +
-      `keeping new, leaving legacy alone for manual review.`,
+        `keeping new, leaving legacy alone for manual review.`,
     );
     return;
   }
@@ -76,7 +107,7 @@ function migrateLegacyUserData() {
   } catch (err) {
     log.warn(
       `[migration] Failed to rename legacy userData (${legacyPath} -> ${newPath}): ` +
-      `${err.message}. Manual cleanup may be needed via Tray → Reset Fox completely…`,
+        `${err.message}. Manual cleanup may be needed via Tray → Reset Fox completely…`,
     );
   }
 }
@@ -84,8 +115,10 @@ function migrateLegacyUserData() {
 migrateLegacyUserData();
 
 app.whenReady().then(main).catch(handleStartupError);
-app.on('will-quit', () => { globalShortcut.unregisterAll(); });
-app.setAppUserModelId('io.foxinthebox.desktop');
+app.on("will-quit", () => {
+  globalShortcut.unregisterAll();
+});
+app.setAppUserModelId("io.foxinthebox.desktop");
 // v0.7.19: `app.setName('Fox in the box')` removed — `productName: fox-in-the-box`
 // in package.json now drives the userData path, which is what we want
 // (drops the `@` prefix that came from the npm scope `@fox-in-the-box/electron`).
@@ -93,16 +126,16 @@ app.setAppUserModelId('io.foxinthebox.desktop');
 // ─── Progress window ─────────────────────────────────────────────────────────
 
 let _progressWin = null;
-let _progressState = { title: '', detail: '' };
+let _progressState = { title: "", detail: "" };
 
 const INSTALL_STEPS = [
-  { label: 'Checking system',        match: 'Check system' },
-  { label: 'Installing Docker',      match: 'Install Docker' },
-  { label: 'Starting Docker',        match: 'Start Docker' },
-  { label: 'Downloading Fox image',  match: 'Download image' },
-  { label: 'Starting container',     match: 'Start container' },
-  { label: 'Waiting for services',   match: 'Wait for services' },
-  { label: 'Connecting to network',  match: 'Connect network' },
+  { label: "Checking system", match: "Check system" },
+  { label: "Installing Docker", match: "Install Docker" },
+  { label: "Starting Docker", match: "Start Docker" },
+  { label: "Downloading Fox image", match: "Download image" },
+  { label: "Starting container", match: "Start container" },
+  { label: "Waiting for services", match: "Wait for services" },
+  { label: "Connecting to network", match: "Connect network" },
 ];
 
 function _activeStepIndex(title) {
@@ -110,41 +143,65 @@ function _activeStepIndex(title) {
   for (let i = INSTALL_STEPS.length - 1; i >= 0; i--) {
     if (title.includes(INSTALL_STEPS[i].match)) return i;
   }
-  if (title.includes('Installing') || title.includes('install')) return 1;
-  if (title.includes('Starting Docker') || title.includes('Launching Docker') || title.includes('daemon')) return 2;
-  if (title.includes('image') || title.includes('pull') || title.includes('Pull')) return 3;
-  if (title.includes('container') || title.includes('Container')) return 4;
-  if (title.includes('health') || title.includes('ready') || title.includes('healthy')) return 5;
-  if (title.includes('Tailscale') || title.includes('network') || title.includes('Opening')) return 6;
+  if (title.includes("Installing") || title.includes("install")) return 1;
+  if (
+    title.includes("Starting Docker") ||
+    title.includes("Launching Docker") ||
+    title.includes("daemon")
+  )
+    return 2;
+  if (
+    title.includes("image") ||
+    title.includes("pull") ||
+    title.includes("Pull")
+  )
+    return 3;
+  if (title.includes("container") || title.includes("Container")) return 4;
+  if (
+    title.includes("health") ||
+    title.includes("ready") ||
+    title.includes("healthy")
+  )
+    return 5;
+  if (
+    title.includes("Tailscale") ||
+    title.includes("network") ||
+    title.includes("Opening")
+  )
+    return 6;
   return 0;
 }
 
 function progressDiagnosticsLine(title, explicitDetail) {
-  if (typeof explicitDetail === 'string' && explicitDetail.trim().length > 0) {
+  if (typeof explicitDetail === "string" && explicitDetail.trim().length > 0) {
     return explicitDetail.trim();
   }
-  const m = String(title || '').match(/^Step \d+\/\d+ - [^:]+: (.+)$/);
-  return m ? m[1].trim() : String(title || '').trim();
+  const m = String(title || "").match(/^Step \d+\/\d+ - [^:]+: (.+)$/);
+  return m ? m[1].trim() : String(title || "").trim();
 }
 
 function showProgress(message) {
-  const update = (typeof message === 'object' && message !== null)
-    ? message
-    : { title: String(message || '') };
-  if (typeof update.title === 'string' && update.title.trim().length > 0) {
+  const update =
+    typeof message === "object" && message !== null
+      ? message
+      : { title: String(message || "") };
+  if (typeof update.title === "string" && update.title.trim().length > 0) {
     _progressState.title = update.title;
   }
-  if (typeof update.detail === 'string') {
+  if (typeof update.detail === "string") {
     _progressState.detail = update.detail;
   }
 
   const idx = _activeStepIndex(_progressState.title);
 
   if (_progressWin) {
-    _progressWin.webContents.send('progress:step', idx);
-    const logLine = progressDiagnosticsLine(_progressState.title, update.detail);
+    _progressWin.webContents.send("progress:step", idx);
+    const logLine = progressDiagnosticsLine(
+      _progressState.title,
+      update.detail,
+    );
     if (logLine) {
-      _progressWin.webContents.send('progress:log', logLine);
+      _progressWin.webContents.send("progress:log", logLine);
     }
     return;
   }
@@ -158,61 +215,64 @@ function showProgress(message) {
     closable: true,
     alwaysOnTop: true,
     frame: true,
-    title: 'Fox in the Box — Setting up',
+    title: "Fox in the Box — Setting up",
     icon: APP_ICON,
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,
-      preload: path.join(__dirname, 'preload-progress.js'),
+      preload: path.join(__dirname, "preload-progress.js"),
     },
   });
 
-  _progressWin.on('closed', async () => {
+  _progressWin.on("closed", async () => {
     _progressWin = null;
     if (_setupInProgress && !_fatalStartup) {
-      log.info('[startup] Setup progress window closed during installation');
+      log.info("[startup] Setup progress window closed during installation");
       const parent = getDialogParent();
       const { response } = await dialog.showMessageBox(parent, {
-        type: 'warning',
-        title: 'Quit setup?',
-        message: 'Fox in the box setup is still in progress.',
+        type: "warning",
+        title: "Quit setup?",
+        message: "Fox in the box setup is still in progress.",
         detail:
-          'Docker may still be starting in the background. If you quit now, reopen Fox from the Start menu to continue.',
-        buttons: ['Quit setup', 'Keep waiting'],
+          "Docker may still be starting in the background. If you quit now, reopen Fox from the Start menu to continue.",
+        buttons: ["Quit setup", "Keep waiting"],
         defaultId: 1,
         cancelId: 1,
       });
       if (response !== 0) {
-        showProgress(_progressState.title || 'Setting up…');
+        showProgress(_progressState.title || "Setting up…");
         return;
       }
     }
     app.quit();
   });
 
-  _progressWin.loadFile(path.join(__dirname, '..', 'assets', 'progress.html'));
+  _progressWin.loadFile(path.join(__dirname, "..", "assets", "progress.html"));
   _progressWin.setMenu(null);
 
   // Send current state once the page is ready. Use _progressState at fire time,
   // not the idx captured at window-creation time (startup may have advanced).
-  _progressWin.webContents.once('did-finish-load', () => {
+  _progressWin.webContents.once("did-finish-load", () => {
     if (!_progressWin || _progressWin.isDestroyed()) return;
     const currentIdx = _activeStepIndex(_progressState.title);
-    _progressWin.webContents.send('progress:step', currentIdx);
-    const logLine = progressDiagnosticsLine(_progressState.title, _progressState.detail);
+    _progressWin.webContents.send("progress:step", currentIdx);
+    const logLine = progressDiagnosticsLine(
+      _progressState.title,
+      _progressState.detail,
+    );
     if (logLine) {
-      _progressWin.webContents.send('progress:log', logLine);
+      _progressWin.webContents.send("progress:log", logLine);
     }
   });
 }
 
 function closeProgress() {
   if (_progressWin) {
-    _progressWin.removeAllListeners('closed');
+    _progressWin.removeAllListeners("closed");
     _progressWin.destroy();
     _progressWin = null;
   }
-  _progressState = { title: '', detail: '' };
+  _progressState = { title: "", detail: "" };
 }
 
 // v0.7.16 #324: when external installers (Docker Desktop, winget, UAC) are
@@ -225,7 +285,7 @@ function setForegroundYield(shouldYield) {
   try {
     _progressWin.setAlwaysOnTop(!shouldYield);
   } catch (err) {
-    log.debug('setForegroundYield failed:', err.message);
+    log.debug("setForegroundYield failed:", err.message);
   }
 }
 
@@ -242,42 +302,48 @@ function buildDiagnosticsText({
   diagnostics,
 }) {
   return [
-    `Session ID: ${sessionId || 'n/a'}`,
-    `Phase: ${phase || 'unknown'}`,
-    `Error code: ${code || 'UNSPECIFIED'}`,
-    `Message: ${message || 'Unknown error'}`,
+    `Session ID: ${sessionId || "n/a"}`,
+    `Phase: ${phase || "unknown"}`,
+    `Error code: ${code || "UNSPECIFIED"}`,
+    `Message: ${message || "Unknown error"}`,
     `Remediation: ${remediation}`,
-    `Log path: ${path.join(app.getPath('logs'), 'main.log')}`,
-    '',
-    'Docker diagnostics:',
+    `Log path: ${path.join(app.getPath("logs"), "main.log")}`,
+    "",
+    "Docker diagnostics:",
     JSON.stringify(diagnostics || {}, null, 2),
-  ].join('\n');
+  ].join("\n");
 }
 
 // Error data stored here so the preload's ipcMain.handle can return it synchronously.
 let _errorData = null;
 
 function showError(details) {
-  if (typeof details === 'string') {
+  if (typeof details === "string") {
     details = {
       message: details,
-      remediation: 'Install Docker Desktop manually and relaunch Fox in the box.',
+      remediation:
+        "Install Docker Desktop manually and relaunch Fox in the box.",
       diagnosticsText: details,
     };
   }
   const {
-    sessionId = 'n/a',
-    phase = 'unknown',
-    code = 'UNSPECIFIED',
-    message = 'Unknown startup error',
-    remediation = 'Check diagnostics and retry.',
-    diagnosticsText = '',
+    sessionId = "n/a",
+    phase = "unknown",
+    code = "UNSPECIFIED",
+    message = "Unknown startup error",
+    remediation = "Check diagnostics and retry.",
+    diagnosticsText = "",
   } = details;
   closeProgress();
 
   _errorData = {
-    sessionId, phase, code, message, remediation, diagnosticsText,
-    logPath: path.join(app.getPath('logs'), 'main.log'),
+    sessionId,
+    phase,
+    code,
+    message,
+    remediation,
+    diagnosticsText,
+    logPath: path.join(app.getPath("logs"), "main.log"),
   };
 
   const win = new BrowserWindow({
@@ -289,32 +355,32 @@ function showError(details) {
     closable: true,
     alwaysOnTop: true,
     frame: true,
-    title: 'Fox in the Box — Error',
+    title: "Fox in the Box — Error",
     icon: APP_ICON,
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,
-      preload: path.join(__dirname, 'preload-error.js'),
+      preload: path.join(__dirname, "preload-error.js"),
     },
   });
 
-  ipcMain.handleOnce('error:get-data', () => _errorData);
-  ipcMain.once('error:copy', () => {
+  ipcMain.handleOnce("error:get-data", () => _errorData);
+  ipcMain.once("error:copy", () => {
     clipboard.writeText(diagnosticsText);
     dialog.showMessageBox(win, {
-      type: 'info',
-      message: 'Diagnostics copied to clipboard.',
-      buttons: ['OK'],
+      type: "info",
+      message: "Diagnostics copied to clipboard.",
+      buttons: ["OK"],
     });
   });
-  ipcMain.once('error:close', () => win.close());
-  ipcMain.once('error:open-diagnostic', () => openDiagnosticWindow());
+  ipcMain.once("error:close", () => win.close());
+  ipcMain.once("error:open-diagnostic", () => openDiagnosticWindow());
 
-  win.loadFile(path.join(__dirname, '..', 'assets', 'error.html'));
+  win.loadFile(path.join(__dirname, "..", "assets", "error.html"));
   win.setMenu(null);
 
-  win.on('closed', () => {
-    ipcMain.removeAllListeners('error:open-diagnostic');
+  win.on("closed", () => {
+    ipcMain.removeAllListeners("error:open-diagnostic");
     _errorData = null;
     if (_fatalStartup) app.exit(1);
   });
@@ -330,9 +396,9 @@ function openDiagnosticWindow() {
     return;
   }
 
-  ipcMain.removeHandler('diagnostic:gather');
-  ipcMain.removeAllListeners('diagnostic:copy');
-  ipcMain.removeAllListeners('diagnostic:close');
+  ipcMain.removeHandler("diagnostic:gather");
+  ipcMain.removeAllListeners("diagnostic:copy");
+  ipcMain.removeAllListeners("diagnostic:close");
 
   _diagnosticWin = new BrowserWindow({
     width: 640,
@@ -343,51 +409,53 @@ function openDiagnosticWindow() {
     closable: true,
     alwaysOnTop: true,
     frame: true,
-    title: 'Fox in the Box — Diagnostic Report',
+    title: "Fox in the Box — Diagnostic Report",
     icon: APP_ICON,
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,
-      preload: path.join(__dirname, 'preload-diagnostic.js'),
+      preload: path.join(__dirname, "preload-diagnostic.js"),
     },
   });
 
-  ipcMain.handle('diagnostic:gather', async () => {
+  ipcMain.handle("diagnostic:gather", async () => {
     try {
       const report = await diagnosticReport.gatherDiagnosticReport({
         dockerManager: docker,
-        logPath: path.join(app.getPath('logs'), 'main.log'),
+        logPath: path.join(app.getPath("logs"), "main.log"),
         foxVersion: app.getVersion(),
       });
       return diagnosticReport.formatAsMarkdown(report);
     } catch (err) {
-      log.error('Diagnostic report gather failed:', err);
+      log.error("Diagnostic report gather failed:", err);
       return null;
     }
   });
 
-  ipcMain.once('diagnostic:copy', (_event, text) => {
+  ipcMain.once("diagnostic:copy", (_event, text) => {
     clipboard.writeText(text);
     if (_diagnosticWin && !_diagnosticWin.isDestroyed()) {
       dialog.showMessageBox(_diagnosticWin, {
-        type: 'info',
-        message: 'Diagnostic report copied to clipboard.',
-        buttons: ['OK'],
+        type: "info",
+        message: "Diagnostic report copied to clipboard.",
+        buttons: ["OK"],
       });
     }
   });
 
-  ipcMain.once('diagnostic:close', () => {
+  ipcMain.once("diagnostic:close", () => {
     if (_diagnosticWin && !_diagnosticWin.isDestroyed()) _diagnosticWin.close();
   });
 
-  _diagnosticWin.loadFile(path.join(__dirname, '..', 'assets', 'diagnostic.html'));
+  _diagnosticWin.loadFile(
+    path.join(__dirname, "..", "assets", "diagnostic.html"),
+  );
   _diagnosticWin.setMenu(null);
 
-  _diagnosticWin.on('closed', () => {
-    ipcMain.removeHandler('diagnostic:gather');
-    ipcMain.removeAllListeners('diagnostic:copy');
-    ipcMain.removeAllListeners('diagnostic:close');
+  _diagnosticWin.on("closed", () => {
+    ipcMain.removeHandler("diagnostic:gather");
+    ipcMain.removeAllListeners("diagnostic:copy");
+    ipcMain.removeAllListeners("diagnostic:close");
     _diagnosticWin = null;
   });
 }
@@ -397,48 +465,60 @@ function openDiagnosticWindow() {
 // main.js wires up the Electron-specific deps (showProgress, showRebootRequired, spawn).
 
 function spawnDetached(exe) {
-  spawn(exe, [], { detached: true, stdio: 'ignore', shell: true }).unref();
+  spawn(exe, [], { detached: true, stdio: "ignore", shell: true }).unref();
 }
 
 async function ensureDockerWindows(progressCb = showProgress) {
   // #356: Show a one-time heads-up before Docker Desktop's first launch.
   // Docker requires ToS acceptance + free account sign-up on first run,
   // which pops up unexpectedly and confuses users into thinking Fox broke.
-  const dockerTosFlag = path.join(app.getPath('userData'), '.docker-tos-shown');
+  const dockerTosFlag = path.join(app.getPath("userData"), ".docker-tos-shown");
   if (!fs.existsSync(dockerTosFlag)) {
-    const dockerConfigPath = path.join(os.homedir(), 'AppData', 'Roaming', 'Docker', 'settings.json');
+    const dockerConfigPath = path.join(
+      os.homedir(),
+      "AppData",
+      "Roaming",
+      "Docker",
+      "settings.json",
+    );
     const dockerAlreadyConfigured = fs.existsSync(dockerConfigPath);
     if (!dockerAlreadyConfigured) {
       await dialog.showMessageBox(getDialogParent(), {
-        type: 'info',
-        title: 'Fox in the Box — Docker setup',
-        message: 'Docker Desktop is about to start.',
+        type: "info",
+        title: "Fox in the Box — Docker setup",
+        message: "Docker Desktop is about to start.",
         detail:
-          'Docker Desktop will ask you to accept their Terms of Service and sign up for a free Docker account.\n\n'
-          + 'This is normal — just follow the Docker window that appears. '
-          + 'Once you\'re done, Fox will continue automatically.',
-        buttons: ['Got it'],
+          "Docker Desktop will ask you to accept their Terms of Service and sign up for a free Docker account.\n\n" +
+          "This is normal — just follow the Docker window that appears. " +
+          "Once you're done, Fox will continue automatically.",
+        buttons: ["Got it"],
         defaultId: 0,
       });
-      try { fs.writeFileSync(dockerTosFlag, '1'); } catch (_) {}
+      try {
+        fs.writeFileSync(dockerTosFlag, "1");
+      } catch (_) {}
     }
   }
 
   return _ensureDockerWindows({
     isDaemonRunning: () => docker.isDaemonRunning(),
-    waitForDaemon: (ms, sp, phaseStartedAt) => _waitForDaemon(
-      () => docker.isDaemonRunning(),
-      ms || 90_000,
-      1_000,
-      Date.now,
-      (t) => new Promise((r) => setTimeout(r, t)),
-      sp || progressCb,
-      phaseStartedAt
-    ),
-    runCommand: (cmd, opts) => _runCommandVerbose(cmd, { windowsHide: true, ...opts }, (line) => showProgress({ detail: line })),
+    waitForDaemon: (ms, sp, phaseStartedAt) =>
+      _waitForDaemon(
+        () => docker.isDaemonRunning(),
+        ms || 90_000,
+        1_000,
+        Date.now,
+        (t) => new Promise((r) => setTimeout(r, t)),
+        sp || progressCb,
+        phaseStartedAt,
+      ),
+    runCommand: (cmd, opts) =>
+      _runCommandVerbose(cmd, { windowsHide: true, ...opts }, (line) =>
+        showProgress({ detail: line }),
+      ),
     spawnDetached,
     showProgress: progressCb,
-    showRebootRequired: () => showDaemonRecoveryRequired('win32'),
+    showRebootRequired: () => showDaemonRecoveryRequired("win32"),
     showError,
     setForegroundYield,
     resumeAfterReboot,
@@ -448,48 +528,84 @@ async function ensureDockerWindows(progressCb = showProgress) {
 // ─── macOS Docker install (kept separate) ────────────────────────────────────
 
 async function installDockerMac(progressCb = showProgress) {
+  // #749: if Docker Desktop is already installed, never touch Homebrew —
+  // `brew install --cask docker` upgrades an existing outdated cask,
+  // which restarts Docker and stops running containers without consent.
+  // A present-but-stopped Docker just needs to be started; if it's
+  // genuinely broken, the existing MAC_DOCKER_LAUNCH_FAILED /
+  // DAEMON_NOT_READY paths tell the user what to do. Homebrew (with its
+  // implicit upgrade of stale cask remnants) runs only when Docker
+  // Desktop is absent.
+  if (fs.existsSync("/Applications/Docker.app")) {
+    log.info(
+      "Docker Desktop already installed — starting it instead of (re)installing",
+    );
+    progressCb({ detail: "Docker Desktop already installed — starting it…" });
+    try {
+      await _runCommandVerbose("open -a Docker", { timeout: 20_000 }, (line) =>
+        showProgress({ detail: line }),
+      );
+    } catch (err) {
+      const openErr = new Error(
+        "Docker Desktop is installed but could not be started automatically. Open Docker Desktop manually and approve any security/helper prompts.",
+      );
+      openErr.code = "MAC_DOCKER_LAUNCH_FAILED";
+      openErr.cause = err;
+      throw openErr;
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+    return;
+  }
+
   const { response } = await dialog.showMessageBox(getDialogParent(), {
-    type: 'question',
-    buttons: ['Install Docker', 'Cancel'],
+    type: "question",
+    buttons: ["Install Docker", "Cancel"],
     defaultId: 0,
     cancelId: 1,
-    title: 'Docker not found',
-    message: 'Docker Desktop is required but was not found.',
-    detail: 'Fox in the box will install it via Homebrew.\n\nThis may take a few minutes.',
+    title: "Docker not found",
+    message: "Docker Desktop is required but was not found.",
+    detail:
+      "Fox in the box will install it via Homebrew.\n\nThis may take a few minutes.",
   });
 
-  if (response !== 0) throw new Error('User cancelled Docker installation');
+  if (response !== 0) throw new Error("User cancelled Docker installation");
 
   try {
-    await _runCommandVerbose('brew --version', { timeout: 20_000 });
+    await _runCommandVerbose("brew --version", { timeout: 20_000 });
   } catch (err) {
     const brewErr = new Error(
-      'Homebrew is not installed or not available in PATH.\nInstall Homebrew from https://brew.sh, then relaunch Fox in the box.'
+      "Homebrew is not installed or not available in PATH.\nInstall Homebrew from https://brew.sh, then relaunch Fox in the box.",
     );
-    brewErr.code = 'BREW_NOT_FOUND';
+    brewErr.code = "BREW_NOT_FOUND";
     brewErr.cause = err;
     throw brewErr;
   }
 
-  log.info('Installing Docker via Homebrew');
+  log.info("Installing Docker via Homebrew");
   try {
-    await _runCommandVerbose('brew install --cask docker', { timeout: 15 * 60 * 1000 }, (line) => showProgress({ detail: line }));
+    await _runCommandVerbose(
+      "brew install --cask docker",
+      { timeout: 15 * 60 * 1000 },
+      (line) => showProgress({ detail: line }),
+    );
   } catch (err) {
     const brewInstallErr = new Error(
-      'Failed to install Docker Desktop via Homebrew. Check your network/proxy settings and Homebrew health, then retry.'
+      "Failed to install Docker Desktop via Homebrew. Check your network/proxy settings and Homebrew health, then retry.",
     );
-    brewInstallErr.code = 'BREW_INSTALL_FAILED';
+    brewInstallErr.code = "BREW_INSTALL_FAILED";
     brewInstallErr.cause = err;
     throw brewInstallErr;
   }
 
   try {
-    await _runCommandVerbose('open -a Docker', { timeout: 20_000 }, (line) => showProgress({ detail: line }));
+    await _runCommandVerbose("open -a Docker", { timeout: 20_000 }, (line) =>
+      showProgress({ detail: line }),
+    );
   } catch (err) {
     const openErr = new Error(
-      'Docker Desktop installed but could not be opened automatically. Open Docker Desktop manually and approve any security/helper prompts.'
+      "Docker Desktop installed but could not be opened automatically. Open Docker Desktop manually and approve any security/helper prompts.",
     );
-    openErr.code = 'MAC_DOCKER_LAUNCH_FAILED';
+    openErr.code = "MAC_DOCKER_LAUNCH_FAILED";
     openErr.cause = err;
     throw openErr;
   }
@@ -502,22 +618,23 @@ async function showDaemonRecoveryRequired(platform) {
   // close it first so the prompt is visible and not stacked underneath.
   closeProgress();
 
-  if (platform === 'win32') {
+  if (platform === "win32") {
     // v0.7.16 #325: register the RunOnce resume BEFORE the user sees the
     // dialog, so the "will continue automatically after restart" line is
     // truthful at the moment we make the promise. If the registration
     // fails, the dialog copy below would be a lie — registerWindowsRunOnceResume
     // logs but does not throw, so detect that we have an exe path at least.
-    await registerWindowsRunOnceResume(app.getPath('exe'));
+    await registerWindowsRunOnceResume(app.getPath("exe"));
     const { response } = await dialog.showMessageBox(getDialogParent(), {
-      type: 'warning',
-      title: 'Restart required to finish Docker setup',
-      message: 'Docker Desktop needs a restart before Fox in the box can continue.',
+      type: "warning",
+      title: "Restart required to finish Docker setup",
+      message:
+        "Docker Desktop needs a restart before Fox in the box can continue.",
       detail:
-        'Fox in the box will resume installation automatically after your PC restarts — '
-        + 'you do not need to re-launch the installer manually.\n\n'
-        + 'Save any unsaved work in other apps before clicking Restart now.',
-      buttons: ['Restart now', 'I\'ll restart later'],
+        "Fox in the box will resume installation automatically after your PC restarts — " +
+        "you do not need to re-launch the installer manually.\n\n" +
+        "Save any unsaved work in other apps before clicking Restart now.",
+      buttons: ["Restart now", "I'll restart later"],
       defaultId: 0,
       cancelId: 1,
     });
@@ -528,64 +645,72 @@ async function showDaemonRecoveryRequired(platform) {
     return;
   }
 
-  if (platform === 'darwin') {
+  if (platform === "darwin") {
     const { response } = await dialog.showMessageBox(getDialogParent(), {
-      type: 'warning',
-      title: 'Docker not ready',
-      message: 'Docker Desktop is installed but daemon is not ready yet.',
-      detail: 'Open Docker Desktop and wait until it says it is running. Approve any helper/Gatekeeper prompts in System Settings, then reopen Fox in the box.',
-      buttons: ['Open Docker Desktop', 'Close'],
+      type: "warning",
+      title: "Docker not ready",
+      message: "Docker Desktop is installed but daemon is not ready yet.",
+      detail:
+        "Open Docker Desktop and wait until it says it is running. Approve any helper/Gatekeeper prompts in System Settings, then reopen Fox in the box.",
+      buttons: ["Open Docker Desktop", "Close"],
       defaultId: 0,
       cancelId: 1,
     });
     if (response === 0) {
       try {
-        await shell.openExternal('docker-desktop://dashboard');
+        await shell.openExternal("docker-desktop://dashboard");
       } catch (_) {
-        exec('open -a Docker');
+        exec("open -a Docker");
       }
     }
   }
 }
 
 function getRemediationForCode(code, platform) {
-  if (code === 'DAEMON_LOST_DURING_HEALTH') {
-    return 'Docker daemon stopped while services were starting. Restart Docker Desktop and relaunch Fox in the box.';
+  if (code === "DAEMON_LOST_DURING_HEALTH") {
+    return "Docker daemon stopped while services were starting. Restart Docker Desktop and relaunch Fox in the box.";
   }
-  if (code === 'CONTAINER_MISSING_DURING_HEALTH' || code === 'CONTAINER_NOT_RUNNING_DURING_HEALTH') {
-    return 'Container stopped unexpectedly during startup. Check Docker Desktop container logs and retry.';
+  if (
+    code === "CONTAINER_MISSING_DURING_HEALTH" ||
+    code === "CONTAINER_NOT_RUNNING_DURING_HEALTH"
+  ) {
+    return "Container stopped unexpectedly during startup. Check Docker Desktop container logs and retry.";
   }
-  if (code === 'BREW_NOT_FOUND') {
-    return 'Install Homebrew from https://brew.sh, then relaunch Fox in the box.';
+  if (code === "BREW_NOT_FOUND") {
+    return "Install Homebrew from https://brew.sh, then relaunch Fox in the box.";
   }
-  if (code === 'BREW_INSTALL_FAILED') {
-    return 'Run brew doctor and brew install --cask docker manually, then relaunch Fox in the box.';
+  if (code === "BREW_INSTALL_FAILED") {
+    return "Run brew doctor and brew install --cask docker manually, then relaunch Fox in the box.";
   }
-  if (code === 'MAC_DOCKER_LAUNCH_FAILED') {
-    return 'Open Docker Desktop manually from Applications and approve security/helper prompts.';
+  if (code === "MAC_DOCKER_LAUNCH_FAILED") {
+    return "Open Docker Desktop manually from Applications and approve security/helper prompts.";
   }
-  if (code === 'WSL_NOT_INITIALIZED' || code === 'WSL_BACKEND_MISSING') {
-    return 'Open an elevated PowerShell and run: wsl --install --no-distribution && wsl --update, reboot, then launch Docker Desktop and retry.';
+  if (code === "WSL_NOT_INITIALIZED" || code === "WSL_BACKEND_MISSING") {
+    return "Open an elevated PowerShell and run: wsl --install --no-distribution && wsl --update, reboot, then launch Docker Desktop and retry.";
   }
-  if (code === 'DOCKER_DESKTOP_NOT_RUNNING') {
-    return 'Open Docker Desktop manually and wait until it shows Docker Engine running, then relaunch Fox in the box.';
+  if (code === "DOCKER_DESKTOP_NOT_RUNNING") {
+    return "Open Docker Desktop manually and wait until it shows Docker Engine running, then relaunch Fox in the box.";
   }
-  if (code === 'DOCKER_DESKTOP_LAUNCH_FAILED') {
-    return 'Docker Desktop launch failed. Start Docker Desktop manually (as Administrator if needed), then retry.';
+  if (code === "DOCKER_DESKTOP_LAUNCH_FAILED") {
+    return "Docker Desktop launch failed. Start Docker Desktop manually (as Administrator if needed), then retry.";
   }
-  if (code === 'DAEMON_NOT_READY') {
-    if (platform === 'win32') return 'Start Docker Desktop manually, wait until it reports running, then relaunch Fox in the box.';
-    return 'Open Docker Desktop and wait for daemon readiness, then relaunch Fox in the box.';
+  if (code === "DAEMON_NOT_READY") {
+    if (platform === "win32")
+      return "Start Docker Desktop manually, wait until it reports running, then relaunch Fox in the box.";
+    return "Open Docker Desktop and wait for daemon readiness, then relaunch Fox in the box.";
   }
-  if (code === 'DOCKER_WINDOWS_CONTAINERS_MODE') {
+  if (code === "DOCKER_WINDOWS_CONTAINERS_MODE") {
     // v0.7.11 #291: Docker IS running but in the wrong mode. There's no
     // recovery to attempt — the user has to flip the switch themselves.
     return 'Docker Desktop is in Windows-containers mode. Fox needs Linux containers. Right-click the Docker Desktop tray icon → "Switch to Linux containers..." → wait for it to finish, then relaunch Fox in the box.';
   }
-  if (code === 'IMAGE_PULL_TIMEOUT') return 'Check network connectivity and retry. Corporate proxies/firewalls can block container pulls.';
-  if (code === 'HEALTH_TIMEOUT') return 'Container started but app is not healthy yet. Wait a bit longer or restart Docker and try again.';
-  if (code === 'ACCESS_MODE_CANCELLED') return 'Relaunch Fox in the box and pick a network option, or set FOX_ACCESS_MODE=1|2|3 before starting.';
-  return 'Check diagnostics and logs, then retry.';
+  if (code === "IMAGE_PULL_TIMEOUT")
+    return "Check network connectivity and retry. Corporate proxies/firewalls can block container pulls.";
+  if (code === "HEALTH_TIMEOUT")
+    return "Container started but app is not healthy yet. Wait a bit longer or restart Docker and try again.";
+  if (code === "ACCESS_MODE_CANCELLED")
+    return "Relaunch Fox in the box and pick a network option, or set FOX_ACCESS_MODE=1|2|3 before starting.";
+  return "Check diagnostics and logs, then retry.";
 }
 
 // Poll /api/tailscale/status until it returns a tailnet_url or we time out.
@@ -594,12 +719,14 @@ async function pollTailscaleUrl(timeoutMs = 30_000) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     try {
-      const res = await fetch('http://127.0.0.1:8787/api/tailscale/status');
+      const res = await fetch("http://127.0.0.1:8787/api/tailscale/status");
       if (res.ok) {
         const data = await res.json();
         if (data && data.tailnet_url) return data.tailnet_url;
       }
-    } catch (_) { /* not yet */ }
+    } catch (_) {
+      /* not yet */
+    }
     await new Promise((r) => setTimeout(r, 2_000));
   }
   return null;
@@ -607,26 +734,28 @@ async function pollTailscaleUrl(timeoutMs = 30_000) {
 
 async function openFox(tailnetUrl) {
   const mode = docker.getEffectiveAccessMode();
-  if ((mode === '2' || mode === '3') && tailnetUrl) {
-    const lines = mode === '3'
-      ? `Local access: http://localhost:8787\nFrom other devices: ${tailnetUrl}`
-      : `From other devices: ${tailnetUrl}`;
+  if ((mode === "2" || mode === "3") && tailnetUrl) {
+    const lines =
+      mode === "3"
+        ? `Local access: http://localhost:8787\nFrom other devices: ${tailnetUrl}`
+        : `From other devices: ${tailnetUrl}`;
     const { response } = await dialog.showMessageBox(getDialogParent(), {
-      type: 'info',
-      title: 'Fox in the box — Ready',
-      message: 'Fox in the box is ready!',
-      detail: lines + '\n\nClick OK to open Fox.',
-      buttons: ['OK', 'Copy Tailscale URL'],
+      type: "info",
+      title: "Fox in the box — Ready",
+      message: "Fox in the box is ready!",
+      detail: lines + "\n\nClick OK to open Fox.",
+      buttons: ["OK", "Copy Tailscale URL"],
       defaultId: 0,
     });
     if (response === 1) clipboard.writeText(tailnetUrl);
-  } else if ((mode === '2' || mode === '3') && !tailnetUrl) {
+  } else if ((mode === "2" || mode === "3") && !tailnetUrl) {
     await dialog.showMessageBox(getDialogParent(), {
-      type: 'info',
-      title: 'Fox in the box — Tailscale not connected yet',
-      message: 'Tailscale hasn\'t connected yet.',
-      detail: 'Open the Tailscale app, sign in if prompted, and wait until it shows "Connected".\n\nFox is opening locally in the meantime. Once Tailscale connects, your tailnet URL will be available from the Tailscale menu.',
-      buttons: ['OK'],
+      type: "info",
+      title: "Fox in the box — Tailscale not connected yet",
+      message: "Tailscale hasn't connected yet.",
+      detail:
+        'Open the Tailscale app, sign in if prompted, and wait until it shows "Connected".\n\nFox is opening locally in the meantime. Once Tailscale connects, your tailnet URL will be available from the Tailscale menu.',
+      buttons: ["OK"],
       defaultId: 0,
     });
   }
@@ -635,15 +764,15 @@ async function openFox(tailnetUrl) {
 
 async function waitForTailscale(progressCb) {
   const mode = docker.getEffectiveAccessMode();
-  if (mode !== '2' && mode !== '3') return null;
-  if (progressCb) progressCb('Waiting for Tailscale to connect…');
+  if (mode !== "2" && mode !== "3") return null;
+  if (progressCb) progressCb("Waiting for Tailscale to connect…");
   return pollTailscaleUrl(30_000);
 }
 
 async function startFromTray() {
-  showProgress('Starting Fox in the box…');
+  showProgress("Starting Fox in the box…");
   try {
-    if (typeof docker.ensureDockerAccessModeChosen === 'function') {
+    if (typeof docker.ensureDockerAccessModeChosen === "function") {
       await docker.ensureDockerAccessModeChosen({ parent: getDialogParent() });
     }
     await ensureContainerHealthy({
@@ -660,11 +789,12 @@ async function startFromTray() {
 async function handleStartupError(err) {
   _fatalStartup = true;
   closeProgress();
-  log.error('Fatal startup error:', err);
+  log.error("Fatal startup error:", err);
 
-  const phase = err instanceof StartupPhaseError ? err.phase : 'unknown';
-  const code = err.code || (err.cause && err.cause.code) || 'UNSPECIFIED';
-  const sessionId = err.details && err.details.sessionId ? err.details.sessionId : 'n/a';
+  const phase = err instanceof StartupPhaseError ? err.phase : "unknown";
+  const code = err.code || (err.cause && err.cause.code) || "UNSPECIFIED";
+  const sessionId =
+    err.details && err.details.sessionId ? err.details.sessionId : "n/a";
   const diagnostics = await docker.getDiagnostics().catch(() => ({}));
   if (err.meta) diagnostics.startupDiagnostics = err.meta;
   const remediation = getRemediationForCode(code, process.platform);
@@ -690,15 +820,16 @@ async function handleStartupError(err) {
 // ─── Main startup sequence ───────────────────────────────────────────────────
 
 async function main() {
-  log.info('Fox in the box starting up');
+  log.info("Fox in the box starting up");
   if (resumeAfterReboot) {
-    log.info('[startup] Post-reboot resume (--resume-setup)');
+    log.info("[startup] Post-reboot resume (--resume-setup)");
   }
 
-  const shortcutOk = globalShortcut.register('CommandOrControl+Shift+D', () => {
+  const shortcutOk = globalShortcut.register("CommandOrControl+Shift+D", () => {
     openDiagnosticWindow();
   });
-  if (!shortcutOk) log.warn('Failed to register diagnostic shortcut Ctrl+Shift+D');
+  if (!shortcutOk)
+    log.warn("Failed to register diagnostic shortcut Ctrl+Shift+D");
 
   _setupInProgress = true;
   let _tailnetUrl = null;
@@ -708,14 +839,15 @@ async function main() {
       waitUntilHealthy,
       ensureDockerWindows,
       installDockerMac,
-      waitForDaemon: (ms, sp) => _waitForDaemon(
-        () => docker.isDaemonRunning(),
-        ms || 180_000,
-        1_000,
-        Date.now,
-        (t) => new Promise((r) => setTimeout(r, t)),
-        sp || showProgress
-      ),
+      waitForDaemon: (ms, sp) =>
+        _waitForDaemon(
+          () => docker.isDaemonRunning(),
+          ms || 180_000,
+          1_000,
+          Date.now,
+          (t) => new Promise((r) => setTimeout(r, t)),
+          sp || showProgress,
+        ),
       showProgress,
       closeProgress,
       openOnboarding: () => openFox(_tailnetUrl),
@@ -726,7 +858,7 @@ async function main() {
       getDialogParent,
       platform: process.platform,
     });
-    if (startupOutcome && startupOutcome.outcome === 'reboot-required') {
+    if (startupOutcome && startupOutcome.outcome === "reboot-required") {
       _setupInProgress = false;
       app.quit();
       return;

--- a/packages/electron/src/main.js
+++ b/packages/electron/src/main.js
@@ -1,54 +1,38 @@
-"use strict";
+'use strict';
 
 // Must run before anything can write to the console (#748): a closed
 // stdout pipe otherwise crashes the app on the first log line.
-const { installStdioGuard } = require("./stdio-guard");
+const { installStdioGuard } = require('./stdio-guard');
 installStdioGuard();
 
-const {
-  app,
-  BrowserWindow,
-  dialog,
-  shell,
-  clipboard,
-  ipcMain,
-  globalShortcut,
-} = require("electron");
-const { spawn, exec } = require("child_process");
-const path = require("path");
-const fs = require("fs");
-const os = require("os");
-const log = require("electron-log");
-const docker = require("./docker-manager");
-const { waitUntilHealthy } = require("./health-check");
-const { createTray, setRunning } = require("./tray-manager");
-const updater = require("./updater");
-const updateWindow = require("./update-window");
+const { app, BrowserWindow, dialog, shell, clipboard, ipcMain, globalShortcut } = require('electron');
+const { spawn, exec } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const log = require('electron-log');
+const docker = require('./docker-manager');
+const { waitUntilHealthy } = require('./health-check');
+const { createTray, setRunning } = require('./tray-manager');
+const updater = require('./updater');
+const updateWindow = require('./update-window');
 const {
   waitForDaemon: _waitForDaemon,
   ensureDockerWindows: _ensureDockerWindows,
   runCommandVerbose: _runCommandVerbose,
-} = require("./startup");
-const {
-  runStartup,
-  ensureContainerHealthy,
-  StartupPhaseError,
-} = require("./startup-orchestrator");
-const { registerWindowsRunOnceResume } = require("./windows-run-once");
-const { APP_HOME_URL } = require("./app-urls");
-const diagnosticReport = require("./diagnostic-report");
-const APP_ICON =
-  process.platform === "win32"
-    ? path.join(__dirname, "..", "assets", "icon.ico")
-    : path.join(__dirname, "..", "assets", "icon.png");
+} = require('./startup');
+const { runStartup, ensureContainerHealthy, StartupPhaseError } = require('./startup-orchestrator');
+const { registerWindowsRunOnceResume } = require('./windows-run-once');
+const { APP_HOME_URL } = require('./app-urls');
+const diagnosticReport = require('./diagnostic-report');
+const APP_ICON = process.platform === 'win32'
+  ? path.join(__dirname, '..', 'assets', 'icon.ico')
+  : path.join(__dirname, '..', 'assets', 'icon.png');
 let _fatalStartup = false;
 let _setupInProgress = false;
 
-const resumeAfterReboot =
-  process.platform === "win32" &&
-  process.argv.some(
-    (arg) => arg === "--resume-setup" || arg === "--resume-setup=true",
-  );
+const resumeAfterReboot = process.platform === 'win32'
+  && process.argv.some((arg) => arg === '--resume-setup' || arg === '--resume-setup=true');
 
 // Prevent multiple instances
 if (!app.requestSingleInstanceLock()) {
@@ -57,7 +41,7 @@ if (!app.requestSingleInstanceLock()) {
 }
 
 // Keep app alive when all windows are closed (tray-only)
-app.on("window-all-closed", (e) => {
+app.on('window-all-closed', (e) => {
   if (_fatalStartup) return;
   e.preventDefault();
 });
@@ -70,34 +54,24 @@ app.on("window-all-closed", (e) => {
 // locks), we log and continue — Electron will create a fresh `fox-in-the-box`
 // dir and the user can manually salvage `@fox-in-the-box` via Tray → Reset.
 function migrateLegacyUserData() {
-  const newPath = app.getPath("userData"); // resolves to .../fox-in-the-box
+  const newPath = app.getPath('userData');  // resolves to .../fox-in-the-box
   let legacyPath;
   switch (process.platform) {
-    case "win32":
-      legacyPath = path.join(
-        os.homedir(),
-        "AppData",
-        "Roaming",
-        "@fox-in-the-box",
-      );
+    case 'win32':
+      legacyPath = path.join(os.homedir(), 'AppData', 'Roaming', '@fox-in-the-box');
       break;
-    case "darwin":
-      legacyPath = path.join(
-        os.homedir(),
-        "Library",
-        "Application Support",
-        "@fox-in-the-box",
-      );
+    case 'darwin':
+      legacyPath = path.join(os.homedir(), 'Library', 'Application Support', '@fox-in-the-box');
       break;
     default:
-      legacyPath = path.join(os.homedir(), ".config", "@fox-in-the-box");
+      legacyPath = path.join(os.homedir(), '.config', '@fox-in-the-box');
       break;
   }
   if (!fs.existsSync(legacyPath)) return;
   if (fs.existsSync(newPath)) {
     log.info(
       `[migration] Both legacy (${legacyPath}) and new (${newPath}) userData dirs exist — ` +
-        `keeping new, leaving legacy alone for manual review.`,
+      `keeping new, leaving legacy alone for manual review.`,
     );
     return;
   }
@@ -107,7 +81,7 @@ function migrateLegacyUserData() {
   } catch (err) {
     log.warn(
       `[migration] Failed to rename legacy userData (${legacyPath} -> ${newPath}): ` +
-        `${err.message}. Manual cleanup may be needed via Tray → Reset Fox completely…`,
+      `${err.message}. Manual cleanup may be needed via Tray → Reset Fox completely…`,
     );
   }
 }
@@ -115,10 +89,8 @@ function migrateLegacyUserData() {
 migrateLegacyUserData();
 
 app.whenReady().then(main).catch(handleStartupError);
-app.on("will-quit", () => {
-  globalShortcut.unregisterAll();
-});
-app.setAppUserModelId("io.foxinthebox.desktop");
+app.on('will-quit', () => { globalShortcut.unregisterAll(); });
+app.setAppUserModelId('io.foxinthebox.desktop');
 // v0.7.19: `app.setName('Fox in the box')` removed — `productName: fox-in-the-box`
 // in package.json now drives the userData path, which is what we want
 // (drops the `@` prefix that came from the npm scope `@fox-in-the-box/electron`).
@@ -126,16 +98,16 @@ app.setAppUserModelId("io.foxinthebox.desktop");
 // ─── Progress window ─────────────────────────────────────────────────────────
 
 let _progressWin = null;
-let _progressState = { title: "", detail: "" };
+let _progressState = { title: '', detail: '' };
 
 const INSTALL_STEPS = [
-  { label: "Checking system", match: "Check system" },
-  { label: "Installing Docker", match: "Install Docker" },
-  { label: "Starting Docker", match: "Start Docker" },
-  { label: "Downloading Fox image", match: "Download image" },
-  { label: "Starting container", match: "Start container" },
-  { label: "Waiting for services", match: "Wait for services" },
-  { label: "Connecting to network", match: "Connect network" },
+  { label: 'Checking system',        match: 'Check system' },
+  { label: 'Installing Docker',      match: 'Install Docker' },
+  { label: 'Starting Docker',        match: 'Start Docker' },
+  { label: 'Downloading Fox image',  match: 'Download image' },
+  { label: 'Starting container',     match: 'Start container' },
+  { label: 'Waiting for services',   match: 'Wait for services' },
+  { label: 'Connecting to network',  match: 'Connect network' },
 ];
 
 function _activeStepIndex(title) {
@@ -143,65 +115,41 @@ function _activeStepIndex(title) {
   for (let i = INSTALL_STEPS.length - 1; i >= 0; i--) {
     if (title.includes(INSTALL_STEPS[i].match)) return i;
   }
-  if (title.includes("Installing") || title.includes("install")) return 1;
-  if (
-    title.includes("Starting Docker") ||
-    title.includes("Launching Docker") ||
-    title.includes("daemon")
-  )
-    return 2;
-  if (
-    title.includes("image") ||
-    title.includes("pull") ||
-    title.includes("Pull")
-  )
-    return 3;
-  if (title.includes("container") || title.includes("Container")) return 4;
-  if (
-    title.includes("health") ||
-    title.includes("ready") ||
-    title.includes("healthy")
-  )
-    return 5;
-  if (
-    title.includes("Tailscale") ||
-    title.includes("network") ||
-    title.includes("Opening")
-  )
-    return 6;
+  if (title.includes('Installing') || title.includes('install')) return 1;
+  if (title.includes('Starting Docker') || title.includes('Launching Docker') || title.includes('daemon')) return 2;
+  if (title.includes('image') || title.includes('pull') || title.includes('Pull')) return 3;
+  if (title.includes('container') || title.includes('Container')) return 4;
+  if (title.includes('health') || title.includes('ready') || title.includes('healthy')) return 5;
+  if (title.includes('Tailscale') || title.includes('network') || title.includes('Opening')) return 6;
   return 0;
 }
 
 function progressDiagnosticsLine(title, explicitDetail) {
-  if (typeof explicitDetail === "string" && explicitDetail.trim().length > 0) {
+  if (typeof explicitDetail === 'string' && explicitDetail.trim().length > 0) {
     return explicitDetail.trim();
   }
-  const m = String(title || "").match(/^Step \d+\/\d+ - [^:]+: (.+)$/);
-  return m ? m[1].trim() : String(title || "").trim();
+  const m = String(title || '').match(/^Step \d+\/\d+ - [^:]+: (.+)$/);
+  return m ? m[1].trim() : String(title || '').trim();
 }
 
 function showProgress(message) {
-  const update =
-    typeof message === "object" && message !== null
-      ? message
-      : { title: String(message || "") };
-  if (typeof update.title === "string" && update.title.trim().length > 0) {
+  const update = (typeof message === 'object' && message !== null)
+    ? message
+    : { title: String(message || '') };
+  if (typeof update.title === 'string' && update.title.trim().length > 0) {
     _progressState.title = update.title;
   }
-  if (typeof update.detail === "string") {
+  if (typeof update.detail === 'string') {
     _progressState.detail = update.detail;
   }
 
   const idx = _activeStepIndex(_progressState.title);
 
   if (_progressWin) {
-    _progressWin.webContents.send("progress:step", idx);
-    const logLine = progressDiagnosticsLine(
-      _progressState.title,
-      update.detail,
-    );
+    _progressWin.webContents.send('progress:step', idx);
+    const logLine = progressDiagnosticsLine(_progressState.title, update.detail);
     if (logLine) {
-      _progressWin.webContents.send("progress:log", logLine);
+      _progressWin.webContents.send('progress:log', logLine);
     }
     return;
   }
@@ -215,64 +163,61 @@ function showProgress(message) {
     closable: true,
     alwaysOnTop: true,
     frame: true,
-    title: "Fox in the Box — Setting up",
+    title: 'Fox in the Box — Setting up',
     icon: APP_ICON,
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,
-      preload: path.join(__dirname, "preload-progress.js"),
+      preload: path.join(__dirname, 'preload-progress.js'),
     },
   });
 
-  _progressWin.on("closed", async () => {
+  _progressWin.on('closed', async () => {
     _progressWin = null;
     if (_setupInProgress && !_fatalStartup) {
-      log.info("[startup] Setup progress window closed during installation");
+      log.info('[startup] Setup progress window closed during installation');
       const parent = getDialogParent();
       const { response } = await dialog.showMessageBox(parent, {
-        type: "warning",
-        title: "Quit setup?",
-        message: "Fox in the box setup is still in progress.",
+        type: 'warning',
+        title: 'Quit setup?',
+        message: 'Fox in the box setup is still in progress.',
         detail:
-          "Docker may still be starting in the background. If you quit now, reopen Fox from the Start menu to continue.",
-        buttons: ["Quit setup", "Keep waiting"],
+          'Docker may still be starting in the background. If you quit now, reopen Fox from the Start menu to continue.',
+        buttons: ['Quit setup', 'Keep waiting'],
         defaultId: 1,
         cancelId: 1,
       });
       if (response !== 0) {
-        showProgress(_progressState.title || "Setting up…");
+        showProgress(_progressState.title || 'Setting up…');
         return;
       }
     }
     app.quit();
   });
 
-  _progressWin.loadFile(path.join(__dirname, "..", "assets", "progress.html"));
+  _progressWin.loadFile(path.join(__dirname, '..', 'assets', 'progress.html'));
   _progressWin.setMenu(null);
 
   // Send current state once the page is ready. Use _progressState at fire time,
   // not the idx captured at window-creation time (startup may have advanced).
-  _progressWin.webContents.once("did-finish-load", () => {
+  _progressWin.webContents.once('did-finish-load', () => {
     if (!_progressWin || _progressWin.isDestroyed()) return;
     const currentIdx = _activeStepIndex(_progressState.title);
-    _progressWin.webContents.send("progress:step", currentIdx);
-    const logLine = progressDiagnosticsLine(
-      _progressState.title,
-      _progressState.detail,
-    );
+    _progressWin.webContents.send('progress:step', currentIdx);
+    const logLine = progressDiagnosticsLine(_progressState.title, _progressState.detail);
     if (logLine) {
-      _progressWin.webContents.send("progress:log", logLine);
+      _progressWin.webContents.send('progress:log', logLine);
     }
   });
 }
 
 function closeProgress() {
   if (_progressWin) {
-    _progressWin.removeAllListeners("closed");
+    _progressWin.removeAllListeners('closed');
     _progressWin.destroy();
     _progressWin = null;
   }
-  _progressState = { title: "", detail: "" };
+  _progressState = { title: '', detail: '' };
 }
 
 // v0.7.16 #324: when external installers (Docker Desktop, winget, UAC) are
@@ -285,7 +230,7 @@ function setForegroundYield(shouldYield) {
   try {
     _progressWin.setAlwaysOnTop(!shouldYield);
   } catch (err) {
-    log.debug("setForegroundYield failed:", err.message);
+    log.debug('setForegroundYield failed:', err.message);
   }
 }
 
@@ -302,48 +247,42 @@ function buildDiagnosticsText({
   diagnostics,
 }) {
   return [
-    `Session ID: ${sessionId || "n/a"}`,
-    `Phase: ${phase || "unknown"}`,
-    `Error code: ${code || "UNSPECIFIED"}`,
-    `Message: ${message || "Unknown error"}`,
+    `Session ID: ${sessionId || 'n/a'}`,
+    `Phase: ${phase || 'unknown'}`,
+    `Error code: ${code || 'UNSPECIFIED'}`,
+    `Message: ${message || 'Unknown error'}`,
     `Remediation: ${remediation}`,
-    `Log path: ${path.join(app.getPath("logs"), "main.log")}`,
-    "",
-    "Docker diagnostics:",
+    `Log path: ${path.join(app.getPath('logs'), 'main.log')}`,
+    '',
+    'Docker diagnostics:',
     JSON.stringify(diagnostics || {}, null, 2),
-  ].join("\n");
+  ].join('\n');
 }
 
 // Error data stored here so the preload's ipcMain.handle can return it synchronously.
 let _errorData = null;
 
 function showError(details) {
-  if (typeof details === "string") {
+  if (typeof details === 'string') {
     details = {
       message: details,
-      remediation:
-        "Install Docker Desktop manually and relaunch Fox in the box.",
+      remediation: 'Install Docker Desktop manually and relaunch Fox in the box.',
       diagnosticsText: details,
     };
   }
   const {
-    sessionId = "n/a",
-    phase = "unknown",
-    code = "UNSPECIFIED",
-    message = "Unknown startup error",
-    remediation = "Check diagnostics and retry.",
-    diagnosticsText = "",
+    sessionId = 'n/a',
+    phase = 'unknown',
+    code = 'UNSPECIFIED',
+    message = 'Unknown startup error',
+    remediation = 'Check diagnostics and retry.',
+    diagnosticsText = '',
   } = details;
   closeProgress();
 
   _errorData = {
-    sessionId,
-    phase,
-    code,
-    message,
-    remediation,
-    diagnosticsText,
-    logPath: path.join(app.getPath("logs"), "main.log"),
+    sessionId, phase, code, message, remediation, diagnosticsText,
+    logPath: path.join(app.getPath('logs'), 'main.log'),
   };
 
   const win = new BrowserWindow({
@@ -355,32 +294,32 @@ function showError(details) {
     closable: true,
     alwaysOnTop: true,
     frame: true,
-    title: "Fox in the Box — Error",
+    title: 'Fox in the Box — Error',
     icon: APP_ICON,
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,
-      preload: path.join(__dirname, "preload-error.js"),
+      preload: path.join(__dirname, 'preload-error.js'),
     },
   });
 
-  ipcMain.handleOnce("error:get-data", () => _errorData);
-  ipcMain.once("error:copy", () => {
+  ipcMain.handleOnce('error:get-data', () => _errorData);
+  ipcMain.once('error:copy', () => {
     clipboard.writeText(diagnosticsText);
     dialog.showMessageBox(win, {
-      type: "info",
-      message: "Diagnostics copied to clipboard.",
-      buttons: ["OK"],
+      type: 'info',
+      message: 'Diagnostics copied to clipboard.',
+      buttons: ['OK'],
     });
   });
-  ipcMain.once("error:close", () => win.close());
-  ipcMain.once("error:open-diagnostic", () => openDiagnosticWindow());
+  ipcMain.once('error:close', () => win.close());
+  ipcMain.once('error:open-diagnostic', () => openDiagnosticWindow());
 
-  win.loadFile(path.join(__dirname, "..", "assets", "error.html"));
+  win.loadFile(path.join(__dirname, '..', 'assets', 'error.html'));
   win.setMenu(null);
 
-  win.on("closed", () => {
-    ipcMain.removeAllListeners("error:open-diagnostic");
+  win.on('closed', () => {
+    ipcMain.removeAllListeners('error:open-diagnostic');
     _errorData = null;
     if (_fatalStartup) app.exit(1);
   });
@@ -396,9 +335,9 @@ function openDiagnosticWindow() {
     return;
   }
 
-  ipcMain.removeHandler("diagnostic:gather");
-  ipcMain.removeAllListeners("diagnostic:copy");
-  ipcMain.removeAllListeners("diagnostic:close");
+  ipcMain.removeHandler('diagnostic:gather');
+  ipcMain.removeAllListeners('diagnostic:copy');
+  ipcMain.removeAllListeners('diagnostic:close');
 
   _diagnosticWin = new BrowserWindow({
     width: 640,
@@ -409,53 +348,51 @@ function openDiagnosticWindow() {
     closable: true,
     alwaysOnTop: true,
     frame: true,
-    title: "Fox in the Box — Diagnostic Report",
+    title: 'Fox in the Box — Diagnostic Report',
     icon: APP_ICON,
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,
-      preload: path.join(__dirname, "preload-diagnostic.js"),
+      preload: path.join(__dirname, 'preload-diagnostic.js'),
     },
   });
 
-  ipcMain.handle("diagnostic:gather", async () => {
+  ipcMain.handle('diagnostic:gather', async () => {
     try {
       const report = await diagnosticReport.gatherDiagnosticReport({
         dockerManager: docker,
-        logPath: path.join(app.getPath("logs"), "main.log"),
+        logPath: path.join(app.getPath('logs'), 'main.log'),
         foxVersion: app.getVersion(),
       });
       return diagnosticReport.formatAsMarkdown(report);
     } catch (err) {
-      log.error("Diagnostic report gather failed:", err);
+      log.error('Diagnostic report gather failed:', err);
       return null;
     }
   });
 
-  ipcMain.once("diagnostic:copy", (_event, text) => {
+  ipcMain.once('diagnostic:copy', (_event, text) => {
     clipboard.writeText(text);
     if (_diagnosticWin && !_diagnosticWin.isDestroyed()) {
       dialog.showMessageBox(_diagnosticWin, {
-        type: "info",
-        message: "Diagnostic report copied to clipboard.",
-        buttons: ["OK"],
+        type: 'info',
+        message: 'Diagnostic report copied to clipboard.',
+        buttons: ['OK'],
       });
     }
   });
 
-  ipcMain.once("diagnostic:close", () => {
+  ipcMain.once('diagnostic:close', () => {
     if (_diagnosticWin && !_diagnosticWin.isDestroyed()) _diagnosticWin.close();
   });
 
-  _diagnosticWin.loadFile(
-    path.join(__dirname, "..", "assets", "diagnostic.html"),
-  );
+  _diagnosticWin.loadFile(path.join(__dirname, '..', 'assets', 'diagnostic.html'));
   _diagnosticWin.setMenu(null);
 
-  _diagnosticWin.on("closed", () => {
-    ipcMain.removeHandler("diagnostic:gather");
-    ipcMain.removeAllListeners("diagnostic:copy");
-    ipcMain.removeAllListeners("diagnostic:close");
+  _diagnosticWin.on('closed', () => {
+    ipcMain.removeHandler('diagnostic:gather');
+    ipcMain.removeAllListeners('diagnostic:copy');
+    ipcMain.removeAllListeners('diagnostic:close');
     _diagnosticWin = null;
   });
 }
@@ -465,60 +402,48 @@ function openDiagnosticWindow() {
 // main.js wires up the Electron-specific deps (showProgress, showRebootRequired, spawn).
 
 function spawnDetached(exe) {
-  spawn(exe, [], { detached: true, stdio: "ignore", shell: true }).unref();
+  spawn(exe, [], { detached: true, stdio: 'ignore', shell: true }).unref();
 }
 
 async function ensureDockerWindows(progressCb = showProgress) {
   // #356: Show a one-time heads-up before Docker Desktop's first launch.
   // Docker requires ToS acceptance + free account sign-up on first run,
   // which pops up unexpectedly and confuses users into thinking Fox broke.
-  const dockerTosFlag = path.join(app.getPath("userData"), ".docker-tos-shown");
+  const dockerTosFlag = path.join(app.getPath('userData'), '.docker-tos-shown');
   if (!fs.existsSync(dockerTosFlag)) {
-    const dockerConfigPath = path.join(
-      os.homedir(),
-      "AppData",
-      "Roaming",
-      "Docker",
-      "settings.json",
-    );
+    const dockerConfigPath = path.join(os.homedir(), 'AppData', 'Roaming', 'Docker', 'settings.json');
     const dockerAlreadyConfigured = fs.existsSync(dockerConfigPath);
     if (!dockerAlreadyConfigured) {
       await dialog.showMessageBox(getDialogParent(), {
-        type: "info",
-        title: "Fox in the Box — Docker setup",
-        message: "Docker Desktop is about to start.",
+        type: 'info',
+        title: 'Fox in the Box — Docker setup',
+        message: 'Docker Desktop is about to start.',
         detail:
-          "Docker Desktop will ask you to accept their Terms of Service and sign up for a free Docker account.\n\n" +
-          "This is normal — just follow the Docker window that appears. " +
-          "Once you're done, Fox will continue automatically.",
-        buttons: ["Got it"],
+          'Docker Desktop will ask you to accept their Terms of Service and sign up for a free Docker account.\n\n'
+          + 'This is normal — just follow the Docker window that appears. '
+          + 'Once you\'re done, Fox will continue automatically.',
+        buttons: ['Got it'],
         defaultId: 0,
       });
-      try {
-        fs.writeFileSync(dockerTosFlag, "1");
-      } catch (_) {}
+      try { fs.writeFileSync(dockerTosFlag, '1'); } catch (_) {}
     }
   }
 
   return _ensureDockerWindows({
     isDaemonRunning: () => docker.isDaemonRunning(),
-    waitForDaemon: (ms, sp, phaseStartedAt) =>
-      _waitForDaemon(
-        () => docker.isDaemonRunning(),
-        ms || 90_000,
-        1_000,
-        Date.now,
-        (t) => new Promise((r) => setTimeout(r, t)),
-        sp || progressCb,
-        phaseStartedAt,
-      ),
-    runCommand: (cmd, opts) =>
-      _runCommandVerbose(cmd, { windowsHide: true, ...opts }, (line) =>
-        showProgress({ detail: line }),
-      ),
+    waitForDaemon: (ms, sp, phaseStartedAt) => _waitForDaemon(
+      () => docker.isDaemonRunning(),
+      ms || 90_000,
+      1_000,
+      Date.now,
+      (t) => new Promise((r) => setTimeout(r, t)),
+      sp || progressCb,
+      phaseStartedAt
+    ),
+    runCommand: (cmd, opts) => _runCommandVerbose(cmd, { windowsHide: true, ...opts }, (line) => showProgress({ detail: line })),
     spawnDetached,
     showProgress: progressCb,
-    showRebootRequired: () => showDaemonRecoveryRequired("win32"),
+    showRebootRequired: () => showDaemonRecoveryRequired('win32'),
     showError,
     setForegroundYield,
     resumeAfterReboot,
@@ -535,77 +460,72 @@ async function installDockerMac(progressCb = showProgress) {
   // genuinely broken, the existing MAC_DOCKER_LAUNCH_FAILED /
   // DAEMON_NOT_READY paths tell the user what to do. Homebrew (with its
   // implicit upgrade of stale cask remnants) runs only when Docker
-  // Desktop is absent.
-  if (fs.existsSync("/Applications/Docker.app")) {
-    log.info(
-      "Docker Desktop already installed — starting it instead of (re)installing",
-    );
-    progressCb({ detail: "Docker Desktop already installed — starting it…" });
+  // Desktop is absent from both install locations.
+  const dockerAppPaths = [
+    '/Applications/Docker.app',
+    path.join(os.homedir(), 'Applications', 'Docker.app'),
+  ];
+  if (dockerAppPaths.some((p) => fs.existsSync(p))) {
+    log.info('Docker Desktop already installed — starting it instead of (re)installing');
+    progressCb({ detail: 'Docker Desktop already installed — starting it…' });
     try {
-      await _runCommandVerbose("open -a Docker", { timeout: 20_000 }, (line) =>
-        showProgress({ detail: line }),
-      );
+      await _runCommandVerbose('open -a Docker', { timeout: 20_000 }, (line) => showProgress({ detail: line }));
     } catch (err) {
       const openErr = new Error(
-        "Docker Desktop is installed but could not be started automatically. Open Docker Desktop manually and approve any security/helper prompts.",
+        'Docker Desktop is installed but could not be started automatically. Open Docker Desktop manually and approve any security/helper prompts.'
       );
-      openErr.code = "MAC_DOCKER_LAUNCH_FAILED";
+      openErr.code = 'MAC_DOCKER_LAUNCH_FAILED';
       openErr.cause = err;
       throw openErr;
     }
+    // Give Docker.app a beat to register with launchd before the
+    // orchestrator's docker_start phase begins its 180s daemon wait.
     await new Promise((r) => setTimeout(r, 1000));
     return;
   }
 
   const { response } = await dialog.showMessageBox(getDialogParent(), {
-    type: "question",
-    buttons: ["Install Docker", "Cancel"],
+    type: 'question',
+    buttons: ['Install Docker', 'Cancel'],
     defaultId: 0,
     cancelId: 1,
-    title: "Docker not found",
-    message: "Docker Desktop is required but was not found.",
-    detail:
-      "Fox in the box will install it via Homebrew.\n\nThis may take a few minutes.",
+    title: 'Docker not found',
+    message: 'Docker Desktop is required but was not found.',
+    detail: 'Fox in the box will install it via Homebrew.\n\nThis may take a few minutes.',
   });
 
-  if (response !== 0) throw new Error("User cancelled Docker installation");
+  if (response !== 0) throw new Error('User cancelled Docker installation');
 
   try {
-    await _runCommandVerbose("brew --version", { timeout: 20_000 });
+    await _runCommandVerbose('brew --version', { timeout: 20_000 });
   } catch (err) {
     const brewErr = new Error(
-      "Homebrew is not installed or not available in PATH.\nInstall Homebrew from https://brew.sh, then relaunch Fox in the box.",
+      'Homebrew is not installed or not available in PATH.\nInstall Homebrew from https://brew.sh, then relaunch Fox in the box.'
     );
-    brewErr.code = "BREW_NOT_FOUND";
+    brewErr.code = 'BREW_NOT_FOUND';
     brewErr.cause = err;
     throw brewErr;
   }
 
-  log.info("Installing Docker via Homebrew");
+  log.info('Installing Docker via Homebrew');
   try {
-    await _runCommandVerbose(
-      "brew install --cask docker",
-      { timeout: 15 * 60 * 1000 },
-      (line) => showProgress({ detail: line }),
-    );
+    await _runCommandVerbose('brew install --cask docker', { timeout: 15 * 60 * 1000 }, (line) => showProgress({ detail: line }));
   } catch (err) {
     const brewInstallErr = new Error(
-      "Failed to install Docker Desktop via Homebrew. Check your network/proxy settings and Homebrew health, then retry.",
+      'Failed to install Docker Desktop via Homebrew. Check your network/proxy settings and Homebrew health, then retry.'
     );
-    brewInstallErr.code = "BREW_INSTALL_FAILED";
+    brewInstallErr.code = 'BREW_INSTALL_FAILED';
     brewInstallErr.cause = err;
     throw brewInstallErr;
   }
 
   try {
-    await _runCommandVerbose("open -a Docker", { timeout: 20_000 }, (line) =>
-      showProgress({ detail: line }),
-    );
+    await _runCommandVerbose('open -a Docker', { timeout: 20_000 }, (line) => showProgress({ detail: line }));
   } catch (err) {
     const openErr = new Error(
-      "Docker Desktop installed but could not be opened automatically. Open Docker Desktop manually and approve any security/helper prompts.",
+      'Docker Desktop installed but could not be opened automatically. Open Docker Desktop manually and approve any security/helper prompts.'
     );
-    openErr.code = "MAC_DOCKER_LAUNCH_FAILED";
+    openErr.code = 'MAC_DOCKER_LAUNCH_FAILED';
     openErr.cause = err;
     throw openErr;
   }
@@ -618,23 +538,22 @@ async function showDaemonRecoveryRequired(platform) {
   // close it first so the prompt is visible and not stacked underneath.
   closeProgress();
 
-  if (platform === "win32") {
+  if (platform === 'win32') {
     // v0.7.16 #325: register the RunOnce resume BEFORE the user sees the
     // dialog, so the "will continue automatically after restart" line is
     // truthful at the moment we make the promise. If the registration
     // fails, the dialog copy below would be a lie — registerWindowsRunOnceResume
     // logs but does not throw, so detect that we have an exe path at least.
-    await registerWindowsRunOnceResume(app.getPath("exe"));
+    await registerWindowsRunOnceResume(app.getPath('exe'));
     const { response } = await dialog.showMessageBox(getDialogParent(), {
-      type: "warning",
-      title: "Restart required to finish Docker setup",
-      message:
-        "Docker Desktop needs a restart before Fox in the box can continue.",
+      type: 'warning',
+      title: 'Restart required to finish Docker setup',
+      message: 'Docker Desktop needs a restart before Fox in the box can continue.',
       detail:
-        "Fox in the box will resume installation automatically after your PC restarts — " +
-        "you do not need to re-launch the installer manually.\n\n" +
-        "Save any unsaved work in other apps before clicking Restart now.",
-      buttons: ["Restart now", "I'll restart later"],
+        'Fox in the box will resume installation automatically after your PC restarts — '
+        + 'you do not need to re-launch the installer manually.\n\n'
+        + 'Save any unsaved work in other apps before clicking Restart now.',
+      buttons: ['Restart now', 'I\'ll restart later'],
       defaultId: 0,
       cancelId: 1,
     });
@@ -645,72 +564,64 @@ async function showDaemonRecoveryRequired(platform) {
     return;
   }
 
-  if (platform === "darwin") {
+  if (platform === 'darwin') {
     const { response } = await dialog.showMessageBox(getDialogParent(), {
-      type: "warning",
-      title: "Docker not ready",
-      message: "Docker Desktop is installed but daemon is not ready yet.",
-      detail:
-        "Open Docker Desktop and wait until it says it is running. Approve any helper/Gatekeeper prompts in System Settings, then reopen Fox in the box.",
-      buttons: ["Open Docker Desktop", "Close"],
+      type: 'warning',
+      title: 'Docker not ready',
+      message: 'Docker Desktop is installed but daemon is not ready yet.',
+      detail: 'Open Docker Desktop and wait until it says it is running. Approve any helper/Gatekeeper prompts in System Settings, then reopen Fox in the box.',
+      buttons: ['Open Docker Desktop', 'Close'],
       defaultId: 0,
       cancelId: 1,
     });
     if (response === 0) {
       try {
-        await shell.openExternal("docker-desktop://dashboard");
+        await shell.openExternal('docker-desktop://dashboard');
       } catch (_) {
-        exec("open -a Docker");
+        exec('open -a Docker');
       }
     }
   }
 }
 
 function getRemediationForCode(code, platform) {
-  if (code === "DAEMON_LOST_DURING_HEALTH") {
-    return "Docker daemon stopped while services were starting. Restart Docker Desktop and relaunch Fox in the box.";
+  if (code === 'DAEMON_LOST_DURING_HEALTH') {
+    return 'Docker daemon stopped while services were starting. Restart Docker Desktop and relaunch Fox in the box.';
   }
-  if (
-    code === "CONTAINER_MISSING_DURING_HEALTH" ||
-    code === "CONTAINER_NOT_RUNNING_DURING_HEALTH"
-  ) {
-    return "Container stopped unexpectedly during startup. Check Docker Desktop container logs and retry.";
+  if (code === 'CONTAINER_MISSING_DURING_HEALTH' || code === 'CONTAINER_NOT_RUNNING_DURING_HEALTH') {
+    return 'Container stopped unexpectedly during startup. Check Docker Desktop container logs and retry.';
   }
-  if (code === "BREW_NOT_FOUND") {
-    return "Install Homebrew from https://brew.sh, then relaunch Fox in the box.";
+  if (code === 'BREW_NOT_FOUND') {
+    return 'Install Homebrew from https://brew.sh, then relaunch Fox in the box.';
   }
-  if (code === "BREW_INSTALL_FAILED") {
-    return "Run brew doctor and brew install --cask docker manually, then relaunch Fox in the box.";
+  if (code === 'BREW_INSTALL_FAILED') {
+    return 'Run brew doctor and brew install --cask docker manually, then relaunch Fox in the box.';
   }
-  if (code === "MAC_DOCKER_LAUNCH_FAILED") {
-    return "Open Docker Desktop manually from Applications and approve security/helper prompts.";
+  if (code === 'MAC_DOCKER_LAUNCH_FAILED') {
+    return 'Open Docker Desktop manually from Applications and approve security/helper prompts.';
   }
-  if (code === "WSL_NOT_INITIALIZED" || code === "WSL_BACKEND_MISSING") {
-    return "Open an elevated PowerShell and run: wsl --install --no-distribution && wsl --update, reboot, then launch Docker Desktop and retry.";
+  if (code === 'WSL_NOT_INITIALIZED' || code === 'WSL_BACKEND_MISSING') {
+    return 'Open an elevated PowerShell and run: wsl --install --no-distribution && wsl --update, reboot, then launch Docker Desktop and retry.';
   }
-  if (code === "DOCKER_DESKTOP_NOT_RUNNING") {
-    return "Open Docker Desktop manually and wait until it shows Docker Engine running, then relaunch Fox in the box.";
+  if (code === 'DOCKER_DESKTOP_NOT_RUNNING') {
+    return 'Open Docker Desktop manually and wait until it shows Docker Engine running, then relaunch Fox in the box.';
   }
-  if (code === "DOCKER_DESKTOP_LAUNCH_FAILED") {
-    return "Docker Desktop launch failed. Start Docker Desktop manually (as Administrator if needed), then retry.";
+  if (code === 'DOCKER_DESKTOP_LAUNCH_FAILED') {
+    return 'Docker Desktop launch failed. Start Docker Desktop manually (as Administrator if needed), then retry.';
   }
-  if (code === "DAEMON_NOT_READY") {
-    if (platform === "win32")
-      return "Start Docker Desktop manually, wait until it reports running, then relaunch Fox in the box.";
-    return "Open Docker Desktop and wait for daemon readiness, then relaunch Fox in the box.";
+  if (code === 'DAEMON_NOT_READY') {
+    if (platform === 'win32') return 'Start Docker Desktop manually, wait until it reports running, then relaunch Fox in the box.';
+    return 'Open Docker Desktop and wait for daemon readiness, then relaunch Fox in the box.';
   }
-  if (code === "DOCKER_WINDOWS_CONTAINERS_MODE") {
+  if (code === 'DOCKER_WINDOWS_CONTAINERS_MODE') {
     // v0.7.11 #291: Docker IS running but in the wrong mode. There's no
     // recovery to attempt — the user has to flip the switch themselves.
     return 'Docker Desktop is in Windows-containers mode. Fox needs Linux containers. Right-click the Docker Desktop tray icon → "Switch to Linux containers..." → wait for it to finish, then relaunch Fox in the box.';
   }
-  if (code === "IMAGE_PULL_TIMEOUT")
-    return "Check network connectivity and retry. Corporate proxies/firewalls can block container pulls.";
-  if (code === "HEALTH_TIMEOUT")
-    return "Container started but app is not healthy yet. Wait a bit longer or restart Docker and try again.";
-  if (code === "ACCESS_MODE_CANCELLED")
-    return "Relaunch Fox in the box and pick a network option, or set FOX_ACCESS_MODE=1|2|3 before starting.";
-  return "Check diagnostics and logs, then retry.";
+  if (code === 'IMAGE_PULL_TIMEOUT') return 'Check network connectivity and retry. Corporate proxies/firewalls can block container pulls.';
+  if (code === 'HEALTH_TIMEOUT') return 'Container started but app is not healthy yet. Wait a bit longer or restart Docker and try again.';
+  if (code === 'ACCESS_MODE_CANCELLED') return 'Relaunch Fox in the box and pick a network option, or set FOX_ACCESS_MODE=1|2|3 before starting.';
+  return 'Check diagnostics and logs, then retry.';
 }
 
 // Poll /api/tailscale/status until it returns a tailnet_url or we time out.
@@ -719,14 +630,12 @@ async function pollTailscaleUrl(timeoutMs = 30_000) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     try {
-      const res = await fetch("http://127.0.0.1:8787/api/tailscale/status");
+      const res = await fetch('http://127.0.0.1:8787/api/tailscale/status');
       if (res.ok) {
         const data = await res.json();
         if (data && data.tailnet_url) return data.tailnet_url;
       }
-    } catch (_) {
-      /* not yet */
-    }
+    } catch (_) { /* not yet */ }
     await new Promise((r) => setTimeout(r, 2_000));
   }
   return null;
@@ -734,28 +643,26 @@ async function pollTailscaleUrl(timeoutMs = 30_000) {
 
 async function openFox(tailnetUrl) {
   const mode = docker.getEffectiveAccessMode();
-  if ((mode === "2" || mode === "3") && tailnetUrl) {
-    const lines =
-      mode === "3"
-        ? `Local access: http://localhost:8787\nFrom other devices: ${tailnetUrl}`
-        : `From other devices: ${tailnetUrl}`;
+  if ((mode === '2' || mode === '3') && tailnetUrl) {
+    const lines = mode === '3'
+      ? `Local access: http://localhost:8787\nFrom other devices: ${tailnetUrl}`
+      : `From other devices: ${tailnetUrl}`;
     const { response } = await dialog.showMessageBox(getDialogParent(), {
-      type: "info",
-      title: "Fox in the box — Ready",
-      message: "Fox in the box is ready!",
-      detail: lines + "\n\nClick OK to open Fox.",
-      buttons: ["OK", "Copy Tailscale URL"],
+      type: 'info',
+      title: 'Fox in the box — Ready',
+      message: 'Fox in the box is ready!',
+      detail: lines + '\n\nClick OK to open Fox.',
+      buttons: ['OK', 'Copy Tailscale URL'],
       defaultId: 0,
     });
     if (response === 1) clipboard.writeText(tailnetUrl);
-  } else if ((mode === "2" || mode === "3") && !tailnetUrl) {
+  } else if ((mode === '2' || mode === '3') && !tailnetUrl) {
     await dialog.showMessageBox(getDialogParent(), {
-      type: "info",
-      title: "Fox in the box — Tailscale not connected yet",
-      message: "Tailscale hasn't connected yet.",
-      detail:
-        'Open the Tailscale app, sign in if prompted, and wait until it shows "Connected".\n\nFox is opening locally in the meantime. Once Tailscale connects, your tailnet URL will be available from the Tailscale menu.',
-      buttons: ["OK"],
+      type: 'info',
+      title: 'Fox in the box — Tailscale not connected yet',
+      message: 'Tailscale hasn\'t connected yet.',
+      detail: 'Open the Tailscale app, sign in if prompted, and wait until it shows "Connected".\n\nFox is opening locally in the meantime. Once Tailscale connects, your tailnet URL will be available from the Tailscale menu.',
+      buttons: ['OK'],
       defaultId: 0,
     });
   }
@@ -764,15 +671,15 @@ async function openFox(tailnetUrl) {
 
 async function waitForTailscale(progressCb) {
   const mode = docker.getEffectiveAccessMode();
-  if (mode !== "2" && mode !== "3") return null;
-  if (progressCb) progressCb("Waiting for Tailscale to connect…");
+  if (mode !== '2' && mode !== '3') return null;
+  if (progressCb) progressCb('Waiting for Tailscale to connect…');
   return pollTailscaleUrl(30_000);
 }
 
 async function startFromTray() {
-  showProgress("Starting Fox in the box…");
+  showProgress('Starting Fox in the box…');
   try {
-    if (typeof docker.ensureDockerAccessModeChosen === "function") {
+    if (typeof docker.ensureDockerAccessModeChosen === 'function') {
       await docker.ensureDockerAccessModeChosen({ parent: getDialogParent() });
     }
     await ensureContainerHealthy({
@@ -789,12 +696,11 @@ async function startFromTray() {
 async function handleStartupError(err) {
   _fatalStartup = true;
   closeProgress();
-  log.error("Fatal startup error:", err);
+  log.error('Fatal startup error:', err);
 
-  const phase = err instanceof StartupPhaseError ? err.phase : "unknown";
-  const code = err.code || (err.cause && err.cause.code) || "UNSPECIFIED";
-  const sessionId =
-    err.details && err.details.sessionId ? err.details.sessionId : "n/a";
+  const phase = err instanceof StartupPhaseError ? err.phase : 'unknown';
+  const code = err.code || (err.cause && err.cause.code) || 'UNSPECIFIED';
+  const sessionId = err.details && err.details.sessionId ? err.details.sessionId : 'n/a';
   const diagnostics = await docker.getDiagnostics().catch(() => ({}));
   if (err.meta) diagnostics.startupDiagnostics = err.meta;
   const remediation = getRemediationForCode(code, process.platform);
@@ -820,16 +726,15 @@ async function handleStartupError(err) {
 // ─── Main startup sequence ───────────────────────────────────────────────────
 
 async function main() {
-  log.info("Fox in the box starting up");
+  log.info('Fox in the box starting up');
   if (resumeAfterReboot) {
-    log.info("[startup] Post-reboot resume (--resume-setup)");
+    log.info('[startup] Post-reboot resume (--resume-setup)');
   }
 
-  const shortcutOk = globalShortcut.register("CommandOrControl+Shift+D", () => {
+  const shortcutOk = globalShortcut.register('CommandOrControl+Shift+D', () => {
     openDiagnosticWindow();
   });
-  if (!shortcutOk)
-    log.warn("Failed to register diagnostic shortcut Ctrl+Shift+D");
+  if (!shortcutOk) log.warn('Failed to register diagnostic shortcut Ctrl+Shift+D');
 
   _setupInProgress = true;
   let _tailnetUrl = null;
@@ -839,15 +744,14 @@ async function main() {
       waitUntilHealthy,
       ensureDockerWindows,
       installDockerMac,
-      waitForDaemon: (ms, sp) =>
-        _waitForDaemon(
-          () => docker.isDaemonRunning(),
-          ms || 180_000,
-          1_000,
-          Date.now,
-          (t) => new Promise((r) => setTimeout(r, t)),
-          sp || showProgress,
-        ),
+      waitForDaemon: (ms, sp) => _waitForDaemon(
+        () => docker.isDaemonRunning(),
+        ms || 180_000,
+        1_000,
+        Date.now,
+        (t) => new Promise((r) => setTimeout(r, t)),
+        sp || showProgress
+      ),
       showProgress,
       closeProgress,
       openOnboarding: () => openFox(_tailnetUrl),
@@ -858,7 +762,7 @@ async function main() {
       getDialogParent,
       platform: process.platform,
     });
-    if (startupOutcome && startupOutcome.outcome === "reboot-required") {
+    if (startupOutcome && startupOutcome.outcome === 'reboot-required') {
       _setupInProgress = false;
       app.quit();
       return;

--- a/packages/electron/src/startup-orchestrator.js
+++ b/packages/electron/src/startup-orchestrator.js
@@ -144,7 +144,7 @@ async function runStartup({
         return { outcome: 'reboot-required' };
       }
     } else if (platform === 'darwin') {
-      installProgress('Installing Docker Desktop…');
+      installProgress('Setting up Docker Desktop…');
       await installDockerMac(installProgress);
     } else {
       throw Object.assign(new Error('Unsupported desktop platform for one-click setup'), {

--- a/packages/electron/src/stdio-guard.js
+++ b/packages/electron/src/stdio-guard.js
@@ -6,12 +6,26 @@
 // event on the stream. With no handler installed, Node escalates it to an
 // uncaught exception and Electron shows a crash dialog. Logging must
 // never take the app down: swallow stream errors; the file transport is
-// unaffected and keeps the record.
+// unaffected and keeps the record. Non-EPIPE stream errors are recorded
+// once via the file transport so observability isn't lost entirely.
+
+let _warned = false;
 
 function installStdioGuard() {
-  for (const stream of [process.stdout, process.stderr]) {
-    if (stream && typeof stream.on === "function") {
-      stream.on("error", () => {});
+  for (const name of ['stdout', 'stderr']) {
+    const stream = process[name];
+    if (stream && typeof stream.on === 'function') {
+      stream.on('error', (err) => {
+        if (_warned || (err && err.code === 'EPIPE')) return;
+        _warned = true;
+        try {
+          // Lazy require: the guard installs before the logger loads, and
+          // electron-log's file transport is safe even when stdio is dead.
+          require('electron-log').warn(
+            `[stdio-guard] ${name} stream error: ${(err && (err.code || err.message)) || 'unknown'}`
+          );
+        } catch (_) { /* logging must never throw from here */ }
+      });
     }
   }
 }

--- a/packages/electron/src/stdio-guard.js
+++ b/packages/electron/src/stdio-guard.js
@@ -1,0 +1,19 @@
+// Guard stdout/stderr against EPIPE (#748).
+//
+// When the packaged app is launched from a terminal whose pipe later
+// closes (parent shell exits, launcher process dies), any console write —
+// electron-log's console transport included — raises an async 'error'
+// event on the stream. With no handler installed, Node escalates it to an
+// uncaught exception and Electron shows a crash dialog. Logging must
+// never take the app down: swallow stream errors; the file transport is
+// unaffected and keeps the record.
+
+function installStdioGuard() {
+  for (const stream of [process.stdout, process.stderr]) {
+    if (stream && typeof stream.on === "function") {
+      stream.on("error", () => {});
+    }
+  }
+}
+
+module.exports = { installStdioGuard };

--- a/tests/electron/manual-smoke-matrix.md
+++ b/tests/electron/manual-smoke-matrix.md
@@ -18,7 +18,7 @@ This matrix validates that desktop users can reach web onboarding in one click.
 2. Docker installed but stopped:
    - Stop Docker Desktop.
    - Launch app and verify daemon wait/recovery flow, then onboarding opens.
-   - **Assert no unprompted upgrade:** with an existing Docker Desktop install, the guided setup must not run `brew upgrade`/installer flows without explicit consent (#749 — design decision pending; record observed behavior).
+   - **Assert no unprompted upgrade (fixed, #749):** with Docker Desktop installed, the guided setup must start it (`open -a Docker`) and must never invoke Homebrew — install/upgrade runs only when `/Applications/Docker.app` is absent.
 3. Slow image pull:
    - Clear local image `ghcr.io/fox-in-the-box-ai/cloud:stable`.
    - Throttle network.
@@ -29,9 +29,9 @@ This matrix validates that desktop users can reach web onboarding in one click.
 5. Existing stopped named container:
    - Leave stopped `fox-in-the-box` container present.
    - Launch app and verify container is reused/started (no name-conflict crash).
-6. Terminal launch with closed stdout (#748):
+6. Terminal launch with closed stdout (#748, fixed):
    - Launch the packaged binary from a shell, then close/kill the parent shell.
-   - Verify no `EPIPE` uncaught-exception dialog (currently FAILS — known issue #748; record until fixed).
+   - Verify no `EPIPE` uncaught-exception dialog (stdio guard swallows stream errors; file logging unaffected).
 
 ## One-Click Success Assertion
 

--- a/tests/electron/stdio-guard.test.js
+++ b/tests/electron/stdio-guard.test.js
@@ -1,54 +1,68 @@
-"use strict";
+'use strict';
 
-const { EventEmitter } = require("events");
-const {
-  installStdioGuard,
-} = require("../../packages/electron/src/stdio-guard");
+jest.mock('electron-log', () => ({ info: jest.fn(), warn: jest.fn(), debug: jest.fn(), error: jest.fn() }));
 
-describe("installStdioGuard", () => {
+const { EventEmitter } = require('events');
+const log = require('electron-log');
+const { installStdioGuard } = require('../../packages/electron/src/stdio-guard');
+
+describe('installStdioGuard', () => {
   let originalStdout;
   let originalStderr;
 
   beforeEach(() => {
-    originalStdout = Object.getOwnPropertyDescriptor(process, "stdout");
-    originalStderr = Object.getOwnPropertyDescriptor(process, "stderr");
+    jest.clearAllMocks();
+    originalStdout = Object.getOwnPropertyDescriptor(process, 'stdout');
+    originalStderr = Object.getOwnPropertyDescriptor(process, 'stderr');
   });
 
   afterEach(() => {
-    Object.defineProperty(process, "stdout", originalStdout);
-    Object.defineProperty(process, "stderr", originalStderr);
+    Object.defineProperty(process, 'stdout', originalStdout);
+    Object.defineProperty(process, 'stderr', originalStderr);
   });
 
-  function swapStream(name) {
-    const fake = new EventEmitter();
-    Object.defineProperty(process, name, { value: fake, configurable: true });
-    return fake;
+  // Swap BOTH streams so the guard never attaches listeners to the real
+  // process streams during the test run.
+  function swapStreams() {
+    const out = new EventEmitter();
+    const err = new EventEmitter();
+    Object.defineProperty(process, 'stdout', { value: out, configurable: true });
+    Object.defineProperty(process, 'stderr', { value: err, configurable: true });
+    return { out, err };
   }
 
-  test("an EPIPE error on stdout no longer throws after the guard is installed", () => {
-    const fakeOut = swapStream("stdout");
-    const epipe = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+  test('an EPIPE error on stdout no longer throws after the guard is installed', () => {
+    const { out } = swapStreams();
+    const epipe = Object.assign(new Error('write EPIPE'), { code: 'EPIPE' });
 
     // Without a handler, EventEmitter turns 'error' into a throw — the
     // exact escalation path that produced the #748 crash dialog.
-    expect(() => fakeOut.emit("error", epipe)).toThrow("write EPIPE");
+    expect(() => out.emit('error', epipe)).toThrow('write EPIPE');
 
     installStdioGuard();
-    expect(() => fakeOut.emit("error", epipe)).not.toThrow();
+    expect(() => out.emit('error', epipe)).not.toThrow();
+    expect(log.warn).not.toHaveBeenCalled(); // EPIPE is expected noise — silent
   });
 
-  test("guards stderr as well", () => {
-    const fakeErr = swapStream("stderr");
+  test('guards stderr as well', () => {
+    const { err } = swapStreams();
     installStdioGuard();
-    expect(() => fakeErr.emit("error", new Error("write EPIPE"))).not.toThrow();
+    expect(() => err.emit('error', Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }))).not.toThrow();
   });
 
-  test("tolerates absent or handler-less streams", () => {
-    Object.defineProperty(process, "stdout", {
-      value: undefined,
-      configurable: true,
-    });
-    Object.defineProperty(process, "stderr", { value: {}, configurable: true });
+  test('a non-EPIPE stream error is swallowed but recorded once via the logger', () => {
+    const { out } = swapStreams();
+    installStdioGuard();
+    const weird = Object.assign(new Error('boom'), { code: 'EIO' });
+    expect(() => out.emit('error', weird)).not.toThrow();
+    expect(() => out.emit('error', weird)).not.toThrow();
+    expect(log.warn).toHaveBeenCalledTimes(1);
+    expect(log.warn.mock.calls[0][0]).toContain('EIO');
+  });
+
+  test('tolerates absent or handler-less streams', () => {
+    Object.defineProperty(process, 'stdout', { value: undefined, configurable: true });
+    Object.defineProperty(process, 'stderr', { value: {}, configurable: true });
     expect(() => installStdioGuard()).not.toThrow();
   });
 });

--- a/tests/electron/stdio-guard.test.js
+++ b/tests/electron/stdio-guard.test.js
@@ -1,0 +1,54 @@
+"use strict";
+
+const { EventEmitter } = require("events");
+const {
+  installStdioGuard,
+} = require("../../packages/electron/src/stdio-guard");
+
+describe("installStdioGuard", () => {
+  let originalStdout;
+  let originalStderr;
+
+  beforeEach(() => {
+    originalStdout = Object.getOwnPropertyDescriptor(process, "stdout");
+    originalStderr = Object.getOwnPropertyDescriptor(process, "stderr");
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "stdout", originalStdout);
+    Object.defineProperty(process, "stderr", originalStderr);
+  });
+
+  function swapStream(name) {
+    const fake = new EventEmitter();
+    Object.defineProperty(process, name, { value: fake, configurable: true });
+    return fake;
+  }
+
+  test("an EPIPE error on stdout no longer throws after the guard is installed", () => {
+    const fakeOut = swapStream("stdout");
+    const epipe = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+
+    // Without a handler, EventEmitter turns 'error' into a throw — the
+    // exact escalation path that produced the #748 crash dialog.
+    expect(() => fakeOut.emit("error", epipe)).toThrow("write EPIPE");
+
+    installStdioGuard();
+    expect(() => fakeOut.emit("error", epipe)).not.toThrow();
+  });
+
+  test("guards stderr as well", () => {
+    const fakeErr = swapStream("stderr");
+    installStdioGuard();
+    expect(() => fakeErr.emit("error", new Error("write EPIPE"))).not.toThrow();
+  });
+
+  test("tolerates absent or handler-less streams", () => {
+    Object.defineProperty(process, "stdout", {
+      value: undefined,
+      configurable: true,
+    });
+    Object.defineProperty(process, "stderr", { value: {}, configurable: true });
+    expect(() => installStdioGuard()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
Closes #748. Closes #749 (per founder decision: auto-upgrade only if needed — otherwise best practices).

- **#748**: `installStdioGuard()` (new `src/stdio-guard.js`) attaches error handlers on stdout/stderr before anything can write to the console, so a closed pipe (terminal launch → parent shell exits) can no longer escalate electron-log's console write into a crash dialog. Unit tests reproduce the exact EventEmitter escalation path (3 new tests, 141/141 suite green).
- **#749**: `installDockerMac` short-circuits when `/Applications/Docker.app` exists — Docker gets **started** (`open -a Docker`), Homebrew is never invoked, so an existing install can't be upgraded (and its running containers restarted) without consent. Homebrew — with its implicit upgrade of stale cask remnants — runs only when Docker Desktop is genuinely absent, which is the 'needed' case. A present-but-broken install still routes through the existing `MAC_DOCKER_LAUNCH_FAILED` / `DAEMON_NOT_READY` guidance.

Manual-smoke-matrix scenarios 2 and 6 updated from record-the-bug to assert-the-fix; CHANGELOG \[Unreleased\] entries included. No VERSION bump — ships with the next release on Electron 43.

## Test plan
- [x] 141/141 electron unit tests (incl. 3 new stdio-guard tests)
- [ ] CI green incl. electron-smoke macOS + Windows
- [ ] Post-merge packaged-app re-smoke: launch with Docker Desktop installed-but-stopped → orchestrator starts it, no brew output in diagnostics; kill parent shell → no EPIPE dialog