### PR TITLE
chore: refresh requirements.lock for hermes-agent 0.21.0

### DIFF
--- a/docs/SECURITY_POSTURE.md
+++ b/docs/SECURITY_POSTURE.md
@@ -28,7 +28,7 @@ On AWS VMs, the instance metadata service (IMDS) makes the machine's default ins
 
 **Open Dependabot alerts: 0** (as of 2026-08-18 — js-yaml 4.3.1 and protobufjs 7.6.5 cleared the last npm alerts). The long-tracked **GHSA-537c-gmf6-5ccf accepted risk is CLOSED**: upstream hermes-agent previously hard-pinned `cryptography` below the 48.0.1 fix; since the v0.52.113 / v2026.8.16.2 pin bump, `requirements.lock` carries `cryptography==50.0.0`.
 
-`packages/integration/requirements.lock` is itself a supply-chain control: 94 exact pins for every Python package in the container, consumed as a pip **constraints** file (`-c`) at build time so transitive resolution cannot drift silently between builds; CI fails on freeze drift.
+`packages/integration/requirements.lock` is itself a supply-chain control: 96 exact pins for every Python package in the container, consumed as a pip **constraints** file (`-c`) at build time so transitive resolution cannot drift silently between builds; the amd64 smoke job compares the image freeze against the lock (warning-only today — hard-gate + arm64 coverage tracked in #795).
 
 ### Triage policy for container-scan (Trivy) alert categories
 

--- a/packages/fox-overlay/versions.toml
+++ b/packages/fox-overlay/versions.toml
@@ -19,7 +19,7 @@ hermes_agent_url = "https://github.com/NousResearch/hermes-agent"
 pinned_at = "2026-09-02"
 pinned_in_pr = "fox-in-the-box-ai/fox-in-the-box#791"
 phase = "option-b-bump"
-notes = "Agent-only bump v2026.8.18 to v2026.8.31 (upstream 0.20.4 to 0.21.0, ~3,091 commits; closes #790; webui stays v0.52.113). Anchor audit: gateway/run.py static patch applies cleanly at the new tag; all four cron_diagnostics substitution anchors (create_job, _mark_job_run_locked, run_job FAILED template, _format_job) present exactly once in the new function bodies; auxiliary_client anchors byte-identical. Dep delta: uvicorn floor 0.24 to 0.31 (lock already at 0.49.0), psutil pinned 7.2.2 upstream (lock matches), new exact-pinned firecrawl-anydoc==0.2.4 + snowballstemmer==3.1.1 float in via upstream; requirements.lock untouched."
+notes = "Agent-only bump v2026.8.18 to v2026.8.31 (upstream 0.20.4 to 0.21.0, ~3,091 commits; closes #790; webui stays v0.52.113). Anchor audit: gateway/run.py static patch applies cleanly at the new tag; all four cron_diagnostics substitution anchors (create_job, _mark_job_run_locked, run_job FAILED template, _format_job) present exactly once in the new function bodies; auxiliary_client anchors byte-identical. Dep delta: uvicorn floor 0.24 to 0.31 (lock already at 0.49.0), psutil pinned 7.2.2 upstream (lock matches), new exact-pinned firecrawl-anydoc==0.2.4 + snowballstemmer==3.1.1 float in via upstream; requirements.lock untouched (refreshed separately in #793 for #792)."
 
 [history]
 prior_pins = [

--- a/packages/integration/requirements.lock
+++ b/packages/integration/requirements.lock
@@ -1,6 +1,6 @@
 # Frozen Python dependencies for the Fox container image.
 # Generated from ghcr.io/fox-in-the-box-ai/cloud:v0.7.51 on 2026-06-20,
-# refreshed for hermes-agent v2026.8.16.2 (2026-08-17).
+# refreshed for hermes-agent v2026.8.31 / 0.21.0 (2026-09-02, #792).
 # hermes-agent hard-pins cryptography==50.0.0 in pyproject.toml — this
 # CLOSES the long-tracked GHSA-537c-gmf6-5ccf accepted risk (fix was
 # 48.0.1; 46.0.7 was below it while upstream pinned there).
@@ -21,6 +21,11 @@
 # in embedded path mode only, intentionally independent of the standalone
 # Qdrant v1.9.4 server binary). protobuf 7.35.1 -> 6.33.6 because mem0ai
 # 2.0.10 requires protobuf<7.0.0,>=5.29.6 (pip check clean on the full set).
+# 2026-09-02: +firecrawl-anydoc==0.2.4 (upstream 0.21.0 document-to-Markdown
+# extraction; genuine firecrawl org, MIT, zero runtime deps; hosted OCR is
+# opt-in via FIRECRAWL_API_KEY which the Fox image never sets — default
+# ocr="reject" is fully offline) + snowballstemmer==3.1.1 (zero deps).
+
 annotated-doc==0.0.4
 annotated-types==0.7.0
 anthropic==0.87.0
@@ -38,6 +43,7 @@ distro==1.9.0
 docstring_parser==0.18.0
 fastapi==0.138.0
 fire==0.7.1
+firecrawl-anydoc==0.2.4
 google-api-core==2.31.0
 google-api-python-client==2.194.0
 google-auth-httplib2==0.3.1
@@ -99,6 +105,7 @@ ruamel.yaml==0.18.17
 s3transfer==0.16.1
 six==1.17.0
 sniffio==1.3.1
+snowballstemmer==3.1.1
 socksio==1.0.0
 SQLAlchemy==2.0.52
 starlette==1.3.1

--- a/packages/integration/requirements.lock
+++ b/packages/integration/requirements.lock
@@ -25,7 +25,6 @@
 # extraction; genuine firecrawl org, MIT, zero runtime deps; hosted OCR is
 # opt-in via FIRECRAWL_API_KEY which the Fox image never sets — default
 # ocr="reject" is fully offline) + snowballstemmer==3.1.1 (zero deps).
-
 annotated-doc==0.0.4
 annotated-types==0.7.0
 anthropic==0.87.0


### PR DESCRIPTION
## Summary
Lock refresh from #792 (board follow-up on #791):

- Two pins added — `firecrawl-anydoc==0.2.4`, `snowballstemmer==3.1.1` — inserted in place so the diff stays surgical; the pin set now matches `pip freeze --exclude-editable` of the shipped `:stable` (agent 0.21.0) exactly: 96 pins, no other version moved, and notably **no new transitives** (both packages have zero runtime deps, resolving the #791 board's determinism concern empty)
- Provenance verified: PyPI package points to the genuine `firecrawl/anydoc` org repo (~20k stars, MIT); not yanked; hosted OCR is opt-in via `FIRECRAWL_API_KEY` (never set in the Fox image) with agent-side gating in `read_extract.py` — default `ocr="reject"` makes the shipped path fully offline
- Header provenance line + dated note updated per file convention

## Test plan
- [x] `diff` of lock pins vs live image freeze: exact match
- [ ] CI green

Closes #792