### PR TITLE
fix(ci): skip duplicate re-fire comments when the tripwire condition is unchanged

### DIFF
--- a/.github/scripts/tripwire-common.sh
+++ b/.github/scripts/tripwire-common.sh
@@ -106,17 +106,32 @@ tripwire_fire() {
     existing=$(printf '%s' "$existing" | head -1)
 
     if [ -n "$existing" ]; then
-        # Compare against the newest comment's body with the run-URL
-        # footer stripped from both sides; skip the comment when the
-        # substance is unchanged. A lookup failure here must not
-        # suppress the re-fire (fail toward commenting, not silence).
+        # Compare against the newest comment's body, NORMALIZED on both
+        # sides: footers dropped (anchored), CRLF stripped, and
+        # run-varying tokens blanked — ISO timestamps, "<N>h ago",
+        # "<N> days (ago)", "<N> commits/runs/hours" — because tripwire
+        # bodies recompute ages every run and a byte-compare would
+        # never match (the first draft of this dedupe was dead code
+        # for exactly that reason). What survives normalization is the
+        # condition's identity; if THAT is unchanged, skip the comment.
+        # A lookup failure must not suppress the re-fire (fail toward
+        # commenting, not silence).
         local last_body new_full
         new_full=$(printf '%s\n\n_Re-fired on %s_' "$body" "$RUN_URL")
         last_body=$(gh issue view "$existing" --repo "$REPO" \
-                      --json comments -q '.comments[-1].body' 2>/dev/null || true)
+                      --json comments -q '.comments[-1].body // empty' 2>/dev/null || true)
+        _tw_normalize() {
+            tr -d '\r' | sed -E \
+                -e '/^_Re-fired on .*_$/d' \
+                -e '/^_Fired by .*_$/d' \
+                -e 's/[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z?//g' \
+                -e 's/[0-9]+(\.[0-9]+)?h ago//g' \
+                -e 's/[0-9]+ days?( ago)?//g' \
+                -e 's/[0-9]+ (commits?|runs?|hours?)//g'
+        }
         if [ -n "$last_body" ] && \
-           [ "$(printf '%s' "$last_body" | sed '/_Re-fired on /d;/_Fired by /d')" = \
-             "$(printf '%s' "$new_full" | sed '/_Re-fired on /d;/_Fired by /d')" ]; then
+           [ "$(printf '%s' "$last_body" | _tw_normalize)" = \
+             "$(printf '%s' "$new_full" | _tw_normalize)" ]; then
             echo "[tripwire] condition unchanged on open #$existing — skipping duplicate re-fire comment"
             return 0
         fi

--- a/.github/scripts/tripwire-common.sh
+++ b/.github/scripts/tripwire-common.sh
@@ -62,7 +62,13 @@ _tw_issue_numbers() {
 #   tripwire_fire "<exact-title>" "<body markdown>" "<comma,sep,labels>" [ack_dedupe]
 #
 # If an open issue with the same title exists, comment "Re-fired on
-# <RUN_URL>" + the new body on it. Otherwise create.
+# <RUN_URL>" + the new body on it — UNLESS the new body is identical to
+# the last re-fire comment's body (only the run URL differing): an
+# unchanged condition then re-fires silently, so a held condition does
+# not stack a near-identical comment per scheduled run (#772 collected
+# 16 of them; #785 drowned the human status note under 5). A changed
+# body (different ages, counts, subjects) still comments. Otherwise
+# create.
 #
 # Pass "ack_dedupe" as the 4th arg for tripwires whose titles name a
 # SPECIFIC subject (an upstream issue number, a branch name): a CLOSED
@@ -100,7 +106,21 @@ tripwire_fire() {
     existing=$(printf '%s' "$existing" | head -1)
 
     if [ -n "$existing" ]; then
-        gh issue comment "$existing" --repo "$REPO" --body "$(printf '%s\n\n_Re-fired on %s_' "$body" "$RUN_URL")"
+        # Compare against the newest comment's body with the run-URL
+        # footer stripped from both sides; skip the comment when the
+        # substance is unchanged. A lookup failure here must not
+        # suppress the re-fire (fail toward commenting, not silence).
+        local last_body new_full
+        new_full=$(printf '%s\n\n_Re-fired on %s_' "$body" "$RUN_URL")
+        last_body=$(gh issue view "$existing" --repo "$REPO" \
+                      --json comments -q '.comments[-1].body' 2>/dev/null || true)
+        if [ -n "$last_body" ] && \
+           [ "$(printf '%s' "$last_body" | sed '/_Re-fired on /d;/_Fired by /d')" = \
+             "$(printf '%s' "$new_full" | sed '/_Re-fired on /d;/_Fired by /d')" ]; then
+            echo "[tripwire] condition unchanged on open #$existing — skipping duplicate re-fire comment"
+            return 0
+        fi
+        gh issue comment "$existing" --repo "$REPO" --body "$new_full"
         echo "[tripwire] re-fired existing issue #$existing"
         return 0
     fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Tripwire re-fires no longer stack a near-identical comment per scheduled run on a held condition: the re-fire compares the new body against the newest comment with run-varying tokens (ages, timestamps, counts) normalized out, and skips the post when the condition's identity is unchanged — one rolling issue had collected 16 such comments (#812)
 - CI lints workflow files with actionlint (pinned, checksum-verified) — GitHub's server-side validator rejections previously surfaced only as zero-job push failures while silently stopping schedules (#777, the #767 duplicate-env incident class).
 - Provider-settings smoke spec no longer flakes when a parallel spec resets onboarding mid-test; the nightly failure tracked by #775 was this race, not an endpoint break (#778).
 - The onboarding-reset race guard is now a shared helper covering the sibling smoke specs with the same window (contract-skillset, hostname-overlay, contract-endpoints-sweep), with redirects disabled so the raced 302 is actually visible to the retry (#794).


### PR DESCRIPTION
## Summary
From the org-triage process audit: issue-level dedupe works (one open issue per condition), but `tripwire_fire` re-posts the **full body as a comment on every scheduled run** of a held condition — #772 has collected 16 near-identical comments and #785's five drowned the one human status note.

The re-fire path now fetches the newest comment, strips the `_Re-fired on_`/`_Fired by_` footers from both sides, and skips the post when the substance is unchanged. Any body change (ages, counts, new subjects) still comments; a comparison-lookup failure fails **toward commenting** (noise over silence — a P1 fire must never be suppressed by a flaky read).

## Test plan
- [x] `bash -n` + shellcheck (warning bar) clean
- [ ] CI green (actionlint job runs on this PR via the scripts path filter)
- [ ] Next scheduled tripwire run on a held condition logs the skip line instead of commenting