### PR TITLE
bump(upstream): hermes-agent v2026.8.18 → v2026.8.31

### DIFF
--- a/packages/fox-overlay/versions.toml
+++ b/packages/fox-overlay/versions.toml
@@ -17,7 +17,7 @@ hermes_agent_url = "https://github.com/NousResearch/hermes-agent"
 
 [meta]
 pinned_at = "2026-09-02"
-pinned_in_pr = "PENDING"
+pinned_in_pr = "fox-in-the-box-ai/fox-in-the-box#791"
 phase = "option-b-bump"
 notes = "Agent-only bump v2026.8.18 to v2026.8.31 (upstream 0.20.4 to 0.21.0, ~3,091 commits; closes #790; webui stays v0.52.113). Anchor audit: gateway/run.py static patch applies cleanly at the new tag; all four cron_diagnostics substitution anchors (create_job, _mark_job_run_locked, run_job FAILED template, _format_job) present exactly once in the new function bodies; auxiliary_client anchors byte-identical. Dep delta: uvicorn floor 0.24 to 0.31 (lock already at 0.49.0), psutil pinned 7.2.2 upstream (lock matches), new exact-pinned firecrawl-anydoc==0.2.4 + snowballstemmer==3.1.1 float in via upstream; requirements.lock untouched."
 

--- a/packages/fox-overlay/versions.toml
+++ b/packages/fox-overlay/versions.toml
@@ -12,14 +12,14 @@
 [upstream]
 hermes_webui_tag = "v0.52.113"
 hermes_webui_url = "https://github.com/nesquena/hermes-webui"
-hermes_agent_tag = "v2026.8.18"
+hermes_agent_tag = "v2026.8.31"
 hermes_agent_url = "https://github.com/NousResearch/hermes-agent"
 
 [meta]
-pinned_at = "2026-08-19"
-pinned_in_pr = "fox-in-the-box-ai/fox-in-the-box#764"
+pinned_at = "2026-09-02"
+pinned_in_pr = "PENDING"
 phase = "option-b-bump"
-notes = "Agent-only bump v2026.8.16.2 to v2026.8.18 (closes #763; webui stays v0.52.113). Basis CLEAN per upstream-watch run 2026-08-19 and CI validate-overlay; only upstream dep delta is hermes-agent 0.20.3 to 0.20.4 (no third-party changes, requirements.lock untouched). Case-colliding contributors/emails caveat from v2026.8.16.2 persists — macOS checkouts stay phantom-dirty."
+notes = "Agent-only bump v2026.8.18 to v2026.8.31 (upstream 0.20.4 to 0.21.0, ~3,091 commits; closes #790; webui stays v0.52.113). Anchor audit: gateway/run.py static patch applies cleanly at the new tag; all four cron_diagnostics substitution anchors (create_job, _mark_job_run_locked, run_job FAILED template, _format_job) present exactly once in the new function bodies; auxiliary_client anchors byte-identical. Dep delta: uvicorn floor 0.24 to 0.31 (lock already at 0.49.0), psutil pinned 7.2.2 upstream (lock matches), new exact-pinned firecrawl-anydoc==0.2.4 + snowballstemmer==3.1.1 float in via upstream; requirements.lock untouched."
 
 [history]
 prior_pins = [

--- a/packages/fox-overlay/versions.toml
+++ b/packages/fox-overlay/versions.toml
@@ -24,6 +24,7 @@ notes = "Agent-only bump v2026.8.18 to v2026.8.31 (upstream 0.20.4 to 0.21.0, ~3
 [history]
 prior_pins = [
   # newest first
+  "webui=v0.52.113, agent=v2026.8.18 -- upstream bump #764 (2026-08-19)",
   "webui=v0.52.113, agent=v2026.8.16.2 -- upstream bump #740 (2026-08-18)",
   "webui=v0.52.0, agent=v2026.7.7.2 -- upstream bump #644 (2026-07-10)",
   "webui=v0.51.537, agent=v2026.6.19 -- patch refresh bump #604 (2026-06-20)",


### PR DESCRIPTION
## Summary
Option B agent-only pin bump, from the revived upstream-watch's #790. Upstream 0.20.4 → 0.21.0 — a large jump (~3,091 commits / 300 files), so the pre-bump audit was done against a clone of both tags rather than trusting the release notes:

- **Static patch:** `gateway/run.py` bootstrap shim `git apply --check` passes at v2026.8.31
- **Monkey-patch anchors:** all four `cron_diagnostics` substitution anchors (`create_job`, `_mark_job_run_locked`, the `run_job` FAILED template, `_format_job`) present **exactly once** in the new function bodies (the bodies changed around the anchors, not through them); every scope variable the replacements reference still exists; `auxiliary_client` anchor functions are byte-identical between tags
- **Deps:** uvicorn floor 0.24 → 0.31 (lock already at 0.49.0), psutil upstream-pinned 7.2.2 (lock matches), new exact-pinned `firecrawl-anydoc==0.2.4` + `snowballstemmer==3.1.1` install at upstream's pins (constraints don't block unlisted packages) — `requirements.lock` untouched
- WebUI stays v0.52.113 (still upstream latest; nesquena quiet since 08-26, see #785)

Per Option B: container-only ship — `:stable` advances on the squash-merge `bump(upstream):` subject; no Fox version bump, no desktop rebuild.

## Test plan
- [x] Anchor/patch audit at the new tag (above)
- [ ] CI: overlay validation, container build, image self-test, smoke, Playwright
- [ ] Post-merge: verify `:stable` advanced on GHCR

Closes #790