### PR TITLE
fix(qa): shared onboarding-race helper for smoke specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - Provider-settings smoke spec no longer flakes when a parallel spec resets onboarding mid-test; the nightly failure tracked by #775 was this race, not an endpoint break (#778).
+- The onboarding-reset race guard is now a shared helper covering the sibling smoke specs with the same window (contract-skillset, hostname-overlay, contract-endpoints-sweep), with redirects disabled so the raced 302 is actually visible to the retry (#794).
 
 ### Changed
 

--- a/qa/playwright/tests/helpers/onboarding.ts
+++ b/qa/playwright/tests/helpers/onboarding.ts
@@ -7,7 +7,9 @@
  * the skip and the request re-enters onboarding and the request gets HTML
  * instead of JSON. Nightly runs with 0 retries by design, so the guard
  * lives here: re-skip immediately before each of up to 3 attempts, and
- * return as soon as the status is one the caller accepts.
+ * return as soon as the status is one the caller accepts. Requests set
+ * maxRedirects: 0 — otherwise the raced 302 is silently followed to the
+ * onboarding page's 200 HTML and the retry loop never sees the race.
  *
  * The final response is returned WITHOUT asserting — callers keep their own
  * status assertions so failure messages stay spec-specific. A genuinely
@@ -15,7 +17,7 @@
  * diagnostics after 3 bounded attempts (the retry absorbs at most 2
  * transient wrong-status responses; see #779 for the trade-off record).
  */
-import type { APIRequestContext, APIResponse } from "@playwright/test";
+import type { APIRequestContext, APIResponse } from '@playwright/test';
 
 const ATTEMPTS = 3;
 
@@ -27,7 +29,7 @@ export async function getSkippingOnboarding(
   let res!: APIResponse;
   for (let attempt = 0; attempt < ATTEMPTS; attempt++) {
     await api.post("/api/setup/skip");
-    res = await api.get(path);
+    res = await api.get(path, { maxRedirects: 0 });
     if (okStatuses.includes(res.status())) break;
   }
   return res;
@@ -42,7 +44,7 @@ export async function postSkippingOnboarding(
   let res!: APIResponse;
   for (let attempt = 0; attempt < ATTEMPTS; attempt++) {
     await api.post("/api/setup/skip");
-    res = await api.post(path, { data });
+    res = await api.post(path, { data, maxRedirects: 0 });
     if (okStatuses.includes(res.status())) break;
   }
   return res;

--- a/qa/playwright/tests/helpers/onboarding.ts
+++ b/qa/playwright/tests/helpers/onboarding.ts
@@ -1,0 +1,49 @@
+/**
+ * Onboarding-reset race guard for smoke specs (#779, generalized from #778).
+ *
+ * Endpoints outside the onboarding whitelist 302-redirect to the onboarding
+ * HTML page whenever the app is in onboarding state. Specs call
+ * /api/setup/skip first, but a parallel spec's /test/reset landing between
+ * the skip and the request re-enters onboarding and the request gets HTML
+ * instead of JSON. Nightly runs with 0 retries by design, so the guard
+ * lives here: re-skip immediately before each of up to 3 attempts, and
+ * return as soon as the status is one the caller accepts.
+ *
+ * The final response is returned WITHOUT asserting — callers keep their own
+ * status assertions so failure messages stay spec-specific. A genuinely
+ * broken endpoint therefore fails the caller's assertion with the caller's
+ * diagnostics after 3 bounded attempts (the retry absorbs at most 2
+ * transient wrong-status responses; see #779 for the trade-off record).
+ */
+import type { APIRequestContext, APIResponse } from "@playwright/test";
+
+const ATTEMPTS = 3;
+
+export async function getSkippingOnboarding(
+  api: APIRequestContext,
+  path: string,
+  okStatuses: number[] = [200],
+): Promise<APIResponse> {
+  let res!: APIResponse;
+  for (let attempt = 0; attempt < ATTEMPTS; attempt++) {
+    await api.post("/api/setup/skip");
+    res = await api.get(path);
+    if (okStatuses.includes(res.status())) break;
+  }
+  return res;
+}
+
+export async function postSkippingOnboarding(
+  api: APIRequestContext,
+  path: string,
+  data: unknown = {},
+  okStatuses: number[] = [200],
+): Promise<APIResponse> {
+  let res!: APIResponse;
+  for (let attempt = 0; attempt < ATTEMPTS; attempt++) {
+    await api.post("/api/setup/skip");
+    res = await api.post(path, { data });
+    if (okStatuses.includes(res.status())) break;
+  }
+  return res;
+}

--- a/qa/playwright/tests/smoke/contract-endpoints-sweep.spec.ts
+++ b/qa/playwright/tests/smoke/contract-endpoints-sweep.spec.ts
@@ -12,6 +12,7 @@
  * upstream's default-path handler).
  */
 import { test, expect, request } from '@playwright/test';
+import { getSkippingOnboarding } from '../helpers/onboarding';
 
 const CONTRACT_ENDPOINTS: Array<{ path: string; ok: number[] }> = [
   { path: '/version', ok: [200] },
@@ -28,8 +29,7 @@ test.describe('Contract + Fox endpoints sweep', () => {
   for (const { path, ok } of CONTRACT_ENDPOINTS) {
     test(`${path} registered (status in {${ok.join(', ')}})`, async ({ baseURL }) => {
       const api = await request.newContext({ baseURL });
-      await api.post('/api/setup/skip');
-      const res = await api.get(path);
+      const res = await getSkippingOnboarding(api, path, ok);
       const status = res.status();
       expect(
         ok.includes(status),

--- a/qa/playwright/tests/smoke/contract-skillset.spec.ts
+++ b/qa/playwright/tests/smoke/contract-skillset.spec.ts
@@ -28,6 +28,7 @@ test.describe('Contract — /skillset', () => {
   test('response body has expected shape', async ({ baseURL }) => {
     const api = await request.newContext({ baseURL });
     const res = await getSkippingOnboarding(api, '/skillset', [200, 404]);
+    expect([200, 404], '/skillset must return 200 or 404').toContain(res.status());
     const body = await res.json();
     if (res.status() === 200) {
       expect(body, '200 response must have a name field').toHaveProperty('name');

--- a/qa/playwright/tests/smoke/contract-skillset.spec.ts
+++ b/qa/playwright/tests/smoke/contract-skillset.spec.ts
@@ -5,18 +5,17 @@
  * skillset is loaded. In standalone mode the default is 404; in managed
  * mode Fleet injects a manifest at provision time.
  *
- * /skillset is not in the onboarding whitelist — call /api/setup/skip
- * first to prevent 302 redirect when running in parallel with tests
- * that call /test/reset.
+ * /skillset is not in the onboarding whitelist — requests go through
+ * the shared onboarding helper (#779) to survive parallel tests that
+ * call /test/reset.
  */
 import { test, expect, request } from '@playwright/test';
+import { getSkippingOnboarding } from '../helpers/onboarding';
 
 test.describe('Contract — /skillset', () => {
   test('returns 200 or 404 with JSON', async ({ baseURL }) => {
     const api = await request.newContext({ baseURL });
-    await api.post('/api/setup/skip');
-
-    const res = await api.get('/skillset');
+    const res = await getSkippingOnboarding(api, '/skillset', [200, 404]);
     const status = res.status();
     expect(
       [200, 404].includes(status),
@@ -28,9 +27,7 @@ test.describe('Contract — /skillset', () => {
 
   test('response body has expected shape', async ({ baseURL }) => {
     const api = await request.newContext({ baseURL });
-    await api.post('/api/setup/skip');
-
-    const res = await api.get('/skillset');
+    const res = await getSkippingOnboarding(api, '/skillset', [200, 404]);
     const body = await res.json();
     if (res.status() === 200) {
       expect(body, '200 response must have a name field').toHaveProperty('name');

--- a/qa/playwright/tests/smoke/hostname-overlay.spec.ts
+++ b/qa/playwright/tests/smoke/hostname-overlay.spec.ts
@@ -5,18 +5,17 @@
  * to populate the instance name in the panel. A broken hostname
  * endpoint means Fleet shows "unknown" for newly provisioned instances.
  *
- * /api/settings/hostname is not in the onboarding whitelist — call
- * /api/setup/skip first to prevent 302 redirect when running in
- * parallel with tests that call /test/reset.
+ * /api/settings/hostname is not in the onboarding whitelist — requests
+ * go through the shared onboarding helper (#779) to survive parallel
+ * tests that call /test/reset.
  */
 import { test, expect, request } from '@playwright/test';
+import { getSkippingOnboarding, postSkippingOnboarding } from '../helpers/onboarding';
 
 test.describe('Hostname overlay', () => {
   test('GET /api/settings/hostname returns state object', async ({ baseURL }) => {
     const api = await request.newContext({ baseURL });
-    await api.post('/api/setup/skip');
-
-    const res = await api.get('/api/settings/hostname');
+    const res = await getSkippingOnboarding(api, '/api/settings/hostname');
     expect(res.status(), '/api/settings/hostname must return 200').toBe(200);
     const body = await res.json();
     expect(body, 'response must have a configured field').toHaveProperty('configured');
@@ -25,11 +24,7 @@ test.describe('Hostname overlay', () => {
 
   test('POST /api/settings/hostname/dismiss-prompt returns ok', async ({ baseURL }) => {
     const api = await request.newContext({ baseURL });
-    await api.post('/api/setup/skip');
-
-    const res = await api.post('/api/settings/hostname/dismiss-prompt', {
-      data: {},
-    });
+    const res = await postSkippingOnboarding(api, '/api/settings/hostname/dismiss-prompt');
     expect(
       res.status(),
       'POST /api/settings/hostname/dismiss-prompt must return 200 — dismissing the ' +

--- a/qa/playwright/tests/smoke/provider-settings.spec.ts
+++ b/qa/playwright/tests/smoke/provider-settings.spec.ts
@@ -8,36 +8,20 @@
  * Response shape (upstream hermes-webui api/providers.py):
  *   { providers: [{id, display_name, has_key, configurable, ...}], active_provider: string }
  *
- * /api/providers is not in the onboarding whitelist — tests go
- * through getProvidersJson below, which re-skips onboarding before
- * each attempt to survive parallel tests calling /test/reset.
+ * /api/providers is not in the onboarding whitelist — requests go
+ * through the shared onboarding helper (#779) to survive parallel
+ * tests calling /test/reset.
  */
 import { test, expect, request } from '@playwright/test';
-import type { APIRequestContext } from '@playwright/test';
-
-/**
- * skip + GET with retry: a parallel test calling /test/reset between our
- * /api/setup/skip and the GET flips the app back into onboarding, and the
- * GET 302s to the onboarding HTML page. Re-skipping immediately before
- * each attempt narrows the window; the last attempt asserts status so a
- * real endpoint break fails with the status, not a JSON SyntaxError.
- */
-async function getProvidersJson(api: APIRequestContext) {
-  let res;
-  for (let attempt = 0; attempt < 3; attempt++) {
-    await api.post('/api/setup/skip');
-    res = await api.get('/api/providers');
-    if (res.status() === 200) return res.json();
-  }
-  expect(res!.status(), '/api/providers must return 200').toBe(200);
-  return res!.json();
-}
+import { getSkippingOnboarding } from '../helpers/onboarding';
 
 test.describe('Provider settings', () => {
   test('GET /api/providers returns provider object with list', async ({ baseURL }) => {
     const api = await request.newContext({ baseURL });
 
-    const body = await getProvidersJson(api);
+    const res = await getSkippingOnboarding(api, '/api/providers');
+    expect(res.status(), '/api/providers must return 200').toBe(200);
+    const body = await res.json();
     expect(body, 'response must have a providers key').toHaveProperty('providers');
     expect(Array.isArray(body.providers), 'providers must be an array').toBe(true);
   });
@@ -45,7 +29,9 @@ test.describe('Provider settings', () => {
   test('each provider has required display fields', async ({ baseURL }) => {
     const api = await request.newContext({ baseURL });
 
-    const body = await getProvidersJson(api);
+    const res = await getSkippingOnboarding(api, '/api/providers');
+    expect(res.status(), '/api/providers must return 200').toBe(200);
+    const body = await res.json();
     const providers = body.providers;
     if (providers.length > 0) {
       const first = providers[0];


### PR DESCRIPTION
## Summary
Closes #779 (board follow-up from #778): generalizes the skip-and-retry pattern into `tests/helpers/onboarding.ts` and routes the sibling specs carrying the same onboarding-reset race through it:

- `contract-skillset` — was parsing `.json()` before any status check, the exact #775 SyntaxError class
- `hostname-overlay` — GET + POST variants
- `contract-endpoints-sweep` — parameterized per-path accepted-status lists
- `provider-settings` — local #778 helper replaced by the shared one; status assertions stay in the spec

Design choice vs #778's local helper: the shared helper returns the final response **without asserting**, so each spec keeps its own diagnostics on genuine breakage (bounded at 3 attempts; absorbs at most 2 transient wrong-status responses — same trade recorded in #779). `model-picker` is deliberately excluded: it calls `/test/reset` on purpose to test fresh-install state, and wrapping it would invert those semantics.

## Test plan
- [x] Full smoke project against live `:stable`: 41 passed
- [x] Race-stress: refactored specs + both reset-callers, `--repeat-each=3` in parallel: 42 passed
- [ ] CI green