### PR TITLE
fix(release): grant issues:write to the build-container nested call

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,12 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # build-container.yml's main-push failure handler declares issues:write.
+      # The job itself never runs on a tag ref, but nested-workflow permission
+      # validation is unconditional — without this grant the whole release run
+      # dies at startup ("requesting 'issues: write', but is only allowed
+      # 'issues: none'", the v0.7.61 first-tag failure).
+      issues: write
 
   wait-for-electron:
     name: Wait — build-electron.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- The release workflow starts again: its build-container nested call now grants issues:write — the ci-health failure handler added this cycle declares it, GitHub validates nested-workflow permission grants unconditionally, and the v0.7.61 tag run died at startup on the missing grant
 - Signed macOS desktop builds are pinned to the macos-15 runner: the 2026-08-31 macos-latest image (macOS 26.6.2) broke electron-builder's temp-keychain unlock, failing every signed build from 2026-09-05 — revert tracked in #827
 - Desktop windows (setup progress, error, diagnostic report, update prompts) are resizable — fixed-size windows clipped content that ran past their bounds; each keeps its previous size as the minimum
 - An ungracefully stopped container (Docker crash, force-quit, power loss) no longer bricks the next desktop startup: the entrypoint now deletes stale per-boot unix sockets before its fail-loud ownership pass — a leftover gateway socket made chown fail under macOS bind mounts, the auto-removed container vanished mid-startup, and the app showed "Container disappeared while waiting for services" until the socket was deleted by hand (#817)


### PR DESCRIPTION
## Summary

The v0.7.61 tag run (34022948580) died with `startup_failure`: build-container.yml's `main_push_health` job (the ci-health rolling-issue handler shipped this cycle) declares `issues: write`, and GitHub validates nested-workflow permission grants **unconditionally** — the job's own `if:` (main-branch pushes only) is irrelevant at validation time. release.yml's `wait-for-container` caller granted only `contents: read` + `packages: write`, so the entire release workflow was rejected before any job started:

> The nested job 'main_push_health' is requesting 'issues: write', but is only allowed 'issues: none'.

This was unreachable by any PR CI — it only manifests when release.yml actually runs, i.e. at tag time.

One-line fix: grant `issues: write` at the caller, with a comment explaining why.

**Full nested-permission audit** (so this is the last of its class): build-electron.yml requests `contents: write` + `id-token: write` — covered by its caller's grant; sbom.yml requests `contents: write` — covered; no other job in build-container.yml requests beyond contents/packages.

## Test plan

- `actionlint` clean (server-side nested-permission validation is not lintable — the audit above is the check)
- Real verification is the re-tagged v0.7.61 run

After merge: the unpublished v0.7.61 tag (zero artifacts, run died at startup) is re-pointed to the fixed tree and the release re-runs.