### PR TITLE
ci: actionlint gate for workflow files + finish env-routing in upstream-watch

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+# Self-hosted runner labels used by this repo's workflows (#777).
+# windows-real-smoke.yml targets the founder-managed Windows box.
+self-hosted-runner:
+  labels:
+    - fitb-runner-01

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,45 @@
+# Workflow-validity gate (#777).
+#
+# GitHub validates workflow files server-side; an invalid file produces
+# only a zero-job "workflow file" failure run on push and silently stops
+# that workflow's schedule — the in-workflow `if: failure()` handlers
+# structurally cannot fire for this class (no job ever starts). A
+# duplicate `env:` key merged in #767 killed the upstream-watch nightly
+# for two days this way: PyYAML accepts duplicate keys locally, GitHub's
+# schema does not. actionlint catches duplicates, expression typos, and
+# (via shellcheck, preinstalled on ubuntu runners) run-block issues.
+name: Workflow Lint
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Download actionlint (pinned, checksum-verified)
+        run: |
+          set -eu
+          version=1.7.12
+          sha256=8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+          curl -sSfLo actionlint.tar.gz \
+              "https://github.com/rhysd/actionlint/releases/download/v${version}/actionlint_${version}_linux_amd64.tar.gz"
+          echo "${sha256}  actionlint.tar.gz" | sha256sum -c -
+          tar -xzf actionlint.tar.gz actionlint
+          rm actionlint.tar.gz
+
+      - name: Run actionlint
+        run: ./actionlint -color

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -80,10 +80,10 @@ jobs:
           # in-app version display is never blank — previously these built
           # with FITB_VERSION="" which surfaced as empty version strings on
           # :latest / :stable images. FITB#122 cosmetic.
-          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-            echo "fitb_version=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            echo "fitb_version=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
           else
-            SHORT_SHA="$(echo "${{ github.sha }}" | cut -c1-7)"
+            SHORT_SHA="$(echo "$GITHUB_SHA" | cut -c1-7)"
             echo "fitb_version=dev-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
           fi
           RUNTIME_VERSION=$(grep '^hermes_webui_tag' packages/fox-overlay/versions.toml | sed 's/.*= *"\(.*\)"/\1/')
@@ -182,9 +182,10 @@ jobs:
           # Source list = name@sha256:<digest> for each per-platform image.
           # `printf '%s '` over the artifact filenames, with an explicit
           # name@sha256: prefix.
-          SOURCES=$(printf "${IMAGE}@sha256:%s " *)
-          echo "Sources: $SOURCES"
-          docker buildx imagetools create -t "${IMAGE}:${TAG}" $SOURCES
+          SOURCES=()
+          for f in *; do SOURCES+=("${IMAGE}@sha256:${f}"); done
+          echo "Sources: ${SOURCES[*]}"
+          docker buildx imagetools create -t "${IMAGE}:${TAG}" "${SOURCES[@]}"
           # Capture the index digest from the freshly-pushed manifest list.
           # `inspect --raw` returns the canonical bytes; their content
           # digest IS the manifest-list digest. Use --format for stability.
@@ -465,7 +466,7 @@ jobs:
             -p 127.0.0.1:8787:8787 \
             "${IMAGE}@${DIGEST}"
 
-          for i in $(seq 1 36); do
+          for _ in $(seq 1 36); do
             RESP=$(curl -fsS http://localhost:8787/health 2>/dev/null) || RESP=""
             if [[ -n "$RESP" ]] && echo "$RESP" | grep -q '"status": "ok"'; then
               RETRY_ELAPSED=$(( $(date +%s) - RETRY_START ))

--- a/.github/workflows/option-b-diff-guard.yml
+++ b/.github/workflows/option-b-diff-guard.yml
@@ -71,6 +71,8 @@ jobs:
           violations=$(echo "$changed" | grep -Ev "$ALLOWED_RE" || true)
           if [ -n "$violations" ]; then
             echo "::error::Option B violation. A PR titled 'bump(upstream): …' must touch ONLY the upstream submodule pointers, packages/fox-overlay/, and this guard workflow. The following files are out-of-bounds for an Option B PR:"
+            # Per-line prefix on a multiline var; ${var//} has no per-line form.
+            # shellcheck disable=SC2001
             echo "$violations" | sed 's/^/::error::  - /'
             echo "::error::If this PR is supposed to include Fox-code changes, rename it to drop the 'bump(upstream):' prefix. If the auto-bump should apply but you also need a code change, split into two PRs."
             exit 1

--- a/.github/workflows/option-b-diff-guard.yml
+++ b/.github/workflows/option-b-diff-guard.yml
@@ -71,7 +71,7 @@ jobs:
           violations=$(echo "$changed" | grep -Ev "$ALLOWED_RE" || true)
           if [ -n "$violations" ]; then
             echo "::error::Option B violation. A PR titled 'bump(upstream): …' must touch ONLY the upstream submodule pointers, packages/fox-overlay/, and this guard workflow. The following files are out-of-bounds for an Option B PR:"
-            # Per-line prefix on a multiline var; ${var//} has no per-line form.
+            # Per-line prefix on a multiline var; ${var//} has no per-line form (#777 documented exception).
             # shellcheck disable=SC2001
             echo "$violations" | sed 's/^/::error::  - /'
             echo "::error::If this PR is supposed to include Fox-code changes, rename it to drop the 'bump(upstream):' prefix. If the auto-bump should apply but you also need a code change, split into two PRs."

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -171,7 +171,7 @@ jobs:
 
       - name: Wait for /health
         run: |
-          for i in $(seq 1 30); do
+          for _ in $(seq 1 30); do
             if curl -sf http://127.0.0.1:880${{ matrix.shard }}/health > /dev/null; then
               exit 0
             fi

--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -121,12 +121,21 @@ jobs:
 
       - name: Determine drift
         id: drift
+        env:
+          # latest_* are third-party-controlled tag names — env-routed,
+          # never interpolated into script text. pinned_* are
+          # repo-controlled (versions.toml) but routed the same way for
+          # consistency.
+          PINNED_WEBUI: ${{ steps.pinned.outputs.webui_tag }}
+          PINNED_AGENT: ${{ steps.pinned.outputs.agent_tag }}
+          LATEST_WEBUI: ${{ steps.latest.outputs.webui }}
+          LATEST_AGENT: ${{ steps.latest.outputs.agent }}
         run: |
           set -eu
-          pinned_webui="${{ steps.pinned.outputs.webui_tag }}"
-          pinned_agent="${{ steps.pinned.outputs.agent_tag }}"
-          latest_webui="${{ steps.latest.outputs.webui }}"
-          latest_agent="${{ steps.latest.outputs.agent }}"
+          pinned_webui="$PINNED_WEBUI"
+          pinned_agent="$PINNED_AGENT"
+          latest_webui="$LATEST_WEBUI"
+          latest_agent="$LATEST_AGENT"
 
           webui_drift="no"; agent_drift="no"
           if [ "$pinned_webui" != "$latest_webui" ] && [ -n "$latest_webui" ]; then
@@ -160,18 +169,27 @@ jobs:
       - name: Check overlay basis against latest tags
         id: basis
         if: steps.drift.outputs.no_drift != 'yes'
+        env:
+          # Tag names are third-party-controlled; a crafted refname must
+          # not reach script text (this job's token has issues:write and
+          # checkout persists credentials). git checkout "$VAR" treats
+          # the value as data.
+          LATEST_WEBUI: ${{ steps.latest.outputs.webui }}
+          LATEST_AGENT: ${{ steps.latest.outputs.agent }}
+          WEBUI_DRIFT: ${{ steps.drift.outputs.webui_drift }}
+          AGENT_DRIFT: ${{ steps.drift.outputs.agent_drift }}
         run: |
           set +e  # we want to capture rather than fail-fast
           # Temporarily check out the latest tag in each submodule that drifted.
-          if [ "${{ steps.drift.outputs.webui_drift }}" = "yes" ]; then
+          if [ "$WEBUI_DRIFT" = "yes" ]; then
               ( cd forks/hermes-webui && \
                 git fetch origin --tags --quiet && \
-                git checkout "${{ steps.latest.outputs.webui }}" --quiet )
+                git checkout "$LATEST_WEBUI" --quiet )
           fi
-          if [ "${{ steps.drift.outputs.agent_drift }}" = "yes" ]; then
+          if [ "$AGENT_DRIFT" = "yes" ]; then
               ( cd forks/hermes-agent && \
                 git fetch origin --tags --quiet && \
-                git checkout "${{ steps.latest.outputs.agent }}" --quiet )
+                git checkout "$LATEST_AGENT" --quiet )
           fi
 
           # Run the overlay basis check.

--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -69,13 +69,15 @@ jobs:
           agent_tag=$(grep -E '^hermes_agent_tag\s*=' "$file" | awk -F'"' '{print $2}')
           webui_url=$(grep -E '^hermes_webui_url\s*=' "$file" | awk -F'"' '{print $2}')
           agent_url=$(grep -E '^hermes_agent_url\s*=' "$file" | awk -F'"' '{print $2}')
-          echo "webui_tag=$webui_tag" >> "$GITHUB_OUTPUT"
-          echo "agent_tag=$agent_tag" >> "$GITHUB_OUTPUT"
-          echo "webui_url=$webui_url" >> "$GITHUB_OUTPUT"
-          echo "agent_url=$agent_url" >> "$GITHUB_OUTPUT"
-          # Derive owner/repo from URL for the GitHub API call below.
-          echo "webui_repo=$(echo "$webui_url" | sed -E 's#https?://github.com/##; s#\.git$##')" >> "$GITHUB_OUTPUT"
-          echo "agent_repo=$(echo "$agent_url" | sed -E 's#https?://github.com/##; s#\.git$##')" >> "$GITHUB_OUTPUT"
+          {
+            echo "webui_tag=$webui_tag"
+            echo "agent_tag=$agent_tag"
+            echo "webui_url=$webui_url"
+            echo "agent_url=$agent_url"
+            # Derive owner/repo from URL for the GitHub API call below.
+            echo "webui_repo=$(echo "$webui_url" | sed -E 's#https?://github.com/##; s#\.git$##')"
+            echo "agent_repo=$(echo "$agent_url" | sed -E 's#https?://github.com/##; s#\.git$##')"
+          } >> "$GITHUB_OUTPUT"
           echo "pinned: webui=$webui_tag, agent=$agent_tag"
 
       - name: Resolve latest upstream tags
@@ -201,15 +203,17 @@ jobs:
           PINNED_AGENT: ${{ steps.pinned.outputs.agent_tag }}
           LATEST_WEBUI: ${{ steps.latest.outputs.webui }}
           LATEST_AGENT: ${{ steps.latest.outputs.agent }}
+          WEBUI_DRIFT: ${{ steps.drift.outputs.webui_drift }}
+          AGENT_DRIFT: ${{ steps.drift.outputs.agent_drift }}
         run: |
           set -eu
           # Title names ONLY drifted components — "webui vX → vX" in #763
           # read as a false webui update.
           parts=""
-          if [ "${{ steps.drift.outputs.webui_drift }}" = "yes" ]; then
+          if [ "$WEBUI_DRIFT" = "yes" ]; then
               parts="webui $PINNED_WEBUI → $LATEST_WEBUI"
           fi
-          if [ "${{ steps.drift.outputs.agent_drift }}" = "yes" ]; then
+          if [ "$AGENT_DRIFT" = "yes" ]; then
               parts="${parts:+$parts, }agent $PINNED_AGENT → $LATEST_AGENT"
           fi
           title="[upstream-watch] Update available: $parts"
@@ -231,16 +235,16 @@ jobs:
 
           | Component | Pinned | Latest | Drift |
           |-----------|--------|--------|-------|
-          | webui     | ${{ steps.pinned.outputs.webui_tag }} | ${{ steps.latest.outputs.webui }} | ${{ steps.drift.outputs.webui_drift }} |
-          | agent     | ${{ steps.pinned.outputs.agent_tag }} | ${{ steps.latest.outputs.agent }} | ${{ steps.drift.outputs.agent_drift }} |
+          | webui     | $PINNED_WEBUI | $LATEST_WEBUI | $WEBUI_DRIFT |
+          | agent     | $PINNED_AGENT | $LATEST_AGENT | $AGENT_DRIFT |
 
           \`check-overlay-basis.sh\` against the new tags returned 0 — overlay anchors + \`.fox-removals\` entries are all stable against the proposed bump.
 
           ## To bump
 
           \`\`\`
-          cd forks/hermes-webui && git fetch origin --tags && git checkout ${{ steps.latest.outputs.webui }}
-          cd forks/hermes-agent && git fetch origin --tags && git checkout ${{ steps.latest.outputs.agent }}
+          cd forks/hermes-webui && git fetch origin --tags && git checkout $LATEST_WEBUI
+          cd forks/hermes-agent && git fetch origin --tags && git checkout $LATEST_AGENT
           # Then edit packages/fox-overlay/versions.toml + open a PR
           \`\`\`
 
@@ -265,15 +269,26 @@ jobs:
         if: steps.drift.outputs.no_drift != 'yes' && steps.basis.outputs.basis_rc != '0'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Third-party-derived values (tag names, script output over
+          # upstream content) — env-routed, never interpolated into the
+          # script text (script-injection surface with an issues:write
+          # token). Same rule as the update-available step.
+          PINNED_WEBUI: ${{ steps.pinned.outputs.webui_tag }}
+          PINNED_AGENT: ${{ steps.pinned.outputs.agent_tag }}
+          LATEST_WEBUI: ${{ steps.latest.outputs.webui }}
+          LATEST_AGENT: ${{ steps.latest.outputs.agent }}
+          WEBUI_DRIFT: ${{ steps.drift.outputs.webui_drift }}
+          AGENT_DRIFT: ${{ steps.drift.outputs.agent_drift }}
+          BASIS_OUTPUT: ${{ steps.basis.outputs.basis_output }}
         run: |
           set -eu
           # Same only-drifted-components rule as the update-available title.
           parts=""
-          if [ "${{ steps.drift.outputs.webui_drift }}" = "yes" ]; then
-              parts="webui ${{ steps.latest.outputs.webui }}"
+          if [ "$WEBUI_DRIFT" = "yes" ]; then
+              parts="webui $LATEST_WEBUI"
           fi
-          if [ "${{ steps.drift.outputs.agent_drift }}" = "yes" ]; then
-              parts="${parts:+$parts / }agent ${{ steps.latest.outputs.agent }}"
+          if [ "$AGENT_DRIFT" = "yes" ]; then
+              parts="${parts:+$parts / }agent $LATEST_AGENT"
           fi
           title="[upstream-drift] Overlay anchors drift against $parts"
           # Dedupe: same drift target already reported → re-fire as a
@@ -292,15 +307,15 @@ jobs:
 
           | Component | Pinned | Latest |
           |-----------|--------|--------|
-          | webui     | ${{ steps.pinned.outputs.webui_tag }} | ${{ steps.latest.outputs.webui }} |
-          | agent     | ${{ steps.pinned.outputs.agent_tag }} | ${{ steps.latest.outputs.agent }} |
+          | webui     | $PINNED_WEBUI | $LATEST_WEBUI |
+          | agent     | $PINNED_AGENT | $LATEST_AGENT |
 
           \`check-overlay-basis.sh\` against the proposed new tags returned non-zero. **Anchor/manifest refresh required BEFORE bumping the submodule pointer**.
 
           ## check-overlay-basis output
 
           \`\`\`
-          ${{ steps.basis.outputs.basis_output }}
+          $BASIS_OUTPUT
           \`\`\`
 
           ## Resolution playbook (per script's exit-banner)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- CI lints workflow files with actionlint (pinned, checksum-verified) — GitHub's server-side validator rejections previously surfaced only as zero-job push failures while silently stopping schedules (#777, the #767 duplicate-env incident class).
 - Provider-settings smoke spec no longer flakes when a parallel spec resets onboarding mid-test; the nightly failure tracked by #775 was this race, not an endpoint break (#778).
 
 ### Changed
@@ -19,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Security
 
+- upstream-watch no longer interpolates third-party-controlled values (upstream tag names, basis-check output) into workflow script text holding an issues:write token; all such values are env-routed (#777, completing #767).
 - Container base layer now applies Debian security upgrades at build time (`apt-get upgrade -y`) — packages frozen at the python:3.11-slim snapshot no longer ship known-fixed CVEs; clears the fixable portion of the container-scan backlog (#755)
 - js-yaml resolved to 4.3.1 in both lockfiles (root pnpm-lock.yaml and packages/electron/package-lock.json), clearing all four open js-yaml advisories. Corrects the 0.7.60 record: that entry listed js-yaml 4.3.1 in its security batch, but the lockfiles still resolved 4.2.0 at release time — this change is what lands it.
 - protobufjs resolved to 7.6.5 in both lockfiles, clearing the last two open dependabot alerts; with the js-yaml 4.3.1 bump this takes the open alert count to zero


### PR DESCRIPTION
## Summary
Closes #777 (filed after the #767 duplicate-env incident silently killed the upstream-watch nightly for two days — GitHub's server-side validator rejects a file that PyYAML accepts, and no in-workflow handler can fire for a zero-job failure).

**Part 1 — the gate:** path-filtered `actionlint` job over `.github/workflows/**` (v1.7.12 pinned, checksum-verified download; shellcheck integration uses the runner's preinstalled binary). `.github/actionlint.yaml` declares the `fitb-runner-01` self-hosted label so windows-real-smoke lints clean.

**Part 2 — make the tree lint-clean by fixing, not silencing:**
- `build-container`: tag detection now compares `$GITHUB_REF` directly (SC2193 — actionlint's dummy-value substitution exposed the `${{ }}`-in-comparison antipattern); manifest sources built as a bash array instead of intentional word-splitting (SC2086); unused wait-loop var (SC2034)
- `playwright`: unused wait-loop var (SC2034)
- `option-b-diff-guard`: one documented shellcheck exception (SC2001 — no parameter-expansion form exists for per-line prefixing)
- `upstream-watch`: `GITHUB_OUTPUT` appends grouped (SC2129)

**Part 3 — completes #767's injection hardening** (folded into #777's scope at filing): upstream-watch's issue-body heredocs and drift conditions now take tag names, drift flags, and `check-overlay-basis` output via `env:` instead of interpolating step outputs into script text — third-party-controlled strings no longer touch a script body holding an `issues:write` token.

## Test plan
- [x] `actionlint` v1.7.12 with shellcheck: clean across all 15 workflow files
- [x] PyYAML parse of edited workflows
- [ ] CI green (the new gate runs on this PR since it touches workflows — it self-tests)
- [ ] Post-merge: `workflow_dispatch` upstream-watch to confirm the env-routed steps still open/dedupe issues correctly