### PR TITLE
fix(ci): shellcheck directive prose broke the sourced-file parse

### DIFF
--- a/.github/scripts/tripwire-common.sh
+++ b/.github/scripts/tripwire-common.sh
@@ -30,7 +30,8 @@ _tw_issue_numbers() {
     local state="$1"
     local attempt out err errfile
     errfile=$(mktemp)
-    # shellcheck disable=SC2064 -- expand errfile now; it never changes
+    # Expand errfile now (it never changes) — hence double quotes.
+    # shellcheck disable=SC2064
     trap "rm -f '$errfile'" RETURN
     for attempt in 1 2 3; do
         # stderr goes to a file, NOT 2>&1 — a success-with-warning would

--- a/.github/scripts/tripwire-cve-feed.sh
+++ b/.github/scripts/tripwire-cve-feed.sh
@@ -27,7 +27,7 @@ check_repo_advisories() {
     fi
 
     echo "$advisories" | while IFS= read -r adv; do
-        local ghsa_id severity summary description html_url
+        local ghsa_id severity summary html_url
         ghsa_id=$(echo "$adv" | jq -r '.ghsa_id // ""')
         severity=$(echo "$adv" | jq -r '.severity // "unknown"')
         summary=$(echo "$adv" | jq -r '.summary // .description // ""' | head -c 200)

--- a/.github/scripts/tripwire-nous-ui-watch.sh
+++ b/.github/scripts/tripwire-nous-ui-watch.sh
@@ -46,7 +46,7 @@ If NousResearch ships an official UI, the calculus for depending on \`nesquena/h
 
 ## Actions
 
-- [ ] Inspect the directory: https://github.com/$AGENT_REPO/tree/$AGENT_BRANCH/$(echo $matches | awk '{print $1}')
+- [ ] Inspect the directory: https://github.com/$AGENT_REPO/tree/$AGENT_BRANCH/$(echo "$matches" | awk '{print $1}')
 - [ ] Read NousResearch's announcement / discussion / README context
 - [ ] Strategic review with Dennis — does this change v0.7.x / v0.8.x direction?
 - [ ] If false positive (dir exists for unrelated reasons), close this issue

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -10,14 +10,20 @@
 # (via shellcheck, preinstalled on ubuntu runners) run-block issues.
 name: Workflow Lint
 
+# Scripts are included in the paths: shellcheck follows `source
+# .github/scripts/…` from run blocks (SC1094 on parse failure), so a
+# scripts-only change can break the gate for every workflow — #797 did
+# exactly that while the filter was workflows-only.
 on:
   pull_request:
     paths:
       - '.github/workflows/**'
+      - '.github/scripts/**'
   push:
     branches: [main]
     paths:
       - '.github/workflows/**'
+      - '.github/scripts/**'
 
 permissions:
   contents: read

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -49,3 +49,11 @@ jobs:
 
       - name: Run actionlint
         run: ./actionlint -color
+
+      - name: Shellcheck the bash-invoked CI scripts
+        # actionlint only follows `source` targets; the per-tripwire
+        # scripts are run via `bash path` and would otherwise stay
+        # unlinted while this gate goes green on their PRs. Severity
+        # bar: warning — info-level findings (SC1091 dynamic source,
+        # intentional word-splitting) are noise for these ops scripts.
+        run: shellcheck --severity=warning -x -s bash .github/scripts/*.sh


### PR DESCRIPTION
## Summary
The actionlint gate's first live catch (#799 failed on it, though the failure wasn't dependabot's doing): #797's `# shellcheck disable=SC2064 -- prose` uses invalid directive syntax — shellcheck aborts parsing `tripwire-common.sh` (SC1094) and actionlint fails every workflow that sources it. The same mistake was made and fixed once already in option-b-diff-guard during #796; this one slipped through because the 774 branch predated the gate and scripts-only changes never triggered it.

Two changes:
- Prose moved to its own comment line above the bare directive (shellcheck + actionlint clean locally)
- **Gate path filter widened to `.github/scripts/**`** — sourced scripts are part of actionlint's parse surface, so a scripts-only change can break the gate for every workflow; now it runs on those PRs too (and self-tests on this one)

## Test plan
- [x] shellcheck parses the sourced file clean
- [x] actionlint clean across all workflows locally
- [ ] CI green — the widened gate now runs on this PR and proves both changes together