### PR TITLE
feat(mem0_oss): Qdrant server mode — shared HTTP server, no file-lock contention

### DIFF
--- a/packages/fox-overlay/agent_memory_plugins/mem0_oss/__init__.py
+++ b/packages/fox-overlay/agent_memory_plugins/mem0_oss/__init__.py
@@ -42,6 +42,16 @@ Overrides (precedence: computed defaults < env < $HERMES_HOME/mem0_oss.json):
   MEM0_OSS_COLLECTION          — Qdrant collection name (default: hermes)
   MEM0_OSS_USER_ID             — memory namespace (default: hermes-user)
   MEM0_OSS_TOP_K               — max results per search (default: 10)
+  MEM0_OSS_QDRANT_URL          — Qdrant server URL (e.g. http://127.0.0.1:6333).
+                                 When set, mem0 connects to a SHARED Qdrant server
+                                 over HTTP instead of the embedded on-disk store.
+                                 Required when the Hermes gateway and WebUI run in
+                                 the same container — both load this provider and
+                                 fight over the embedded store's exclusive file lock,
+                                 causing intermittent "Qdrant lock still held" failures.
+  MEM0_OSS_QDRANT_HOST         — Qdrant server hostname (alternative to URL).
+  MEM0_OSS_QDRANT_PORT         — Qdrant server port (default: 6333 when HOST is set).
+  MEM0_OSS_QDRANT_API_KEY      — optional Qdrant API key for server auth.
 """
 
 from __future__ import annotations
@@ -1091,6 +1101,13 @@ def _load_runtime_config() -> dict:
         "collection": os.environ.get("MEM0_OSS_COLLECTION", "hermes"),
         "user_id": os.environ.get("MEM0_OSS_USER_ID", "hermes-user"),
         "top_k": int(os.environ.get("MEM0_OSS_TOP_K", "10")),
+        # Qdrant server mode — when a server URL or host is set, mem0 connects
+        # to the shared server (HTTP, no file lock) instead of the embedded
+        # store.  Both gateway and WebUI can safely share it concurrently.
+        "qdrant_url": os.environ.get("MEM0_OSS_QDRANT_URL", "").strip(),
+        "qdrant_host": os.environ.get("MEM0_OSS_QDRANT_HOST", "").strip(),
+        "qdrant_port": os.environ.get("MEM0_OSS_QDRANT_PORT", "6333").strip(),
+        "qdrant_api_key": os.environ.get("MEM0_OSS_QDRANT_API_KEY", "").strip(),
     }
     for key in (
         "vector_store_path",
@@ -1098,6 +1115,10 @@ def _load_runtime_config() -> dict:
         "collection",
         "user_id",
         "top_k",
+        "qdrant_url",
+        "qdrant_host",
+        "qdrant_port",
+        "qdrant_api_key",
     ):
         if key in file_cfg:
             config[key] = file_cfg[key]
@@ -1123,6 +1144,38 @@ def _build_llm_cfg(resolved: ResolvedConfig) -> dict:
     return cfg
 
 
+def _build_qdrant_cfg(runtime_cfg: dict, store_dims: int) -> dict:
+    """Build the Qdrant vector-store config dict for mem0ai.
+
+    When a server URL or host is configured, connects to the shared Qdrant
+    server over HTTP (no exclusive file lock) so gateway and WebUI can both
+    use memory concurrently.  Falls back to the embedded on-disk store when
+    no server endpoint is configured (backward compatible).
+    """
+    qdrant_url = (runtime_cfg.get("qdrant_url") or "").strip()
+    qdrant_host = (runtime_cfg.get("qdrant_host") or "").strip()
+    base = {
+        "collection_name": runtime_cfg["collection"],
+        "embedding_model_dims": store_dims,
+    }
+    if qdrant_url or qdrant_host:
+        if qdrant_url:
+            base["url"] = qdrant_url
+        else:
+            base["host"] = qdrant_host
+            try:
+                base["port"] = int(runtime_cfg.get("qdrant_port") or 6333)
+            except (TypeError, ValueError):
+                base["port"] = 6333
+        if runtime_cfg.get("qdrant_api_key"):
+            base["api_key"] = runtime_cfg["qdrant_api_key"]
+            base["https"] = qdrant_url.startswith("https://") if qdrant_url else False
+    else:
+        base["path"] = runtime_cfg["vector_store_path"]
+        base["on_disk"] = True
+    return base
+
+
 def _build_mem0_config(
     resolved: ResolvedConfig, embedder: dict, runtime_cfg: dict
 ) -> dict:
@@ -1130,12 +1183,7 @@ def _build_mem0_config(
     return {
         "vector_store": {
             "provider": "qdrant",
-            "config": {
-                "collection_name": runtime_cfg["collection"],
-                "path": runtime_cfg["vector_store_path"],
-                "embedding_model_dims": embedder["store_dims"],
-                "on_disk": True,
-            },
+            "config": _build_qdrant_cfg(runtime_cfg, embedder["store_dims"]),
         },
         "llm": {
             "provider": resolved.mem0_llm_provider,

--- a/packages/fox-overlay/tests/test_mem0_resolution.py
+++ b/packages/fox-overlay/tests/test_mem0_resolution.py
@@ -718,3 +718,111 @@ class TestNegativeInvariants:
         # auth.py's own resolve_provider (registry-space) — the plugin must
         # only use providers.resolve_provider_full.
         assert "from hermes_cli.auth import resolve_provider" not in source
+
+
+# ── Qdrant server mode ────────────────────────────────────────────────────────
+
+
+class TestQdrantServerMode:
+    """_build_qdrant_cfg returns a server or embedded config based on runtime_cfg.
+
+    Pure-function tests — no env fixture needed.
+    """
+
+    def _build(self, **kw):
+        from agent_memory_plugins.mem0_oss import _build_qdrant_cfg  # noqa: PLC0415
+
+        runtime = {
+            "collection": "hermes",
+            "vector_store_path": "/x/qdrant",
+            "qdrant_url": "",
+            "qdrant_host": "",
+            "qdrant_port": "6333",
+            "qdrant_api_key": "",
+        }
+        runtime.update(kw)
+        return _build_qdrant_cfg(runtime, store_dims=768)
+
+    def test_no_server_config_returns_embedded(self):
+        cfg = self._build()
+        assert cfg["path"] == "/x/qdrant"
+        assert cfg["on_disk"] is True
+        assert "url" not in cfg
+        assert "host" not in cfg
+
+    def test_url_returns_server_mode_no_path(self):
+        cfg = self._build(qdrant_url="http://127.0.0.1:6333")
+        assert cfg["url"] == "http://127.0.0.1:6333"
+        assert "path" not in cfg
+        assert "on_disk" not in cfg
+
+    def test_host_port_returns_server_mode(self):
+        cfg = self._build(qdrant_host="myhost", qdrant_port="6399")
+        assert cfg["host"] == "myhost"
+        assert cfg["port"] == 6399
+        assert "url" not in cfg
+        assert "path" not in cfg
+
+    def test_host_without_port_defaults_to_6333(self):
+        cfg = self._build(qdrant_host="myhost", qdrant_port="")
+        assert cfg["port"] == 6333
+
+    def test_bad_port_string_defaults_to_6333(self):
+        cfg = self._build(qdrant_host="myhost", qdrant_port="notanumber")
+        assert cfg["port"] == 6333
+
+    def test_api_key_added_when_set(self):
+        cfg = self._build(qdrant_url="http://127.0.0.1:6333", qdrant_api_key="secret")
+        assert cfg["api_key"] == "secret"
+        assert cfg["https"] is False  # http:// url
+
+    def test_https_flag_for_https_url(self):
+        cfg = self._build(
+            qdrant_url="https://qdrant.example.com", qdrant_api_key="tok"
+        )
+        assert cfg["https"] is True
+
+    def test_url_takes_precedence_over_host(self):
+        """When both url and host are set, url wins."""
+        cfg = self._build(
+            qdrant_url="http://127.0.0.1:6333", qdrant_host="otherhost"
+        )
+        assert cfg["url"] == "http://127.0.0.1:6333"
+        assert "host" not in cfg
+
+    def test_dims_forwarded(self):
+        from agent_memory_plugins.mem0_oss import _build_qdrant_cfg  # noqa: PLC0415
+
+        runtime = {
+            "collection": "hermes",
+            "vector_store_path": "/x",
+            "qdrant_url": "http://127.0.0.1:6333",
+            "qdrant_host": "",
+            "qdrant_port": "6333",
+            "qdrant_api_key": "",
+        }
+        cfg = _build_qdrant_cfg(runtime, store_dims=384)
+        assert cfg["embedding_model_dims"] == 384
+
+    def test_runtime_config_reads_env_vars(self, monkeypatch):
+        """_load_runtime_config picks up MEM0_OSS_QDRANT_* env vars."""
+        from agent_memory_plugins.mem0_oss import _load_runtime_config  # noqa: PLC0415
+
+        monkeypatch.setenv("MEM0_OSS_QDRANT_URL", "http://qdrant.local:6333")
+        monkeypatch.setenv("MEM0_OSS_QDRANT_API_KEY", "mykey")
+        cfg = _load_runtime_config()
+        assert cfg["qdrant_url"] == "http://qdrant.local:6333"
+        assert cfg["qdrant_api_key"] == "mykey"
+
+    def test_runtime_config_file_override_qdrant(self, tmp_path, monkeypatch):
+        """mem0_oss.json overrides take effect for qdrant server keys."""
+        import json  # noqa: PLC0415
+        from agent_memory_plugins.mem0_oss import _load_runtime_config  # noqa: PLC0415
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("MEM0_OSS_QDRANT_URL", raising=False)
+        (tmp_path / "mem0_oss.json").write_text(
+            json.dumps({"qdrant_url": "http://fileserver:6333"}), encoding="utf-8"
+        )
+        cfg = _load_runtime_config()
+        assert cfg["qdrant_url"] == "http://fileserver:6333"


### PR DESCRIPTION
## Summary

The `mem0_oss` plugin hardcodes embedded on-disk Qdrant (`path` + `on_disk: True`), which takes an **exclusive file lock**. When the Hermes gateway and WebUI both run in the same container (standard Fox topology), each loads this provider and they fight over that single lock → intermittent `"Qdrant lock still held after 10 attempts — giving up"` memory failures, making long-term memory unreliable.

## Changes

**`packages/fox-overlay/agent_memory_plugins/mem0_oss/__init__.py`**:
- `_load_runtime_config()`: add `qdrant_url`, `qdrant_host`, `qdrant_port`, `qdrant_api_key` keys from `MEM0_OSS_QDRANT_*` env vars and `mem0_oss.json` file overrides
- `_build_qdrant_cfg()`: new pure-function helper that returns a server config (with `url`/host/port/api_key) when a server endpoint is configured, or the existing embedded `path` + `on_disk` fallback
- `_build_mem0_config()`: delegate vector-store config to `_build_qdrant_cfg()`
- Docstring: document the new env vars

**`packages/fox-overlay/tests/test_mem0_resolution.py`**:
- 11 new test cases for `_build_qdrant_cfg`: URL, host+port, embedded fallback, API key + https, precedence, dims, env-var loading, file-override

## Backwards compatibility

Zero breaking changes. When no `MEM0_OSS_QDRANT_URL` or `MEM0_OSS_QDRANT_HOST` is set, the plugin uses the existing embedded store unchanged. Server mode is opt-in.

## Verification

All 36 existing tests pass plus 11 new (47 total). Syntax-validated with `py_compile`. Verified end-to-end on a live Fox instance:
- Write → local embed → Qdrant server → semantic search → recall
- No lock contention between gateway and WebUI processes