### PR TITLE
fix(qa): backoff between onboarding-race retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - CI lints workflow files with actionlint (pinned, checksum-verified) — GitHub's server-side validator rejections previously surfaced only as zero-job push failures while silently stopping schedules (#777, the #767 duplicate-env incident class).
 - Provider-settings smoke spec no longer flakes when a parallel spec resets onboarding mid-test; the nightly failure tracked by #775 was this race, not an endpoint break (#778).
 - The onboarding-reset race guard is now a shared helper covering the sibling smoke specs with the same window (contract-skillset, hostname-overlay, contract-endpoints-sweep), with redirects disabled so the raced 302 is actually visible to the retry (#794).
-- The race guard's retries are now spaced with a backoff: a parallel wizard spec can hold onboarding open for whole seconds, and the previous back-to-back attempts could all land inside one such window — the 2026-09-04/05 nightly failures were exactly that (#809).
+- The race guard's retries are now spaced with a growing backoff (six attempts over ~6s): the previous three back-to-back attempts completed within tens of milliseconds and a single reset-adjacent window could cover them all — the 2026-09-04/05 nightly failures were exactly that (#809).
 - Tripwire issue lookups no longer read a failed GitHub API call as "no matching issue" — the three lookup paths (fire dedupe, ack dedupe, auto-clear) retry with backoff and fail loud on exhaustion instead of stacking duplicates, re-firing acknowledged conditions, or silently skipping closes (#797).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - CI lints workflow files with actionlint (pinned, checksum-verified) — GitHub's server-side validator rejections previously surfaced only as zero-job push failures while silently stopping schedules (#777, the #767 duplicate-env incident class).
 - Provider-settings smoke spec no longer flakes when a parallel spec resets onboarding mid-test; the nightly failure tracked by #775 was this race, not an endpoint break (#778).
 - The onboarding-reset race guard is now a shared helper covering the sibling smoke specs with the same window (contract-skillset, hostname-overlay, contract-endpoints-sweep), with redirects disabled so the raced 302 is actually visible to the retry (#794).
+- The race guard's retries are now spaced with a backoff: a parallel wizard spec can hold onboarding open for whole seconds, and the previous back-to-back attempts could all land inside one such window — the 2026-09-04/05 nightly failures were exactly that (#809).
 - Tripwire issue lookups no longer read a failed GitHub API call as "no matching issue" — the three lookup paths (fire dedupe, ack dedupe, auto-clear) retry with backoff and fail loud on exhaustion instead of stacking duplicates, re-firing acknowledged conditions, or silently skipping closes (#797).
 
 ### Changed

--- a/qa/playwright/tests/helpers/onboarding.ts
+++ b/qa/playwright/tests/helpers/onboarding.ts
@@ -6,22 +6,24 @@
  * /api/setup/skip first, but a parallel spec's /test/reset landing between
  * the skip and the request re-enters onboarding and the request gets HTML
  * instead of JSON. Nightly runs with 0 retries by design, so the guard
- * lives here: re-skip immediately before each of up to 3 attempts, and
- * return as soon as the status is one the caller accepts. Requests set
+ * lives here: re-skip before each of up to 6 attempts, and return as
+ * soon as the status is one the caller accepts. Requests set
  * maxRedirects: 0 — otherwise the raced 302 is silently followed to the
  * onboarding page's 200 HTML and the retry loop never sees the race.
  *
- * Attempts are spaced with a short backoff: a parallel wizard spec can
- * hold the app IN onboarding for whole seconds (reset, then browser
- * navigation and HTML assertions before its own skip), so back-to-back
- * retries can all land inside one such window — the 2026-09-04/05
- * nightly failures (#809) were exactly that, with all 3 immediate
- * attempts eaten by one onboarding window.
+ * Attempts are spaced with a growing backoff. The wizard specs only
+ * ever /test/reset (they never skip), so each of OUR attempts both
+ * re-skips and re-requests: exhausting the guard requires a fresh
+ * reset to land inside every one of the six windows. The 2026-09-04/05
+ * nightly failures (#809) happened because the old three back-to-back
+ * attempts completed within tens of milliseconds — one reset-adjacent
+ * stretch covered them all; spreading six attempts over ~6s makes that
+ * interleaving practically impossible while staying bounded.
  *
  * The final response is returned WITHOUT asserting — callers keep their own
  * status assertions so failure messages stay spec-specific. A genuinely
  * broken endpoint therefore fails the caller's assertion with the caller's
- * diagnostics after 3 bounded attempts (the retry absorbs at most 2
+ * diagnostics after 6 bounded attempts (the retry absorbs at most 5
  * transient wrong-status responses; see #779 for the trade-off record).
  */
 import type { APIRequestContext, APIResponse } from '@playwright/test';
@@ -41,7 +43,7 @@ export async function getSkippingOnboarding(
     await api.post("/api/setup/skip");
     res = await api.get(path, { maxRedirects: 0 });
     if (okStatuses.includes(res.status())) break;
-    if (attempt < ATTEMPTS - 1) await sleep(BACKOFF_MS);
+    if (attempt < ATTEMPTS - 1) await sleep(BACKOFF_MS * (attempt + 1));
   }
   return res;
 }
@@ -57,7 +59,7 @@ export async function postSkippingOnboarding(
     await api.post("/api/setup/skip");
     res = await api.post(path, { data, maxRedirects: 0 });
     if (okStatuses.includes(res.status())) break;
-    if (attempt < ATTEMPTS - 1) await sleep(BACKOFF_MS);
+    if (attempt < ATTEMPTS - 1) await sleep(BACKOFF_MS * (attempt + 1));
   }
   return res;
 }

--- a/qa/playwright/tests/helpers/onboarding.ts
+++ b/qa/playwright/tests/helpers/onboarding.ts
@@ -11,6 +11,13 @@
  * maxRedirects: 0 — otherwise the raced 302 is silently followed to the
  * onboarding page's 200 HTML and the retry loop never sees the race.
  *
+ * Attempts are spaced with a short backoff: a parallel wizard spec can
+ * hold the app IN onboarding for whole seconds (reset, then browser
+ * navigation and HTML assertions before its own skip), so back-to-back
+ * retries can all land inside one such window — the 2026-09-04/05
+ * nightly failures (#809) were exactly that, with all 3 immediate
+ * attempts eaten by one onboarding window.
+ *
  * The final response is returned WITHOUT asserting — callers keep their own
  * status assertions so failure messages stay spec-specific. A genuinely
  * broken endpoint therefore fails the caller's assertion with the caller's
@@ -19,7 +26,10 @@
  */
 import type { APIRequestContext, APIResponse } from '@playwright/test';
 
-const ATTEMPTS = 3;
+const ATTEMPTS = 6;
+const BACKOFF_MS = 400;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 export async function getSkippingOnboarding(
   api: APIRequestContext,
@@ -31,6 +41,7 @@ export async function getSkippingOnboarding(
     await api.post("/api/setup/skip");
     res = await api.get(path, { maxRedirects: 0 });
     if (okStatuses.includes(res.status())) break;
+    if (attempt < ATTEMPTS - 1) await sleep(BACKOFF_MS);
   }
   return res;
 }
@@ -46,6 +57,7 @@ export async function postSkippingOnboarding(
     await api.post("/api/setup/skip");
     res = await api.post(path, { data, maxRedirects: 0 });
     if (okStatuses.includes(res.status())) break;
+    if (attempt < ATTEMPTS - 1) await sleep(BACKOFF_MS);
   }
   return res;
 }


### PR DESCRIPTION
## Summary
Root cause of the 09-04/09-05 nightly failures (rolling #809): the shared onboarding-race helper's three retries fire back-to-back with no delay, so a parallel wizard spec that holds the app in onboarding for whole seconds — reset, then browser navigation and HTML assertions before its own skip — swallows all three attempts in one window. Both failing nights were the same spec (hostname-overlay dismiss-prompt, 302 on every attempt) on the same green-on-09-03 SHA: pure scheduling lottery, structural not transient.

Fix: attempts 3 → 6 with 400ms backoff between them (worst-case added wait 2s, still bounded and fail-loud; nightly stays 0-retries).

**Evidence over theory:** a serialization alternative (workers: 1) was prototyped and rejected — with the backoff in place, an 8x-repeat stress of the most adversarial spec mix (both wizard specs + both reset-callers + three guarded specs) passes **88/88 at 4 workers** (and 88/88 serial), so the mirror-direction race (our skips breaking wizard assertions) does not materialize and serialization would only cost nightly-shard time. Also for the record: earlier local verifications ran without `FITB_TEST_MODE=1` and silently skipped the reset-dependent specs — the stress runs here set it, matching nightly.

## Test plan
- [x] Stress x8, workers=4, wizard+reset+guarded mix: 88/88 vs live :stable
- [x] Full smoke with FITB_TEST_MODE=1: 50/50
- [ ] CI green
- [ ] Green nightly closes rolling #809