### PR TITLE
fix(ci): upstream-watch.yml duplicate env key — the nightly watch was dead

### DIFF
--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -194,7 +194,6 @@ jobs:
         if: steps.drift.outputs.no_drift != 'yes' && steps.basis.outputs.basis_rc == '0'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        env:
           # Tag names come from third-party repos — env-routed, never
           # interpolated into the script text (script-injection surface
           # with an issues:write token).


### PR DESCRIPTION
## Summary
Found while triaging failed pipelines: #767 added a second `env:` key to the update-available step (the existing one held `GH_TOKEN`). PyYAML keeps the last duplicate silently, so local validation passed — but GitHub's workflow validator rejects the file: every push since logged a zero-job failure named after the workflow file, and the 05:17 nightly silently stopped (no runs 2026-08-20/21).

- Gap audit: manual drift check shows both pins still match the latest upstream releases — the dead watch missed nothing
- All 13 workflow files scanned with actionlint for the duplicate-key/expression class: this was the only instance
- Post-merge: `gh workflow run upstream-watch.yml` to confirm revival

Follow-up filed for actionlint in CI (this is the same lint-blind-spot class the ps1 story had).

## Test plan
- [x] actionlint clean on the fixed file (remaining note is a pre-existing shellcheck style hint)
- [ ] CI green; post-merge dispatch runs end-to-end