### PR TITLE
fix(ci): pin the macOS Electron build to macos-15

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -54,7 +54,7 @@ jobs:
           # image 20260831.0337.3) broke electron-builder's temp-keychain unlock
           # (`security set-key-partition-list` → SecKeychainUnlock passphrase
           # error), failing every signed macOS build since 2026-09-05. Revert to
-          # macos-latest once electron-builder handles the new keychain semantics.
+          # macos-latest once the break is resolved — tracked in #827.
           - os: macos-15
             artifact-name: fox-macos
             # latest-mac.yml + blockmaps: same rule as Windows (#819).

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -50,7 +50,12 @@ jobs:
             artifact-path: |
               packages/electron/dist/*.exe
               packages/electron/dist/latest*.yml
-          - os: macos-latest
+          # Pinned to macos-15: the 2026-08-31 macos-latest image (macOS 26.6.2,
+          # image 20260831.0337.3) broke electron-builder's temp-keychain unlock
+          # (`security set-key-partition-list` → SecKeychainUnlock passphrase
+          # error), failing every signed macOS build since 2026-09-05. Revert to
+          # macos-latest once electron-builder handles the new keychain semantics.
+          - os: macos-15
             artifact-name: fox-macos
             # latest-mac.yml + blockmaps: same rule as Windows (#819).
             artifact-path: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Signed macOS desktop builds are pinned to the macos-15 runner: the 2026-08-31 macos-latest image (macOS 26.6.2) broke electron-builder's temp-keychain unlock, failing every signed build from 2026-09-05 — revert tracked in #827
 - Desktop windows (setup progress, error, diagnostic report, update prompts) are resizable — fixed-size windows clipped content that ran past their bounds; each keeps its previous size as the minimum
 - An ungracefully stopped container (Docker crash, force-quit, power loss) no longer bricks the next desktop startup: the entrypoint now deletes stale per-boot unix sockets before its fail-loud ownership pass — a leftover gateway socket made chown fail under macOS bind mounts, the auto-removed container vanished mid-startup, and the app showed "Container disappeared while waiting for services" until the socket was deleted by hand (#817)
 - Desktop auto-update is repaired from this release forward: releases now publish electron-updater's channel files, and the Windows metadata is regenerated after installer signing so its checksums match the shipped binary — releases never carried the channel files, so every installed app's update check has 404ed since the updater shipped (#819)


### PR DESCRIPTION
## Summary

Every signed macOS desktop build has failed since 2026-09-05 (and flickered on 2026-09-02): the 2026-08-31 `macos-latest` runner image (macOS 26.6.2, image 20260831.0337.3) breaks electron-builder's temp-keychain unlock — `security set-key-partition-list` fails with `SecKeychainUnlock: The user name or passphrase you entered is not correct`. The 09-02 interleaving of green and red runs was the image rolling out across the runner pool (green runs landed on 20260728/macOS 26.5.2 hosts).

Pins the build matrix's macOS leg to `macos-15`, where the keychain flow works. The pin applies to release builds too (release.yml consumes this workflow via `workflow_call`). Revert to `macos-latest` once electron-builder handles the new image's keychain semantics.

**Release blocker:** v0.7.61 is cut and gated only on this — the tag run's signed macOS leg fails without it.

## Test plan

- `actionlint` clean
- Branch dispatch of Build Electron exercising the exact failing path (CSC_LINK signing env is set on dispatch runs): run 34021520048 — macOS leg must pass the keychain step