### PR TITLE
fix(deps): fast-uri 3.1.7 in both lockfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Security
 
+- fast-uri bumped to 3.1.7 in both lockfiles, clearing the eight high advisories of 2026-09-02 (fixed in 3.1.6); dev/build tooling consumer (ajv via the electron toolchain), not shipped runtime
 - Dependency-alert wave of 2026-09-01/02: browserslist 4.28.8 in both lockfiles (two high — untrusted browserslist-stats crash / prototype write, unbounded cache growth; via the grouped dependency PRs) and @xmldom/xmldom 0.8.15 / 0.9.12 in both lockfiles (three medium — XML fragment injection via invalid EntityReference.nodeName). All build-time or test tooling; none of the vulnerable paths ship in the container or desktop runtime.
 - upstream-watch no longer interpolates third-party-controlled values (upstream tag names, basis-check output) into workflow script text holding an issues:write token; all such values are env-routed (#777, completing #767).
 - Container base layer now applies Debian security upgrades at build time (`apt-get upgrade -y`) — packages frozen at the python:3.11-slim snapshot no longer ship known-fixed CVEs; clears the fixable portion of the container-scan backlog (#755)

--- a/packages/electron/package-lock.json
+++ b/packages/electron/package-lock.json
@@ -14,7 +14,7 @@
         "electron-updater": "^6.8.9"
       },
       "devDependencies": {
-        "electron": "^44.0.0",
+        "electron": "^44.1.1",
         "electron-builder": "^26.15.3",
         "electron-builder-squirrel-windows": "26.15.3",
         "jest": "^30.5.0",
@@ -4427,9 +4427,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1250,8 +1250,8 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
@@ -3243,7 +3243,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3824,7 +3824,7 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fb-watchman@2.0.2:
     dependencies:


### PR DESCRIPTION
## Summary
Clears dependabot alerts 139–146 (eight high, advisory published today): fast-uri < 3.1.6. Both lockfiles move 3.1.5 → **3.1.7** (latest 3.x; 4.x exists but ajv's `^3.0.1` range makes 3.x the correct target — not an incomplete bump). Integrity hashes registry-verified in review; sole consumer is `ajv` under electron-builder dev tooling — nothing ships in the container or desktop runtime.

**Record correction from review:** the npm diff is *not* purely fast-uri — 2 of its 10 lines realign the lock's root devDependencies mirror `electron ^44.0.0 → ^44.1.1`. That is the load-bearing completion of #805's manifest bump (main's `package.json` says `^44.1.1` but the lock mirror still said `^44.0.0`, so `npm ci` on main was still broken — undetected because no PR job exercises the npm lock, which is exactly #806). The line stays; the record now says so.

## Test plan
- [x] Both lockfiles resolve fast-uri 3.1.7 only; vulnerable ranges fully vacated
- [x] `pnpm install --frozen-lockfile` passes locally
- [ ] CI green