### PR TITLE
fix(ci): tripwire issue lookups retry instead of swallowing API failures

### DIFF
--- a/.github/scripts/tripwire-common.sh
+++ b/.github/scripts/tripwire-common.sh
@@ -13,6 +13,34 @@ RUN_URL="${GITHUB_SERVER_URL:-https://github.com}/${REPO}/actions/runs/${GITHUB_
 # carry correct provenance.
 SOURCE_WORKFLOW="${GITHUB_WORKFLOW:-upstream-tripwires.yml}"
 
+# Bounded-retry gh issue lookup (#774): a transient API failure (429,
+# network) must not read as "no matching issue" — in the fire path that
+# stacks a duplicate, in the ack path it re-fires an acknowledged
+# condition, and in the clear path it silently skips the close. Retry
+# 3x with backoff; on exhaustion fail the script so the workflow's
+# self-health handler reports the API outage once, instead of every
+# tripwire guessing wrong. (Immediate exit-1 without retry was rejected
+# in #774: one 429 blip would fail all ten tripwires.)
+# Uses TW_TITLE from the environment for both the server-side search
+# narrowing and the exact jq match — same injection rule as the callers.
+_tw_issue_numbers() {
+    local state="$1"
+    local attempt out
+    for attempt in 1 2 3; do
+        if out=$(gh issue list --repo "$REPO" --state "$state" --limit 100 \
+                   --search "in:title \"$TW_TITLE\"" \
+                   --json number,title \
+                   -q '.[] | select(.title == env.TW_TITLE) | .number' 2>&1); then
+            printf '%s\n' "$out"
+            return 0
+        fi
+        echo "[tripwire] gh issue list ($state) failed (attempt $attempt/3): $out" >&2
+        [ "$attempt" -lt 3 ] && sleep $((attempt * 5))
+    done
+    echo "::error::gh issue list ($state) failed after 3 attempts — cannot determine tripwire issue state for: $TW_TITLE"
+    return 1
+}
+
 # Open or re-fire an issue. De-dupe by exact title match.
 #
 # Usage:
@@ -44,11 +72,8 @@ tripwire_fire() {
 
     if [ "$mode" = "ack_dedupe" ]; then
         local acked
-        acked=$(gh issue list --repo "$REPO" --state closed --limit 100 \
-                  --search "in:title \"$title\"" \
-                  --json number,title \
-                  -q '.[] | select(.title == env.TW_TITLE) | .number' \
-                  2>/dev/null | head -1)
+        acked=$(_tw_issue_numbers closed)
+        acked=$(printf '%s' "$acked" | head -1)
         if [ -n "$acked" ]; then
             echo "[tripwire] condition previously acknowledged in closed #$acked — skipping re-fire"
             return 0
@@ -56,11 +81,8 @@ tripwire_fire() {
     fi
 
     local existing
-    existing=$(gh issue list --repo "$REPO" --state open --limit 100 \
-                 --search "in:title \"$title\"" \
-                 --json number,title \
-                 -q '.[] | select(.title == env.TW_TITLE) | .number' \
-                 2>/dev/null | head -1)
+    existing=$(_tw_issue_numbers open)
+    existing=$(printf '%s' "$existing" | head -1)
 
     if [ -n "$existing" ]; then
         gh issue comment "$existing" --repo "$REPO" --body "$(printf '%s\n\n_Re-fired on %s_' "$body" "$RUN_URL")"
@@ -105,11 +127,7 @@ tripwire_clear() {
 
     export TW_TITLE="$title"
     local numbers
-    numbers=$(gh issue list --repo "$REPO" --state open --limit 100 \
-                 --search "in:title \"$title\"" \
-                 --json number,title \
-                 -q '.[] | select(.title == env.TW_TITLE) | .number' \
-                 2>/dev/null)
+    numbers=$(_tw_issue_numbers open)
 
     if [ -z "$numbers" ]; then
         return 0

--- a/.github/scripts/tripwire-common.sh
+++ b/.github/scripts/tripwire-common.sh
@@ -25,18 +25,25 @@ SOURCE_WORKFLOW="${GITHUB_WORKFLOW:-upstream-tripwires.yml}"
 # narrowing and the exact jq match — same injection rule as the callers.
 _tw_issue_numbers() {
     local state="$1"
-    local attempt out
+    local attempt out err errfile
+    errfile=$(mktemp)
     for attempt in 1 2 3; do
+        # stderr goes to a file, NOT 2>&1 — a success-with-warning would
+        # otherwise mix warning text into the captured number list and
+        # head -1 could read a warning line as an issue number.
         if out=$(gh issue list --repo "$REPO" --state "$state" --limit 100 \
                    --search "in:title \"$TW_TITLE\"" \
                    --json number,title \
-                   -q '.[] | select(.title == env.TW_TITLE) | .number' 2>&1); then
+                   -q '.[] | select(.title == env.TW_TITLE) | .number' 2>"$errfile"); then
+            rm -f "$errfile"
             printf '%s\n' "$out"
             return 0
         fi
-        echo "[tripwire] gh issue list ($state) failed (attempt $attempt/3): $out" >&2
+        err=$(cat "$errfile" 2>/dev/null || true)
+        echo "[tripwire] gh issue list ($state) failed (attempt $attempt/3): $err" >&2
         [ "$attempt" -lt 3 ] && sleep $((attempt * 5))
     done
+    rm -f "$errfile"
     echo "::error::gh issue list ($state) failed after 3 attempts — cannot determine tripwire issue state for: $TW_TITLE"
     return 1
 }

--- a/.github/scripts/tripwire-common.sh
+++ b/.github/scripts/tripwire-common.sh
@@ -17,9 +17,12 @@ SOURCE_WORKFLOW="${GITHUB_WORKFLOW:-upstream-tripwires.yml}"
 # network) must not read as "no matching issue" — in the fire path that
 # stacks a duplicate, in the ack path it re-fires an acknowledged
 # condition, and in the clear path it silently skips the close. Retry
-# 3x with backoff; on exhaustion fail the script so the workflow's
-# self-health handler reports the API outage once, instead of every
-# tripwire guessing wrong. (Immediate exit-1 without retry was rejected
+# 3x with backoff; on exhaustion fail the script. In
+# upstream-tripwires.yml the self-health handler then reports the API
+# outage once; the other sourcing workflows (build-container
+# main_push_health, playwright cron_health) have no such backstop — an
+# exhaustion there fails the handler step, so the signal is the red
+# run itself, not an issue. (Immediate exit-1 without retry was rejected
 # in #774: one 429 blip would fail all ten tripwires.)
 # Uses TW_TITLE from the environment for both the server-side search
 # narrowing and the exact jq match — same injection rule as the callers.
@@ -27,6 +30,8 @@ _tw_issue_numbers() {
     local state="$1"
     local attempt out err errfile
     errfile=$(mktemp)
+    # shellcheck disable=SC2064 -- expand errfile now; it never changes
+    trap "rm -f '$errfile'" RETURN
     for attempt in 1 2 3; do
         # stderr goes to a file, NOT 2>&1 — a success-with-warning would
         # otherwise mix warning text into the captured number list and

--- a/.github/scripts/tripwire-common.sh
+++ b/.github/scripts/tripwire-common.sh
@@ -44,7 +44,9 @@ _tw_issue_numbers() {
         [ "$attempt" -lt 3 ] && sleep $((attempt * 5))
     done
     rm -f "$errfile"
-    echo "::error::gh issue list ($state) failed after 3 attempts — cannot determine tripwire issue state for: $TW_TITLE"
+    # >&2: inside $(…) capture, stdout is swallowed into the (discarded)
+    # assignment — the annotation must ride stderr to reach the job log.
+    echo "::error::gh issue list ($state) failed after 3 attempts — cannot determine tripwire issue state for: $TW_TITLE" >&2
     return 1
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Provider-settings smoke spec no longer flakes when a parallel spec resets onboarding mid-test; the nightly failure tracked by #775 was this race, not an endpoint break (#778).
 - The onboarding-reset race guard is now a shared helper covering the sibling smoke specs with the same window (contract-skillset, hostname-overlay, contract-endpoints-sweep), with redirects disabled so the raced 302 is actually visible to the retry (#794).
+- Tripwire issue lookups no longer read a failed GitHub API call as "no matching issue" — the three lookup paths (fire dedupe, ack dedupe, auto-clear) retry with backoff and fail loud on exhaustion instead of stacking duplicates, re-firing acknowledged conditions, or silently skipping closes (#797).
 
 ### Changed
 


### PR DESCRIPTION
## Summary
Closes #774 (deferred from the #773 fail-loud wave with a design note). The three `gh issue list` calls in `tripwire-common.sh` discarded errors (`2>/dev/null`) and treated failure as "no matching issue", with a different bad outcome per path:

- **fire/existing lookup** → duplicate issue stacked next to the open one
- **ack_dedupe lookup** → re-fires a condition a human already dispositioned (the #747-after-#723 class)
- **clear lookup** → auto-close silently skipped, leaving a stale open tripwire

New `_tw_issue_numbers` helper: 3 attempts with 5s/10s backoff, then `::error` + fail the script so the workflow's self-health handler reports the API outage once. Immediate exit-1 without retry was explicitly rejected in #774 — a single 429 blip would have failed all ten tripwires at once. `TW_TITLE` stays env-routed for both the server-side search and the exact jq match (same injection rule as before). Pipe-masking avoided: capture first, `head -1` second (`set -o pipefail` is deliberately not flipped repo-wide).

## Test plan
- [x] `bash -n` + shellcheck clean (SC2148 pre-existing: sourced file, no shebang by design)
- [ ] CI green
- [ ] Next scheduled tripwire run green (all ten tripwires exercise the helper via fire-or-clear paths)