### PR TITLE
ci: keep electron out of grouped dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,14 @@ updates:
     groups:
       root-deps:
         patterns: ["*"]
+        # electron stays out of grouped bumps: a grouped PR once changed
+        # packages/electron/package.json to a new electron MAJOR while
+        # regenerating only the pnpm lockfile (#788 -> #806 incident),
+        # silently promoting a runtime major and breaking npm ci.
+        # Ungrouped, an electron update arrives as its own clearly-named
+        # PR that can be held for the packaged-smoke arc (#750/#802
+        # pattern).
+        exclude-patterns: ["electron"]
 
   - package-ecosystem: npm
     directory: /packages/electron
@@ -24,6 +32,8 @@ updates:
     groups:
       electron-deps:
         patterns: ["*"]
+        # Same rule as root-deps: electron majors get standalone PRs.
+        exclude-patterns: ["electron"]
 
   - package-ecosystem: npm
     directory: /qa/playwright

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,8 +22,10 @@ updates:
         # silently promoting a runtime major and breaking npm ci.
         # Ungrouped, an electron update arrives as its own clearly-named
         # PR that can be held for the packaged-smoke arc (#750/#802
-        # pattern).
-        exclude-patterns: ["electron"]
+        # pattern). electron-builder is excluded for the same reason:
+        # packaging breakage is invisible to PR CI (no job builds
+        # installers) and surfaces only at release time.
+        exclude-patterns: ["electron", "electron-builder"]
 
   - package-ecosystem: npm
     directory: /packages/electron
@@ -32,8 +34,9 @@ updates:
     groups:
       electron-deps:
         patterns: ["*"]
-        # Same rule as root-deps: electron majors get standalone PRs.
-        exclude-patterns: ["electron"]
+        # Same rule as root-deps: electron and electron-builder get
+        # standalone PRs.
+        exclude-patterns: ["electron", "electron-builder"]
 
   - package-ecosystem: npm
     directory: /qa/playwright

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Dependency updates for electron and electron-builder now arrive as standalone PRs instead of riding grouped bumps — a grouped update once promoted an Electron major silently; standalone PRs can be held for the packaged-smoke release gate
 - Bundled desktop Electron → 44.1.1 (from 43.4.x). The version ranges landed on main through a grouped dependency update that moved only the pnpm lockfile; this change realigns the electron npm lockfile to the same resolution and pins both lockfiles to 44.1.1. Dev-mode CI (startup smoke on macOS/Windows/Linux) has exercised the 44 line since the ranges landed; the packaged-app launch smoke per the Electron-43 precedent is tracked in #802 and gates the next desktop release
 - Bundled desktop Electron → 43.4.0 (Chromium 150, Node 24), from 42.8.0 in the npm lockfile and 42.5.1 in the pnpm lockfile — the bump also heals that pre-existing cross-lockfile skew. Verified with a packaged-app launch smoke on macOS arm64 (window renders, startup orchestrator runs, zero renderer errors, clean exit) plus the full startup test suite; Windows coverage is the CI dev-mode startup smoke — no packaged-exe install test exists yet
 


### PR DESCRIPTION
## Summary
First half of #806 — the recurrence stopper, landed ahead of the weekly dependabot window. `electron` is excluded from both npm groups that can touch it (`root-deps` covers the workspace manifest; `electron-deps` the npm-lockfile dir), so electron updates arrive as standalone, clearly-named PRs that can be held for the packaged-smoke arc (#750/#802 pattern) instead of riding a grouped bump the way the #788 incident did.

The second half of #806 — a CI gate that fails any PR desyncing `packages/electron/package.json` from its lockfiles — stays tracked there, scheduled for the CI-hygiene slot with #795 after v0.7.61 tags.

## Test plan
- [x] YAML parses; config-only change (dependabot validates server-side on merge)
- [ ] CI green